### PR TITLE
Fix MBC1 support

### DIFF
--- a/appData/src/gb/include/BankManager.h
+++ b/appData/src/gb/include/BankManager.h
@@ -1,6 +1,7 @@
 #ifndef BANK_MANAGER_H
 #define BANK_MANAGER_H
 
+#include "game.h"
 #include "Stack.h"
 
 #define N_PUSH_BANKS 10
@@ -12,6 +13,7 @@ void PopBank();
 
 #define PUSH_BANK(N) PushBank(N);
 #define POP_BANK PopBank();
-#define REFRESH_BANK SWITCH_ROM_MBC5(StackPeek(bank_stack))
+
+#define REFRESH_BANK SWITCH_ROM(StackPeek(bank_stack))
 
 #endif

--- a/appData/src/gb/include/game.h
+++ b/appData/src/gb/include/game.h
@@ -3,6 +3,9 @@
 
 #define CUSTOM_COLORS
 #define FAST_CPU
+#define SWITCH_ROM SWITCH_ROM_MBC5
+#define ENABLE_RAM ENABLE_RAM_MBC5
+#define DISABLE_RAM DISABLE_RAM_MBC5
 
 #include <gb/gb.h>
 

--- a/appData/src/gb/src/BankManager.c
+++ b/appData/src/gb/src/BankManager.c
@@ -5,7 +5,7 @@ DECLARE_STACK(bank_stack, N_PUSH_BANKS);
 void PushBank(UINT8 b)
 {
   StackPush(bank_stack, b);
-  SWITCH_ROM_MBC5(b);
+  SWITCH_ROM(b);
 }
 
 void PopBank()

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -7,6 +7,7 @@
 #include "MusicManager.h"
 #include "FadeManager.h"
 #include "BankData.h"
+#include "BankManager.h"
 #include "UI.h"
 #include "Macros.h"
 #include "game.h"
@@ -769,7 +770,7 @@ void Script_SaveData_b()
 {
   UWORD i;
 
-  ENABLE_RAM_MBC5;
+  ENABLE_RAM;
 
   RAMPtr = (UBYTE *)RAM_START_PTR;
   RAMPtr[0] = TRUE; // Flag to determine if data has been stored
@@ -807,7 +808,7 @@ void Script_SaveData_b()
     RAMPtr[i] = script_variables[i];
   }
 
-  DISABLE_RAM_MBC5;
+  DISABLE_RAM;
 
   script_ptr += 1 + script_cmd_args_len;
   script_continue = TRUE;
@@ -822,7 +823,7 @@ void Script_LoadData_b()
 {
   UWORD i;
 
-  ENABLE_RAM_MBC5;
+  ENABLE_RAM;
 
   RAMPtr = (UBYTE *)RAM_START_PTR;
   if (*RAMPtr == TRUE)
@@ -863,7 +864,7 @@ void Script_LoadData_b()
     script_action_complete = FALSE;
   }
 
-  DISABLE_RAM_MBC5;
+  DISABLE_RAM;
 
   script_ptr += 1 + script_cmd_args_len;
 }
@@ -875,10 +876,10 @@ void Script_LoadData_b()
  */
 void Script_ClearData_b()
 {
-  ENABLE_RAM_MBC5;
+  ENABLE_RAM;
   RAMPtr = (UBYTE *)RAM_START_PTR;
   RAMPtr[0] = FALSE;
-  DISABLE_RAM_MBC5;
+  DISABLE_RAM;
 
   script_ptr += 1 + script_cmd_args_len;
   script_continue = TRUE;
@@ -896,11 +897,11 @@ void Script_IfSavedData_b()
 {
   UBYTE jump;
 
-  ENABLE_RAM_MBC5;
+  ENABLE_RAM;
   RAMPtr = (UBYTE *)RAM_START_PTR;
   jump = 0;
   jump = *RAMPtr == TRUE;
-  DISABLE_RAM_MBC5;
+  DISABLE_RAM;
 
   if (jump)
   { // True path, jump to position specified by ptr

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1,6 +1,11 @@
 import { copy } from "fs-extra";
 import uuid from "uuid/v4";
-import BankedData, { MIN_DATA_BANK, GB_MAX_BANK_SIZE } from "./bankedData";
+import BankedData, {
+  MIN_DATA_BANK,
+  GB_MAX_BANK_SIZE,
+  MBC1,
+  MBC5
+} from "./bankedData";
 import {
   walkScenesEvents,
   findSceneEvent,
@@ -29,7 +34,8 @@ import {
   moveSpeedDec,
   animSpeedDec,
   spriteTypeDec,
-  actorFramesPerDir
+  actorFramesPerDir,
+  isMBC1
 } from "./helpers";
 import { textNumLines } from "../helpers/trimlines";
 import { assetFilename } from "../helpers/gbstudio";
@@ -78,9 +84,12 @@ const compile = async (
     warnings
   });
 
+  const cartType = projectData.settings.cartType;
+
   const banked = new BankedData({
     bankSize,
-    bankOffset
+    bankOffset,
+    bankController: isMBC1(cartType) ? MBC1 : MBC5
   });
 
   // Add event data
@@ -243,10 +252,10 @@ const compile = async (
     startAnimSpeed = "3"
   } = projectData.settings;
 
-  const bankNums = [...Array(bankOffset + banked.data.length).keys()];
+  const bankNums = banked.exportUsedBankNumbers();
 
-  const bankDataPtrs = bankNums.map(bankNum => {
-    return bankNum >= bankOffset ? `&bank_${bankNum}_data` : 0;
+  const bankDataPtrs = bankNums.map((usedBank, num) => {
+    return usedBank ? `&bank_${num}_data` : 0;
   });
 
   const fixEmptyDataPtrs = ptrs => {
@@ -267,12 +276,18 @@ const compile = async (
 
   const bankHeader = banked.exportCHeader(bankOffset);
   const bankData = banked.exportCData(bankOffset);
-  const nextAvailableBank = bankData.length + bankOffset + 1;
+
+  const musicBanks = [];
+  for (let i = 0; i < NUM_MUSIC_BANKS; i++) {
+    banked.currentBank++;
+    musicBanks[i] = banked.getWriteBank();
+  }
 
   const music = precompiled.usedMusic.map((track, index) => {
+    const bank = musicBanks[index % musicBanks.length];
     return {
       ...track,
-      bank: nextAvailableBank + (index % NUM_MUSIC_BANKS)
+      bank
     };
   });
 
@@ -360,7 +375,8 @@ const compile = async (
   output[`banks.h`] = bankHeader;
 
   bankData.forEach((bankDataBank, index) => {
-    output[`bank_${bankOffset + index}.c`] = bankDataBank;
+    const bank = bankDataBank.match(/pragma bank=([0-9]+)/)[1];
+    output[`bank_${bank}.c`] = bankDataBank;
   });
 
   return {

--- a/src/lib/compiler/helpers.js
+++ b/src/lib/compiler/helpers.js
@@ -137,6 +137,8 @@ const combineMultipleChoiceText = args => {
   return `${trueText}\n${falseText}`;
 };
 
+const isMBC1 = cartType => cartType === "03" || cartType === "02";
+
 module.exports = {
   nameToCName,
   dirDec,
@@ -149,5 +151,6 @@ module.exports = {
   operatorDec,
   spriteTypeDec,
   actorFramesPerDir,
-  combineMultipleChoiceText
+  combineMultipleChoiceText,
+  isMBC1
 };

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -6,6 +6,7 @@ import copy from "../helpers/fsCopy";
 import buildMakeBat from "./buildMakeBat";
 import { hexDec } from "../helpers/8bit";
 import getTmp from "../helpers/getTmp";
+import { isMBC1 } from "./helpers"
 
 const HEADER_TITLE = 0x134;
 const HEADER_CHECKSUM = 0x14d;
@@ -109,6 +110,9 @@ const makeBuild = ({
     }
     if (!settings.gbcFastCPUEnabled) {
       gameHeader = gameHeader.replace(/#define FAST_CPU/g, '');
+    }
+    if(isMBC1(settings.cartType)) {
+      gameHeader = gameHeader.replace(/_MBC5/g, '_MBC1');
     }
     await fs.writeFile(`${buildRoot}/include/game.h`, gameHeader, "utf8");
 

--- a/test/data/compiler/bankedData.test.js
+++ b/test/data/compiler/bankedData.test.js
@@ -3,7 +3,8 @@ import BankedData, {
   BANKED_DATA_TOO_LARGE,
   BANKED_COUNT_OVERFLOW,
   GB_MAX_BANK_SIZE,
-  MIN_DATA_BANK
+  MIN_DATA_BANK,
+  MBC1
 } from "../../../src/lib/compiler/bankedData";
 import {
   cIntArray,
@@ -157,4 +158,113 @@ test("should throw if unsupported number of rom banks are required", () => {
   const banked = new BankedData({ bankSize: 2, bankOffset: 1024 });
   banked.push([0]);
   expect(() => banked.romBanksNeeded()).toThrow(BANKED_COUNT_OVERFLOW);
+});
+
+test("should disallow bank 0x20 when using MBC1", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 30,
+    bankController: MBC1
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 30, offset: 0 });
+  expect(ptr2).toEqual({ bank: 31, offset: 0 });
+  expect(ptr3).toEqual({ bank: 33, offset: 0 });
+  expect(ptr4).toEqual({ bank: 34, offset: 0 });
+});
+
+test("should disallow bank 0x40 when using MBC1", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 62,
+    bankController: MBC1
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 62, offset: 0 });
+  expect(ptr2).toEqual({ bank: 63, offset: 0 });
+  expect(ptr3).toEqual({ bank: 65, offset: 0 });
+  expect(ptr4).toEqual({ bank: 66, offset: 0 });
+});
+
+test("should disallow bank 0x60 when using MBC1", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 94,
+    bankController: MBC1
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 94, offset: 0 });
+  expect(ptr2).toEqual({ bank: 95, offset: 0 });
+  expect(ptr3).toEqual({ bank: 97, offset: 0 });
+  expect(ptr4).toEqual({ bank: 98, offset: 0 });
+});
+
+test("should allow bank 0x20 when using MBC5", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 30
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 30, offset: 0 });
+  expect(ptr2).toEqual({ bank: 31, offset: 0 });
+  expect(ptr3).toEqual({ bank: 32, offset: 0 });
+  expect(ptr4).toEqual({ bank: 33, offset: 0 });
+});
+
+test("should allow bank 0x40 when using MBC5", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 62
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 62, offset: 0 });
+  expect(ptr2).toEqual({ bank: 63, offset: 0 });
+  expect(ptr3).toEqual({ bank: 64, offset: 0 });
+  expect(ptr4).toEqual({ bank: 65, offset: 0 });
+});
+
+test("should allow bank 0x60 when using MBC5", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 94
+  });
+  const ptr1 = banked.push([1, 2]);
+  const ptr2 = banked.push([1, 2]);
+  const ptr3 = banked.push([1, 2]);
+  const ptr4 = banked.push([1, 2]);
+  expect(ptr1).toEqual({ bank: 94, offset: 0 });
+  expect(ptr2).toEqual({ bank: 95, offset: 0 });
+  expect(ptr3).toEqual({ bank: 96, offset: 0 });
+  expect(ptr4).toEqual({ bank: 97, offset: 0 });
+});
+
+test("should not create data files for bank 0x20 when using MBC1", () => {
+  const banked = new BankedData({
+    bankSize: 2,
+    bankOffset: 30,
+    bankController: MBC1
+  });
+  banked.push([1, 2]);
+  banked.push([1, 2]);
+  banked.push([1, 2]);
+  banked.push([1, 2]);
+  const cData = banked.exportCData();
+  const cHeader = banked.exportCHeader();
+  expect(cData.length).toBe(4);
+  expect(cHeader).not.toContain("bank_32");
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix MBC1 support, using correct GBDK banking functions when enabled and avoiding banks 0x20, 0x40 and 0x60 for data and music based on issue noted in #317 

* **What is the current behavior?** (You can also link to an open issue here)

When MBC1 is enabled as the memory bank controller in project settings the game engine was still using the GBDK functions for MBC5 which would likely not work on real cartridges. Also when MBC1 is enabled banks 0x20, 0x40, and 0x60 cannot be used and should be avoided.

* **What is the new behavior (if this is a feature change)?**

When MBC1 is selected in settings the C headers are modified to use MBC1 functions instead of MBC5, also data and music will no longer be stored in banks 0x20, 0x40 and 0x60.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Hopefully not, though I still need to test on Windows before merging.