### PR TITLE
Scroll 'Add Event' list items into view when necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-highlight-words": "^0.16.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-redux": "^5.0.7",
+    "react-scroll-into-view-if-needed": "^2.1.7",
     "react-select": "^3.0.4",
     "redux": "^4.0.0",
     "redux-thunk": "^2.2.0",

--- a/src/components/script/AddCommandButton.js
+++ b/src/components/script/AddCommandButton.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import Highlighter from "react-highlight-words";
+import ScrollIntoViewIfNeeded from 'react-scroll-into-view-if-needed';
 import Button from "../library/Button";
 import {
   EventsOnlyForActors,
@@ -189,7 +190,12 @@ class AddCommandButton extends Component {
             </div>
             <div className="AddCommandButton__List">
               {actionsList.map((action, actionIndex) => (
-                <div
+                <ScrollIntoViewIfNeeded
+                  active={selectedIndex === actionIndex}
+                  options={{
+                    behavior: 'instant',
+                    block: 'nearest'
+                  }}
                   key={action.id}
                   className={cx("AddCommandButton__ListItem", {
                     "AddCommandButton__ListItem--Selected":
@@ -204,7 +210,7 @@ class AddCommandButton extends Component {
                     autoEscape
                     textToHighlight={action.name}
                   />
-                </div>
+                </ScrollIntoViewIfNeeded>
               ))}
               {actionsList.length === 0 && (
                 <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -8274,6 +8274,11 @@ react-redux@^5.0.7:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
+react-scroll-into-view-if-needed@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/react-scroll-into-view-if-needed/-/react-scroll-into-view-if-needed-2.1.7.tgz#cb349882ec1462025ed63d47bf37f3504f7c1b32"
+  integrity sha512-ix9AB0GMFkilR05PQN9YvdgyEUkeZQB0JhQeafxyLdl+hzQc60+Ji/NZUiQEkxSxDZ3G5A3UJoxb+HnmNXiQsA==
+
 react-select@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.4.tgz#16bde37c24fd4f6444914d4681e78f15ffbc86d3"


### PR DESCRIPTION
Fixes #246.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Using the keyboard to navigate through the event list doesn't scroll along with the selected item, causing the selected list item to be out of view. #246 

* **What is the new behavior (if this is a feature change)?**

The list scrolls to the selected item when necessary.

![Oct-14-2019 17-20-13](https://user-images.githubusercontent.com/10043207/66784355-33a6da00-eea8-11e9-86a9-c397b83159fa.gif)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It shouldn't!

* **Other information**:

I introduced a small dependency, `react-scroll-into-view-if-needed`. This is my first PR in this project and I'm unsure if this is something I should have avoided, but it made the fix much simpler to implement. Please let me know if you'd prefer a fix without a dependency being introduced!