### PR TITLE
Stop Static multiframe actors animating when moving

### DIFF
--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -587,7 +587,7 @@ void SceneUpdateActors_b()
     {
       if (ACTOR_ANIM_SPEED(ptr) == 4 || (ACTOR_ANIM_SPEED(ptr) == 3 && IS_FRAME_16) || (ACTOR_ANIM_SPEED(ptr) == 2 && IS_FRAME_32) || (ACTOR_ANIM_SPEED(ptr) == 1 && IS_FRAME_64) || (ACTOR_ANIM_SPEED(ptr) == 0 && IS_FRAME_128))
       {
-        if (ACTOR_MOVING(ptr) || ACTOR_ANIMATE(ptr))
+        if ((ACTOR_MOVING(ptr) & actors[i].sprite_type != SPRITE_STATIC) || ACTOR_ANIMATE(ptr))
         {
           if (ACTOR_FRAME(ptr) == ACTOR_FRAMES_LEN(ptr) - 1)
           {

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -587,7 +587,7 @@ void SceneUpdateActors_b()
     {
       if (ACTOR_ANIM_SPEED(ptr) == 4 || (ACTOR_ANIM_SPEED(ptr) == 3 && IS_FRAME_16) || (ACTOR_ANIM_SPEED(ptr) == 2 && IS_FRAME_32) || (ACTOR_ANIM_SPEED(ptr) == 1 && IS_FRAME_64) || (ACTOR_ANIM_SPEED(ptr) == 0 && IS_FRAME_128))
       {
-        if ((ACTOR_MOVING(ptr) & actors[i].sprite_type != SPRITE_STATIC) || ACTOR_ANIMATE(ptr))
+        if ((ACTOR_MOVING(ptr) && actors[i].sprite_type != SPRITE_STATIC) || ACTOR_ANIMATE(ptr))
         {
           if (ACTOR_FRAME(ptr) == ACTOR_FRAMES_LEN(ptr) - 1)
           {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix #237 add check to general actors update so a moving static is not forced to animate.

* **What is the current behavior?** (You can also link to an open issue here)
A multi frame actor set to static would still animate when moving via script.

* **What is the new behavior (if this is a feature change)?**
A multi frame actor set to static will not animate when moving via script, unless set directly.

* **Does this PR introduce a breaking change?** 
If the user intended this effect, they could switch to face interaction? 
Made sure that a cycling static actor will still animate when moving.