### PR TITLE
Fix JS GameBoy emulator audio

### DIFF
--- a/appData/js-emulator/js/GameBoyCore.js
+++ b/appData/js-emulator/js/GameBoyCore.js
@@ -5084,7 +5084,7 @@ GameBoyCore.prototype.GyroEvent = function (x, y) {
 GameBoyCore.prototype.initSound = function () {
 	console.log("INT SOUND")
 	this.audioResamplerFirstPassFactor = Math.max(Math.min(Math.floor(this.clocksPerSecond / 44100), Math.floor(0xFFFF / 0x1E0)), 1);
-	this.downSampleInputDivider = 1 / (this.audioResamplerFirstPassFactor * 0xF0);
+	this.downSampleInputDivider = 0.5 / (this.audioResamplerFirstPassFactor * 0xF0); // Reduced to 0.5 from 1 to half volume.
 	if (settings[0]) {
 		this.audioHandle = new XAudioServer(2, this.clocksPerSecond / this.audioResamplerFirstPassFactor, 0, Math.max(this.baseCPUCyclesPerIteration * settings[8] / this.audioResamplerFirstPassFactor, 8192) << 1, null, settings[3], function () {
 			settings[0] = false;
@@ -5256,8 +5256,8 @@ GameBoyCore.prototype.initializeAudioStartState = function () {
 	this.noiseSampleTable = this.LSFR15Table;
 }
 GameBoyCore.prototype.outputAudio = function () {
-	this.audioBuffer[this.audioDestinationPosition++] = (this.downsampleInput >>> 16) * this.downSampleInputDivider - 1;
-	this.audioBuffer[this.audioDestinationPosition++] = (this.downsampleInput & 0xFFFF) * this.downSampleInputDivider - 1;
+	this.audioBuffer[this.audioDestinationPosition++] = (this.downsampleInput >>> 16) * this.downSampleInputDivider;
+	this.audioBuffer[this.audioDestinationPosition++] = (this.downsampleInput & 0xFFFF) * this.downSampleInputDivider; //had - 1, removing fixes pop
 	if (this.audioDestinationPosition == this.numSamplesTotal) {
 		this.audioHandle.writeAudioNoCallback(this.audioBuffer);
 		this.audioDestinationPosition = 0;

--- a/appData/js-emulator/js/GameBoyIO.js
+++ b/appData/js-emulator/js/GameBoyIO.js
@@ -2,7 +2,7 @@
 var gameboy = null;						//GameBoyCore object.
 var gbRunInterval = null;				//GameBoyCore Timer
 var settings = [						//Some settings.
-	window.location.href.indexOf("audio=true") > -1, //Turn on sound.
+	true,								//Turn on sound. Removed //window.location.href.indexOf("audio=true") > -1,
 	true,								//Boot with boot ROM first?
 	false,								//Give priority to GameBoy mode
 	1,									//Volume level set.

--- a/appData/js-emulator/js/GameBoyIO.js
+++ b/appData/js-emulator/js/GameBoyIO.js
@@ -2,7 +2,7 @@
 var gameboy = null;						//GameBoyCore object.
 var gbRunInterval = null;				//GameBoyCore Timer
 var settings = [						//Some settings.
-	true,								//Turn on sound. Removed //window.location.href.indexOf("audio=true") > -1,
+	window.location.href.indexOf("audio=true") > -1, //Turn on sound.
 	true,								//Boot with boot ROM first?
 	false,								//Give priority to GameBoy mode
 	1,									//Volume level set.

--- a/appData/js-emulator/js/other/XAudioServer.js
+++ b/appData/js-emulator/js/other/XAudioServer.js
@@ -205,31 +205,11 @@ XAudioServer.prototype.initializeWebAudio = function () {
     }
 	XAudioJSWebAudioAudioNode.onaudioprocess = XAudioJSWebAudioEvent;
 	var gainNode = XAudioJSWebAudioContextHandle.createGain();
-	var scriptNode = XAudioJSWebAudioContextHandle.createScriptProcessor(4096, 1, 1);
-
-	scriptNode.onaudioprocess = function(audioProcessingEvent) {
-		var inputBuffer = audioProcessingEvent.inputBuffer;
-		var outputBuffer = audioProcessingEvent.outputBuffer;
-
-		// Loop through the output channels (in this case there is only one)
-		for (var channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
-		  var inputData = inputBuffer.getChannelData(channel);
-		  var outputData = outputBuffer.getChannelData(channel);
-	  
-		  // Loop through the 4096 samples
-		  for (var sample = 0; sample < inputBuffer.length; sample++) {
-			// make output equal to the same as the input
-			outputData[sample] = 0.5 + (inputData[sample] / 2);
-		  }
-		}
-	  }
-
-	XAudioJSWebAudioAudioNode.connect(scriptNode); //Connect the audio processing event to a handling function so we can manipulate output
-	scriptNode.connect(gainNode);
+	XAudioJSWebAudioAudioNode.connect(gainNode); //Connect the audio processing event to a handling function so we can manipulate output
 	//Connect the audio processing event to a handling function so we can manipulate output
 	gainNode.connect(XAudioJSWebAudioContextHandle.destination);
-	// Ramp up gain to avoid pop when initialised
-	gainNode.gain.value = 0.001;
+	// Ramp up gain to avoid pop when initialised, these can be relaxed/removed with the fixed dc offset in GameBoyCore.js no longer popping
+	gainNode.gain.value = 0.2;
 	gainNode.gain.exponentialRampToValueAtTime(
 	  1,
 	  XAudioJSWebAudioContextHandle.currentTime + 0.5
@@ -452,7 +432,7 @@ var XAudioJSMediaStreamWorker = null;
 var XAudioJSMediaStreamBuffer = [];
 var XAudioJSMediaStreamSampleRate = 44100;
 var XAudioJSMozAudioSampleRate = 44100;
-var XAudioJSSamplesPerCallback = 2048;			//Has to be between 2048 and 4096 (If over, then samples are ignored, if under then silence is added).
+var XAudioJSSamplesPerCallback = 4096;			//Has to be between 2048 and 4096 (If over, then samples are ignored, if under then silence is added, 4096 fixes chrome android).
 var XAudioJSFlashTransportEncoder = null;
 var XAudioJSMediaStreamLengthAliasCounter = 0;
 var XAudioJSBinaryString = [];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** 
Audio was mono, had major crackle on chrome android, could cause clicking if in the background on some devices.
Did not play until a button was pressed. #177

* **What is the new behavior (if this is a feature change)?**
Audio is stereo again, and play's better on all devices (optimized, and buffer increased to 4096). 
Sound starts as soon as emulation begins now. 
Overall sound volume is the same as 1.1 (Half volume).

* **Does this PR introduce a breaking change?** 
Not likely!

* **Other information**:
Pop fix being done in the gameboy core let me remove the code blob from last dc offset pop fix, which was performance intensive and had channels limited to 1.
Wanted this separate from GBT expansion to get this merged quickly as it improves all web outputs.