### PR TITLE
Improve in editor music scriptracker.js to act like GBT

### DIFF
--- a/src/lib/vendor/scriptracker/channel.js
+++ b/src/lib/vendor/scriptracker/channel.js
@@ -70,8 +70,8 @@ Channel.prototype.reset = function() {
 	this.sample.remain   = 0;
 	this.sample.reversed = false;
 	
-	this.volume.channelVolume = 0;
-	this.volume.sampleVolume  = 0;
+	this.volume.channelVolume = 1; //GBT sets full volume on song start
+	this.volume.sampleVolume  = 1; //GBT sets full volume on song start
 	this.volume.volumeSlide   = 0;
 	this.volume.envelope      = null;
 	

--- a/src/lib/vendor/scriptracker/sample.js
+++ b/src/lib/vendor/scriptracker/sample.js
@@ -51,6 +51,7 @@ Sample.prototype.loadSample = function(sampleData, signed) {
 			} else {
 				val = (val8 / 128.0) - 1.0;
 			}
+			// val = ( Math.round(val*1000) / 1000 ); // keep number decimal place short when writing to log.
 		} else {
 			var val16 = Helpers.readWord(sampleData, i * 2);
 			i ++;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Bug fix / feature.

* **What is the current behavior?** (You can also link to an open issue here)
Split of #294 to make merging easier.
Related to #172, #83 and partly #176
The in editor music preview is very inaccurate and will play any mod files without GameBoyTracker limits, leading to confusion and not being useful for previewing common mistakes.

* **What is the new behavior (if this is a feature change)?**
Notes use last set volume instead of the default sample volume.
Channel 4 Noise is forced to note C5.
Instruments are limited to their channels, (no pulse waves on the noise track.)
Forced pan to hard left, both, or hard right.
Tick speed changes the tempo to match in game speeds (tick speeds 4 or faster).
Instrument 28 pitched to better match in game noise.
Hard code Pulse and Wave sample instruments 1-14 as small, accurate samples.
(Catch users with wrong instruments in their mod. Sounds nicer.)
Add persistent Volume sweep for volume envelopes (not in GBT just yet ;)

* **Other information**:
Most cases except odd GBT bugs are now reproduced, (some gbt bugs are being fixed)
It is now useful as a fast preview that reveals common mistakes (volume), without building a game.