### PR TITLE
Add "Self" to Actor select

### DIFF
--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -110,8 +110,10 @@ class ScriptBuilder {
 
   actorSetActive = id => {
     const output = this.output;
-    const { scene } = this.options;
-    const index = getActorIndex(id, scene);
+    const { scene, entity } = this.options;
+    const index = id === "$self$"
+      ? getActorIndex(entity.id, scene)
+      : getActorIndex(id, scene);
     output.push(cmd(ACTOR_SET_ACTIVE));
     output.push(index);
   };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds a new `Self` option to Actor Selector fields inside Actor Scripts

* **What is the current behavior?** (You can also link to an open issue here)

When copy and pasting an Actor with scripts that reference itself all the Actor select fields need to be set to the new Actor again.

* **What is the new behavior (if this is a feature change)?**

When selected, "Self" always references the current actor. So when the actor is copied it'll reference the newly created Actor rather than the previous one.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**:
