### PR TITLE
Updating the lang_missing.js file to be more readable on console

### DIFF
--- a/src/lang/list_missing.js
+++ b/src/lang/list_missing.js
@@ -3,8 +3,9 @@ const locale = process.argv[2];
 if (!locale) {
   console.log("No language to check specified");
   console.log("");
-  console.log("Run as:");
+  console.log("Run either one of the following (change pt-PT to the lang intended):");
   console.log("npm run missing-translations pt-PT");
+  console.log("node list_missing pt-PT");
   console.log("");
   process.exit();
 }


### PR DESCRIPTION
Some users might not be able to run the .js script via:
"npm run missing-translations pt-PT"

So I updated the console log to also suggest:
"node list_missing pt-PT"

And also clarified that "pt-PT" should be changed to the intended language for more readability.