### PR TITLE
Increase CameraMoveTo speed and fix lock to player speed

### DIFF
--- a/appData/src/gb/include/Scene.h
+++ b/appData/src/gb/include/Scene.h
@@ -19,13 +19,17 @@
 #define BUBBLE_ANIMATION_FRAMES 15
 #define BUBBLE_TOTAL_FRAMES 60
 
+// bits 1111xxxx for masking cam speed data
 #define CAMERA_SPEED_MASK 0xF
-#define CAMERA_SPEED_1 0x0F
-#define CAMERA_SPEED_2 0x07
-#define CAMERA_SPEED_3 0x03
-#define CAMERA_SPEED_4 0x01
-#define CAMERA_SPEED_5 0x00
+/* Only calculated in scriptBuilder.js
+#define CAMERA_SPEED_1 0x0F // 1111, only true every 16 frames
+#define CAMERA_SPEED_2 0x07 // 1110, move every 8 frames
+#define CAMERA_SPEED_3 0x03 // 1100, move every 4 frames
+#define CAMERA_SPEED_4 0x01 // 1000, move every 'even' time
+#define CAMERA_SPEED_5 0x00 // 0000, always true */
+
 #define CAMERA_LOCK_FLAG 0x10
+// bit xxxx0100 for transition, low bits are speed
 #define CAMERA_TRANSITION_FLAG 0x20
 
 extern UINT8 scene_bank;

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -587,7 +587,7 @@ void SceneUpdateActors_b()
     {
       if (ACTOR_ANIM_SPEED(ptr) == 4 || (ACTOR_ANIM_SPEED(ptr) == 3 && IS_FRAME_16) || (ACTOR_ANIM_SPEED(ptr) == 2 && IS_FRAME_32) || (ACTOR_ANIM_SPEED(ptr) == 1 && IS_FRAME_64) || (ACTOR_ANIM_SPEED(ptr) == 0 && IS_FRAME_128))
       {
-        if (ACTOR_MOVING(ptr) || ACTOR_ANIMATE(ptr))
+        if ((ACTOR_MOVING(ptr) & actors[i].sprite_type != SPRITE_STATIC) || ACTOR_ANIMATE(ptr))
         {
           if (ACTOR_FRAME(ptr) == ACTOR_FRAMES_LEN(ptr) - 1)
           {

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -240,7 +240,7 @@ void Script_CameraLock_b()
   UBYTE cam_x, cam_y;
 
   camera_settings = script_cmd_args[0] & ~CAMERA_LOCK_FLAG;
-
+  camera_speed = (UBYTE)script_cmd_args[0] & CAMERA_SPEED_MASK;
   cam_x = ClampUBYTE(actors[0].pos.x, SCREEN_WIDTH_HALF, MUL_8(scene_width) - SCREEN_WIDTH_HALF);
   camera_dest.x = cam_x - SCREEN_WIDTH_HALF;
   cam_y = ClampUBYTE(actors[0].pos.y, SCREEN_HEIGHT_HALF, MUL_8(scene_height) - SCREEN_HEIGHT_HALF);

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -649,13 +649,15 @@ class ScriptBuilder {
     const camY = Math.min(y, scene.height - 18);
     output.push(camX);
     output.push(camY);
-    const speedFlag = ((1 << speed) - 1) | (speed > 0 ? 32 : 0);
+    // Direct speed in binary, first bits 0000 to 1111 are "&" compared with binary time
+    // Speed 0 = 0 instant, Speed 1 = 32 0x20 move every frame, Speed 2 = 33 0x21
+    const speedFlag = (speed > 0 ? (32 + (1 << (speed - 1)) - 1) : 0);
     output.push(speedFlag);
   };
 
   cameraLock = (speed = 0) => {
     const output = this.output;
-    const speedFlag = ((1 << speed) - 1) | (speed > 0 ? 32 : 0);
+    const speedFlag = (speed > 0 ? (32 + (1 << (speed - 1)) - 1) : 0);
     output.push(cmd(CAMERA_LOCK));
     output.push(speedFlag);
   };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature.)
Changes an oversight where the **fastest camera** move to speed was **every second frame**.
Also fixes **Camera : lock to player** only supporting **instant**, or **every frame**.

* **What is the current behavior?** 
Code is calculated in **ScriptBuilder.js,**
**6**th bit set for transitioning, 
low **4** bits are masked, then bitwise **&** against time binary, if=0, moves cam 1px.
Speed **0** (instant), value 0 (instant)`binary 0000-0000`
Speed **1** (Faster), 32+1 (every **2**)   `binary 1000-0100`
Speed **2**, 32+ 3    ( move every **4** )   `binary 1100-0100`
Speed **3**, 32+ 7   (every **8** frames)  `binary 1110-0100`
Speed **4**, 32+15 (every **16** frame)  `binary 1111-0100`
Speed **5**, 32+31 (every **16** frame)  `binary 1111-1100`

* **What is the new behavior (if this is a feature change)?**
Speed **0** (instant) value 0 (instant) `binary 0000-0000`
Speed **1**, 32 + 0 (every **1**  frame )    `binary 0000-0100`
Speed **2** 32 + 1 (every **2** frames)    `binary 1000-0100`
Speed **3** 32+ 3 (every **4** frames)    `binary 1100-0100`
Speed **4** 32+ 7 (every **8** frames)    `binary 1110-0100`
Speed **5** 32+15 (every **16** frame)  `binary 1111-0100`
Also adds `camera_speed = (UBYTE)script_cmd_args[0] & CAMERA_SPEED_MASK;` to Script_CameraLock_b

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
May need migration,
If you want to keep **old speeds** for camera move, Instant and speed 5 no change, 
speed 1 is equivalent speed 2 and so on.
Camera lock to player was always instant, or every frame, so no change, users will have more options.

* **Other information**:
Accidentally includes static multiframe actor fix Commit.