### PR TITLE
Variable list update on rename

### DIFF
--- a/src/components/forms/GlobalVariableSelect.js
+++ b/src/components/forms/GlobalVariableSelect.js
@@ -54,7 +54,7 @@ class GlobalVariableSelect extends Component {
   };
 
   render() {
-    const { id, value, onChange } = this.props;
+    const { id, value, onChange, variablesVersion } = this.props;
 
     const options = [
       {
@@ -81,6 +81,7 @@ class GlobalVariableSelect extends Component {
 
     return (
       <SelectRenamable
+        key={variablesVersion}
         editPlaceholder={l10n("FIELD_VARIABLE_NAME")}
         editDefaultValue={
           valueIsLocal ? this.localName(value) : this.variableName(value || "0")
@@ -107,7 +108,8 @@ GlobalVariableSelect.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   variables: PropTypes.objectOf(VariableShape).isRequired,
-  renameVariable: PropTypes.func.isRequired
+  renameVariable: PropTypes.func.isRequired,
+  variablesVersion: PropTypes.number.isRequired
 };
 
 GlobalVariableSelect.defaultProps = {
@@ -117,8 +119,10 @@ GlobalVariableSelect.defaultProps = {
 
 function mapStateToProps(state) {
   const variables = state.entities.present.entities.variables;
+  const variablesVersion = state.editor.variableVersion;
   return {
-    variables
+    variables,
+    variablesVersion
   };
 }
 

--- a/src/reducers/editorReducer.js
+++ b/src/reducers/editorReducer.js
@@ -42,7 +42,8 @@ import {
   SELECT_CUSTOM_EVENT,
   ADD_CUSTOM_EVENT,
   REMOVE_CUSTOM_EVENT,
-  RELOAD_ASSETS
+  RELOAD_ASSETS,
+  RENAME_VARIABLE
 } from "../actions/actionTypes";
 import { zoomIn, zoomOut } from "../lib/helpers/zoom";
 
@@ -317,6 +318,12 @@ export default function editor(state = initialState.editor, action) {
       return {
         ...state,
         uiVersion: state.uiVersion + 1
+      };
+    }
+    case RENAME_VARIABLE: {
+      return {
+        ...state,
+        variableVersion: state.variableVersion + 1
       };
     }
     case ZOOM_IN:

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -25,6 +25,7 @@ export default {
     sceneDragX: 0,
     sceneDragY: 0,
     uiVersion: 0,
+    variableVersion: 0,
     hover: {
       sceneId: "",
       actorId: "",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When a variable selector is opened the list of variable names is cached so that if you open one selector, rename a variable in a second selector, and open the first one again the rename will not be displayed. First reported in #352 

* **What is the new behavior (if this is a feature change)?**
When any variables are renamed all variable selectors currently on screen will now rerender causing their internal cache to clear.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
