### PR TITLE
fix for issues/262 flushing data after write and add backup of previous data

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -197,7 +197,11 @@ export const pauseMusic = () => {
 
 export const saveProject = () => async (dispatch, getState) => {
   const state = getState();
-  if (!state.document.loaded || state.document.saving) {
+  if (
+    !state.document.loaded ||
+    state.document.saving ||
+    !state.document.modified
+  ) {
     return;
   }
   await asyncAction(

--- a/src/lib/helpers/fs/writeFileAndFlush.js
+++ b/src/lib/helpers/fs/writeFileAndFlush.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-param-reassign */
+import { open, writeFile, close, fdatasync } from "fs";
+
+export const writeFileAndFlush = (path, data, options, callback) => {
+  if (typeof options === "function") {
+    callback = options;
+    options = null;
+  }
+
+  if (!options) {
+    options = { encoding: "utf8", mode: 0o666, flag: "w" };
+  } else if (typeof options === "string") {
+    options = { encoding: options, mode: 0o666, flag: "w" };
+  }
+
+  // Open the file with same flags and mode as fs.writeFile()
+  open(path, options.flag, options.mode, (openError, fd) => {
+    if (openError) {
+      return callback(openError);
+    }
+
+    // It is valid to pass a fd handle to fs.writeFile() and this will keep the handle open!
+    return writeFile(fd, data, options.encoding, writeError => {
+      if (writeError) {
+        return close(fd, () => callback(writeError)); // still need to close the handle on error!
+      }
+
+      // Flush contents (not metadata) of the file to disk
+      return fdatasync(fd, syncError => {
+        return close(fd, closeError => callback(syncError || closeError)); // make sure to carry over the fdatasync error if any!
+      });
+    });
+  });
+};
+
+export const writeFileAndFlushAsync = (path, data, options) => {
+  return new Promise((resolve, reject) => {
+    writeFileAndFlush(path, data, options, err => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve();
+    });
+  });
+};

--- a/src/lib/helpers/fs/writeFileWithBackup.js
+++ b/src/lib/helpers/fs/writeFileWithBackup.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-param-reassign */
+import { access, constants, copyFile, renameSync } from "fs";
+import { writeFileAndFlush } from "./writeFileAndFlush";
+
+const BACKUP_EXTENSION = "bak";
+const TMP_EXTENSION = "new";
+
+export const backupFile = (path, callback) => {
+  access(path, constants.F_OK, err => {
+    if (!err) {
+      return copyFile(path, `${path}.${BACKUP_EXTENSION}`, callback);
+    }
+    return callback();
+  });
+};
+
+export const writeFileWithBackup = (path, data, options, callback) => {
+  if (typeof options === "function") {
+    callback = options;
+    options = null;
+  }
+  return backupFile(path, backupError => {
+    if (backupError) {
+      return callback(backupError);
+    }
+    return writeFileAndFlush(
+      `${path}.${TMP_EXTENSION}`,
+      data,
+      options,
+      writeError => {
+        if (writeError) {
+          return callback(writeError);
+        }
+        renameSync(`${path}.new`, path);
+        return callback();
+      }
+    );
+  });
+};
+
+export const writeFileWithBackupAsync = (path, data, options) => {
+  return new Promise((resolve, reject) => {
+    writeFileWithBackup(path, data, options, err => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve();
+    });
+  });
+};

--- a/src/lib/project/saveProjectData.js
+++ b/src/lib/project/saveProjectData.js
@@ -1,7 +1,7 @@
-import fs from "fs-extra";
+import { writeFileWithBackupAsync } from "../helpers/fs/writeFileWithBackup";
 
 const saveProjectData = async (projectPath, project) => {
-  fs.writeFileSync(projectPath, JSON.stringify(project, null, 4));
+  await writeFileWithBackupAsync(projectPath, JSON.stringify(project, null, 4));
 };
 
 export default saveProjectData;

--- a/test/helpers/fs/writeFileAndFlush.test.js
+++ b/test/helpers/fs/writeFileAndFlush.test.js
@@ -1,0 +1,39 @@
+import { readFile, unlink } from "fs-extra";
+import {
+  writeFileAndFlush,
+  writeFileAndFlushAsync
+} from "../../../src/lib/helpers/fs/writeFileAndFlush";
+
+test("Should write file correctly using callbacks", done => {
+  const data = "Testing 123";
+  const path = `${__dirname}/tmp_data.txt`;
+  writeFileAndFlush(path, data, writeError => {
+    expect(writeError).toBeFalsy();
+    readFile(path, "utf8", (readError, savedData) => {
+      expect(readError).toBeFalsy();
+      expect(savedData).toBe(data);
+      unlink(path, unlinkError => {
+        expect(unlinkError).toBeFalsy();
+        done();
+      });
+    });
+  });
+});
+
+test("Should write file correctly using promises", async () => {
+  const data = "Testing 123";
+  const path = `${__dirname}/tmp_data.txt`;
+  await writeFileAndFlushAsync(path, data);
+  const savedData = await readFile(path, "utf8");
+  expect(savedData).toBe(data);
+  await unlink(path);
+});
+
+test("Should allow setting file encoding", async () => {
+  const data = "Testing 123";
+  const path = `${__dirname}/tmp_data.txt`;
+  await writeFileAndFlushAsync(path, data, "utf8");
+  const savedData = await readFile(path, "utf8");
+  expect(savedData).toBe(data);
+  await unlink(path);
+});

--- a/test/helpers/fs/writeFileWithBackup.test.js
+++ b/test/helpers/fs/writeFileWithBackup.test.js
@@ -1,0 +1,43 @@
+import { readFile, unlink } from "fs-extra";
+import { writeFileWithBackupAsync } from "../../../src/lib/helpers/fs/writeFileWithBackup";
+
+test("Should write file correctly on first save", async () => {
+  const data = "Testing Backup 123";
+  const path = `${__dirname}/tmp_data.txt`;
+  await writeFileWithBackupAsync(path, data);
+  const savedData = await readFile(path, "utf8");
+  expect(savedData).toBe(data);
+  await unlink(path);
+});
+
+test("Should store backup of previous store in .bak file", async () => {
+  const data = "Testing Backup 123";
+  const updatedData = "Testing Backup UPDATED";
+  const path = `${__dirname}/tmp_data.txt`;
+  await writeFileWithBackupAsync(path, data);
+  const savedData = await readFile(path, "utf8");
+  expect(savedData).toBe(data);
+  await writeFileWithBackupAsync(path, updatedData);
+  const savedData2 = await readFile(path, "utf8");
+  const backupData = await readFile(`${path}.bak`, "utf8");
+  expect(savedData2).toBe(updatedData);
+  expect(backupData).toBe(data);
+  await unlink(path);
+  await unlink(`${path}.bak`);
+});
+
+test("Should write file with backup using callbacks", done => {
+  const data = "Testing Backup 123";
+  const path = `${__dirname}/tmp_data.txt`;
+  writeFileWithBackupAsync(path, data, writeError => {
+    expect(writeError).toBeFalsy();
+    readFile(path, "utf8", (readError, savedData) => {
+      expect(readError).toBeFalsy();
+      expect(savedData).toBe(data);
+      unlink(path, unlinkError => {
+        expect(unlinkError).toBeFalsy();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for issue saving project data

* **What is the current behavior?** (You can also link to an open issue here)
In very rare instances in the Windows version it's possible for the project file to be written to an in memory cache but not written to the file system causing complete loss of the project data file. To my knowledge this has happened twice so far. Similar issues have been seen in VSCode, Notepad++ and Aseprite as referenced in the reported issue #262 

* **What is the new behavior (if this is a feature change)?**
A replacement to fs.writeFile has been written (based partially on a fix submitted for the same issue in VSCode https://github.com/microsoft/vscode/commit/974bce453ec0d39996bda3d4bf31707ca1825c94) which uses `fdatasync` to force the file to be written to disk directly after saving. As an additional safety measure every save now copies the existing `.gbsproj` file to a `.gbsproj.bak` file in the same folder which can be renamed to restore to the previous version in case of data loss or accidental saving. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No known breaking change + tests have been added./

* **Other information**:
https://notepad-plus-plus.org/community/topic/13302/fix-corrupted-txt-file-null/60
https://github.com/Microsoft/vscode/issues/9589#issuecomment-235552090
https://community.aseprite.org/t/file-full-of-null-bytes/31/5
https://superuser.com/questions/845270/what-could-cause-the-files-to-be-replaced-with-null-bytes-size-and-timestamp-no