### PR TITLE
Skip new line character when adding to dialogue

### DIFF
--- a/appData/src/gb/src/UI.c
+++ b/appData/src/gb/src/UI.c
@@ -22,6 +22,7 @@ UBYTE text_x;
 UBYTE text_y;
 UBYTE text_drawn;
 UBYTE text_count;
+UBYTE text_tile_count;
 UBYTE text_wait;
 UBYTE text_in_speed = 1;
 UBYTE text_out_speed = 1;
@@ -157,6 +158,7 @@ void UIShowText(UWORD line)
   text_x = 0;
   text_y = 0;
   text_count = 0;
+  text_tile_count = 0;
 }
 
 void UIShowAvatar(UBYTE avatar_index) {
@@ -207,6 +209,7 @@ void UISetTextBuffer(unsigned char *text)
   text_x = 0;
   text_y = 0;
   text_count = 0;
+  text_tile_count = 0;
 }
 
 void UIDrawTextBuffer()
@@ -264,12 +267,13 @@ void UIDrawTextBufferChar()
       text_y++;
     }
 
-    if (text_lines[text_count] != '\b')
+    if (text_lines[text_count] != '\b' && text_lines[text_count] != '\n')
     {
-      i = text_count + avatar_enabled * 4;
+      i = text_tile_count + avatar_enabled * 4;
       SetBankedBkgData(FONT_BANK, TEXT_BUFFER_START + i, 1, ptr + ((UWORD)letter * 16));
       tile = TEXT_BUFFER_START + i;
       set_win_tiles(text_x + 1 + choice_enabled + avatar_enabled * 2, text_y + 1, 1, 1, &tile);
+      text_tile_count++;
     }
 
     if (text_lines[text_count] == '\b')
@@ -366,6 +370,7 @@ void UIOnInteract()
     else if (JOY(J_B))
     {
       text_count = 0;
+      text_tile_count = 0;
       text_lines[0] = '\0';
       script_variables[choice_flag] = FALSE;
       choice_enabled = FALSE;

--- a/test/projects/Test_TextWithAvatar/Test_TextWithAvatar.gbsproj
+++ b/test/projects/Test_TextWithAvatar/Test_TextWithAvatar.gbsproj
@@ -37,6 +37,16 @@
                     "y": 6,
                     "script": [
                         {
+                            "id": "85b1a845-a68d-4085-8afd-7b08697b6c80",
+                            "command": "EVENT_TEXT",
+                            "args": {
+                                "text": [
+                                    "1234567891234567\n1234567891234567\n1234567891234567"
+                                ],
+                                "avatarId": "daf95270-e30d-423b-9ee7-990ae29f57f6"
+                            }
+                        },
+                        {
                             "id": "d5936672-55ea-4ec6-9d00-5d4abebe9550",
                             "command": "EVENT_TEXT",
                             "args": {
@@ -89,8 +99,29 @@
                     "id": "ea2d3d5f-31ec-4832-b759-fa4fb2f7df21",
                     "command": "EVENT_TEXT",
                     "args": {
-                        "text": "This is a text\nwithout avatar",
+                        "text": [
+                            "123456789123456789\n123456789123456789\n1234567891234567"
+                        ],
                         "avatarId": ""
+                    }
+                },
+                {
+                    "id": "fc033772-8ee3-425f-b4e8-58c2f3b2bd7f",
+                    "command": "EVENT_CHOICE",
+                    "args": {
+                        "variable": "0",
+                        "trueText": "12345678912345678",
+                        "falseText": "12345678912345678"
+                    }
+                },
+                {
+                    "id": "8442730f-399f-4f02-a749-cde1a777b17f",
+                    "command": "EVENT_TEXT",
+                    "args": {
+                        "text": [
+                            "1234567891234567\n1234567891234567\n1234567891234567"
+                        ],
+                        "avatarId": "daf95270-e30d-423b-9ee7-990ae29f57f6"
                     }
                 },
                 {
@@ -113,7 +144,7 @@
             "imageWidth": 160,
             "imageHeight": 144,
             "filename": "placeholder.png",
-            "_v": 1567812411708
+            "_v": 1568631259628
         }
     ],
     "spriteSheets": [
@@ -123,7 +154,7 @@
             "numFrames": 3,
             "type": "actor",
             "filename": "actor.png",
-            "_v": 1567812411709
+            "_v": 1568631259629
         },
         {
             "id": "581d34d0-9591-4e6e-a609-1d94f203b0cd",
@@ -131,7 +162,7 @@
             "numFrames": 6,
             "type": "actor_animated",
             "filename": "actor_animated.png",
-            "_v": 1567812411708
+            "_v": 1568631259629
         },
         {
             "id": "daf95270-e30d-423b-9ee7-990ae29f57f6",
@@ -139,7 +170,7 @@
             "numFrames": 1,
             "type": "static",
             "filename": "static.png",
-            "_v": 1567812411709
+            "_v": 1568631259629
         }
     ],
     "music": [
@@ -147,7 +178,7 @@
             "id": "f50428ab-a084-4591-9bba-2ba10fe7b1c6",
             "name": "template",
             "filename": "template.mod",
-            "_v": 1567812411696
+            "_v": 1568631259626
         }
     ]
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

#284 introduced a bug in any dialogue (with or without avatar) that counted the line break characters as a new tile, effectively reducing the max numbers of characters by 2 and allowing the overflow reported in issue #291. 

This fix reverts to the same behavior as before #284 but using a slightly different code.

The image shows how the following text is stored in the tile data for each of those versions:
```
123456789123456789
123456789123456789
1234567891234567
```

![image](https://user-images.githubusercontent.com/54246642/64997565-067f0000-d8d9-11e9-8708-9c8e34eef249.png)

No functional change but fixes issue https://github.com/chrismaltby/gb-studio/issues/291

* **What is the current behavior?** (You can also link to an open issue here)

The dialogue tiles will overflown if the max character per line was used on all three lines

* **What is the new behavior (if this is a feature change)?**

When rendering text dialogues, instead of using an empty tile for new line character is found just skip it and render the next character in the next line.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

N/A

* **Other information**:
