### PR TITLE
Prevent actors from exiting scene edges

### DIFF
--- a/appData/src/gb/include/Macros.h
+++ b/appData/src/gb/include/Macros.h
@@ -13,7 +13,9 @@
 #define JOY_CHANGED (joy != prev_joy)
 
 #define ACTOR_BETWEEN_TILES(i) (((actors[(i)].pos.x & 7) != 0) || ((actors[(i)].pos.y & 7) != 0))
-#define ACTOR_ON_TILE(i) (((actors[(i)].pos.x & 7) == 0) && ((actors[(i)].pos.y & 7) == 0))
+#define ACTOR_ON_TILE_X(i) ((actors[(i)].pos.x & 7) == 0)
+#define ACTOR_ON_TILE_Y(i) (((actors[(i)].pos.y & 7) == 0) || (actors[(i)].pos.y == 254))
+#define ACTOR_ON_TILE(i) ((ACTOR_ON_TILE_X(i)) && (ACTOR_ON_TILE_Y(i)))
 
 #define IS_FRAME_128 ((time & 0x7F) == 0)
 #define IS_FRAME_64 ((time & 0x3F) == 0)
@@ -38,6 +40,8 @@
 #define DIV_8(a) ((a) >> 3)
 #define DIV_4(a) ((a) >> 2)
 #define DIV_2(a) ((a) >> 1)
+
+#define LT_8(a) (((a) >> 3) == 0)
 
 #define ACTOR_SPRITE(ptr) (*(ptr))
 #define ACTOR_X(ptr) (*((ptr) + 1))

--- a/appData/src/gb/include/Scene.h
+++ b/appData/src/gb/include/Scene.h
@@ -35,7 +35,7 @@
 #define ACTOR_MIN_X 8
 #define ACTOR_MAX_X 248
 #define ACTOR_MIN_Y 16
-#define ACTOR_MAX_Y 255
+#define ACTOR_MAX_Y 254
 
 extern UINT8 scene_bank;
 extern POS map_next_pos;

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -342,6 +342,10 @@ void Script_ActorSetPos_b()
   actors[script_actor].pos.x = (script_cmd_args[0] << 3) + 8;
   actors[script_actor].pos.y = 0; // @wtf-but-needed
   actors[script_actor].pos.y = (script_cmd_args[1] << 3) + 8;
+  if (script_cmd_args[1] == 31)
+  {
+    actors[script_actor].pos.y = ACTOR_MAX_Y;
+  }
   script_ptr += 1 + script_cmd_args_len;
   script_continue = TRUE;
 }
@@ -362,6 +366,10 @@ void Script_ActorMoveTo_b()
   actor_move_dest.x = (script_cmd_args[0] << 3) + 8;
   actor_move_dest.y = 0; // @wtf-but-needed
   actor_move_dest.y = (script_cmd_args[1] << 3) + 8;
+  if (script_cmd_args[1] == 31)
+  {
+    actor_move_dest.y = ACTOR_MAX_Y;
+  }
   script_ptr += 1 + script_cmd_args_len;
   script_action_complete = FALSE;
 }
@@ -696,7 +704,7 @@ void Script_ActorPush_b()
     }
     else if (actors[0].dir.x > 0)
     {
-      dest_x = 240;
+      dest_x = ACTOR_MAX_X;
     }
     else
     {
@@ -708,7 +716,7 @@ void Script_ActorPush_b()
     }
     else if (actors[0].dir.y > 0)
     {
-      dest_y = 240;
+      dest_y = ACTOR_MAX_Y;
     }
     else
     {
@@ -989,6 +997,10 @@ void Script_ActorSetPosToVal_b()
   actors[script_actor].pos.x = (script_variables[script_ptr_x] << 3) + 8;
   actors[script_actor].pos.y = 0; // @wtf-but-needed
   actors[script_actor].pos.y = (script_variables[script_ptr_y] << 3) + 8;
+  if (script_variables[script_ptr_y] == 31)
+  {
+    actors[script_actor].pos.y = ACTOR_MAX_Y;
+  }
   script_ptr += 1 + script_cmd_args_len;
   script_continue = TRUE;
 }
@@ -1006,6 +1018,10 @@ void Script_ActorMoveToVal_b()
   actor_move_dest.x = (script_variables[script_ptr_x] << 3) + 8;
   actor_move_dest.y = 0; // @wtf-but-needed
   actor_move_dest.y = (script_variables[script_ptr_y] << 3) + 8;
+  if (script_variables[script_ptr_y] == 31)
+  {
+    actor_move_dest.y = ACTOR_MAX_Y;
+  }
   script_ptr += 1 + script_cmd_args_len;
   script_action_complete = FALSE;
 }

--- a/src/lib/events/eventActorMoveTo.js
+++ b/src/lib/events/eventActorMoveTo.js
@@ -13,7 +13,7 @@ export const fields = [
     label: l10n("FIELD_X"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 30,
     width: "50%",
     defaultValue: 0
   },
@@ -22,7 +22,7 @@ export const fields = [
     label: l10n("FIELD_Y"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 31,
     width: "50%",
     defaultValue: 0
   }

--- a/src/lib/events/eventActorSetPosition.js
+++ b/src/lib/events/eventActorSetPosition.js
@@ -13,7 +13,7 @@ export const fields = [
     label: l10n("FIELD_X"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 30,
     width: "50%",
     defaultValue: 0
   },
@@ -22,7 +22,7 @@ export const fields = [
     label: l10n("FIELD_Y"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 31,
     width: "50%",
     defaultValue: 0
   }

--- a/src/lib/events/eventIfActorAtPosition.js
+++ b/src/lib/events/eventIfActorAtPosition.js
@@ -13,7 +13,7 @@ export const fields = [
     label: l10n("FIELD_X"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 30,
     width: "50%",
     defaultValue: 0
   },
@@ -22,7 +22,7 @@ export const fields = [
     label: l10n("FIELD_Y"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 31,
     width: "50%",
     defaultValue: 0
   },

--- a/src/lib/events/eventSceneSwitch.js
+++ b/src/lib/events/eventSceneSwitch.js
@@ -13,7 +13,7 @@ export const fields = [
     label: l10n("FIELD_X"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 30,
     defaultValue: 0,
     width: "50%"
   },
@@ -22,7 +22,7 @@ export const fields = [
     label: l10n("FIELD_Y"),
     type: "number",
     min: 0,
-    max: 32,
+    max: 31,
     defaultValue: 0,
     width: "50%"
   },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Prevents actors from walking off scene edges fixing the issues seen in #315

* **What is the current behavior?** (You can also link to an open issue here)
Walking off scene edges has inconsistent collision handling requiring a strip of collisions to be placed around all four edges of a scene to be certain that the player can't walk through edges.

* **What is the new behavior (if this is a feature change)?**
Actors now stop walking at scene edges allowing a larger area of the map to be used for the walking area with no manual collision setup required.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If anyone was depending on scene wrapping this will no longer be working, though it would be possible to add this functionality using triggers at the scene edges with "Actor: Set Position" events to jump to the other side of the scene.

* **Other information**:
I still need to test this on the Windows build before merging.