### PR TITLE
Editor keep scene collision when switching to bg without collision

### DIFF
--- a/src/reducers/entitiesReducer.js
+++ b/src/reducers/entitiesReducer.js
@@ -426,6 +426,7 @@ const editScene = (state, action) => {
 
   // If switched background use collisions from another
   // scene using the background already if available
+  // otherwise keep old collisions if same width
   // otherwise make empty collisions array of
   // the correct size
   let newState = state;
@@ -439,10 +440,16 @@ const editScene = (state, action) => {
     const otherScene = scenes.find(s => {
       return s.backgroundId === action.values.backgroundId;
     });
+    const oldBackground = state.entities.backgrounds[scene.backgroundId];
     const background = state.entities.backgrounds[action.values.backgroundId];
 
     if (otherScene) {
       newCollisions = otherScene.collisions;
+    } else if (oldBackground.width == background.width){
+      const collisionsSize = Math.ceil(
+        (background.width * background.height) / 8
+      );
+        newCollisions = (scene.collisions.slice(0,collisionsSize));
     } else {
       const collisionsSize = Math.ceil(
         (background.width * background.height) / 8


### PR DESCRIPTION
Only keeps if it's the same width, and if there's no other collision currently for that background.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Feature / bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When you change the background of a scene containing collision, it destroys the current collision and either copies collision if a scene with that background has some, or clears it.

* **What is the new behavior (if this is a feature change)?**
If you change the background of a scene to one that has not been used yet, and is the same width, it will keep your current collision.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The original method takes priority, if it finds a scene it can copy collision from, it will.
If the scene is taller, it will work fine, if the scene is shorter, it will split/crop the collision array to size.
If the width changes, it will clear the collision (unless there's a background in use with collision to steal).

* **Other information**:
This was asked for on discord, and when i had the issue and found how frustrating it was, decided to fix it. 
It took me an hour or more just to find where background switching happened...
