### PR TITLE
Update scroll registers on VBL interrupt

### DIFF
--- a/appData/src/gb/include/Scene.h
+++ b/appData/src/gb/include/Scene.h
@@ -60,6 +60,8 @@ extern UBYTE timer_script_duration;
 extern UBYTE timer_script_time;
 extern BANK_PTR timer_script_ptr;
 extern UBYTE scene_loaded;
+extern UBYTE scroll_x;
+extern UBYTE scroll_y;
 
 void SceneInit();
 void SceneUpdate();

--- a/appData/src/gb/src/Scene.c
+++ b/appData/src/gb/src/Scene.c
@@ -37,7 +37,8 @@ BANK_PTR input_script_ptrs[NUM_INPUTS] = {{0}};
 UBYTE timer_script_duration = 0;
 UBYTE timer_script_time = 0;
 BANK_PTR timer_script_ptr = {0};
-
+UBYTE scroll_x;
+UBYTE scroll_y;
 
 void SceneInit()
 {

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -89,8 +89,8 @@ void SceneInit_b1()
   SpritesReset();
   UIInit();
 
-  SCX_REG = 0;
-  SCY_REG = 0;
+  scroll_x = 0;
+  scroll_y = 0;
   WX_REG = MAXWNDPOSX;
   WY_REG = MAXWNDPOSY;
 
@@ -367,7 +367,7 @@ void SceneUpdateCamera_b()
     camera_dest.y = cam_y - SCREEN_HEIGHT_HALF;
   }
 
-  camera_moved = SCX_REG != camera_dest.x || SCY_REG != camera_dest.y;
+  camera_moved = scroll_x != camera_dest.x || scroll_y != camera_dest.y;
 
   if (camera_moved)
   {
@@ -376,29 +376,29 @@ void SceneUpdateCamera_b()
     {
       if ((time & camera_speed) == 0)
       {
-        if (SCX_REG > camera_dest.x)
+        if (scroll_x > camera_dest.x)
         {
-          SCX_REG--;
+          scroll_x--;
         }
-        else if (SCX_REG < camera_dest.x)
+        else if (scroll_x < camera_dest.x)
         {
-          SCX_REG++;
+          scroll_x++;
         }
-        if (SCY_REG > camera_dest.y)
+        if (scroll_y > camera_dest.y)
         {
-          SCY_REG--;
+          scroll_y--;
         }
-        else if (SCY_REG < camera_dest.y)
+        else if (scroll_y < camera_dest.y)
         {
-          SCY_REG++;
+          scroll_y++;
         }
       }
     }
     // Otherwise jump imediately to camera destination
     else
     {
-      SCX_REG = camera_dest.x;
-      SCY_REG = camera_dest.y;
+      scroll_x = camera_dest.x;
+      scroll_y = camera_dest.y;
     }
   }
 }
@@ -939,7 +939,7 @@ void SceneRenderCameraShake_b()
   // Handle Shake
   if (shake_time != 0)
   {
-    SCX_REG += shake_time & 0x5;
+    scroll_x += shake_time & 0x5;
   }
 }
 
@@ -978,8 +978,8 @@ void SceneRenderActors_b()
   for (i = 0; i != scene_num_actors; ++i)
   {
     s = MUL_2(i) + ACTOR_SPRITE_OFFSET;
-    x = ACTOR_X(ptr) - SCX_REG;
-    y = ACTOR_Y(ptr) - SCY_REG;
+    x = ACTOR_X(ptr) - scroll_x;
+    y = ACTOR_Y(ptr) - scroll_y;
 
     if (ACTOR_ENABLED(ptr) && (win_pos_y == MENU_CLOSED_Y || (y < win_pos_y + 16 || x < win_pos_x + 8)))
     {
@@ -1063,8 +1063,8 @@ void SceneRenderEmoteBubble_b()
     {
 
       // Set x and y above actor displaying emote
-      screen_x = actors[emote_actor].pos.x - SCX_REG;
-      screen_y = actors[emote_actor].pos.y - ACTOR_HEIGHT - SCY_REG;
+      screen_x = actors[emote_actor].pos.x - scroll_x;
+      screen_y = actors[emote_actor].pos.y - ACTOR_HEIGHT - scroll_y;
 
       // At start of animation bounce bubble in using stored offsets
       if (emote_timer < BUBBLE_ANIMATION_FRAMES)
@@ -1171,7 +1171,7 @@ UBYTE SceneIsEmoting_b()
 
 UBYTE SceneCameraAtDest_b()
 {
-  return SCX_REG == camera_dest.x && SCY_REG == camera_dest.y;
+  return scroll_x == camera_dest.x && scroll_y == camera_dest.y;
 }
 
 UBYTE SceneAwaitInputPressed_b()

--- a/appData/src/gb/src/game.c
+++ b/appData/src/gb/src/game.c
@@ -27,12 +27,27 @@ SCENE_STATE scene_stack[MAX_SCENE_STATES] = {{0}};
 
 void game_loop();
 
+void vbl_update() {
+  SCX_REG = scroll_x;
+  SCY_REG = scroll_y;
+}
+
 int main()
 {
+  #ifdef FAST_CPU
+  if (_cpu == CGB_TYPE)
+  {
+    cpu_fast();
+  }
+  #endif
+
+  disable_interrupts();
+  add_VBL(vbl_update);
+
   // Init LCD
   LCDC_REG = 0x67;
   set_interrupts(VBL_IFLAG | LCD_IFLAG);
-  STAT_REG = 0x45;
+  enable_interrupts();
 
   // Set palettes
   #ifdef CUSTOM_COLORS
@@ -47,13 +62,6 @@ int main()
     BGP_REG = 0xE4U;
     OBP0_REG = 0xD2U;
   }  
-
-  #ifdef FAST_CPU
-  if (_cpu == CGB_TYPE)
-  {
-    cpu_fast();
-  }
-  #endif
 
   // Position Window Layer
   WY_REG = MAXWNDPOSY - 7;


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix. 

* **What is the current behavior?** (You can also link to an open issue here)

On scene, sprite position sometimes gets out of sync with background.

![old_scroll](https://user-images.githubusercontent.com/54246642/69684645-57695c80-10b1-11ea-83df-7eb70be338e5.gif)
(It might be hard to appreciate in the GIF, but the rock sprite moves one pixel up and down as the player walks and the scene scrolls)

* **What is the new behavior (if this is a feature change)?**

`SCX_REG` and `SCY_REG` are now updated on a VBL interrupt. Keeping backgrounds and sprites in sync.

![new_scroll](https://user-images.githubusercontent.com/54246642/69684662-6b14c300-10b1-11ea-97fb-b6fd038857c8.gif)
(the rock sprite stays in the same position with the scene scroll)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

After some quick tests, doesn't seem to break anything. However I'm not 100% sure of the possible side-effects of moving the scroll updates. Further testing would be good.

* **Other information**:

The change was inspired by ZGB logic for scroll https://github.com/Zal0/ZGB/blob/0f6f59eea1f4787ac76629661d2abc4ce8bb3b7a/common/src/main.c#L39