### PR TITLE
Fix collision bug at bottom edge of screen

### DIFF
--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -1021,6 +1021,12 @@ UBYTE SceneNpcAt_b(UBYTE index, UBYTE tx_a, UBYTE ty_a)
     }
     tx_b = DIV_8(ACTOR_X(ptr));
     ty_b = DIV_8(ACTOR_Y(ptr));
+    if (ty_b == 0)
+    {
+      // If actor at posY=256 (really 0 since 8bit) convert to correct tile
+      // since DIV_8 will give tile as 0 rather than 32
+      ty_b = 32;
+    }
     if ((ty_a == ty_b || ty_a == ty_b - 1) &&
         (tx_a == tx_b || tx_a == tx_b + 1 || tx_a + 1 == tx_b))
     {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Actors placed on Y=31 are not collidable. This is because in engine the actor positions are stored in pixel values and converted to tile values when needed by dividing by 8, Y=31 in editor is Y=256 ingame and since the position is stored as an 8-bit int it is actually Y=0 causing checks for actors at this tile position to not be found.

* **What is the new behavior (if this is a feature change)?**
Updated NPC at tile checks to account for this behaviour

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Fixes #255 