### PR TITLE
Fix for #351 where collisions couldn't be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix bug where collisions couldn't be placed if "Show Collisions" setting was off.
 - Fix bug where variable lists sometimes show show old names.
 - Fix bug where opening menu would modify text draw speed. [@pau-tomas](https://github.com/pau-tomas)
 - Switching scene background will keep current collisions if image hasn't had collisions set already. [@RichardULZ](https://github.com/RichardULZ)

--- a/src/components/world/SceneCursor.js
+++ b/src/components/world/SceneCursor.js
@@ -68,7 +68,7 @@ class SceneCursor extends Component {
       this.setState({ resize: true });
       window.addEventListener("mousemove", this.onResizeTrigger);
       window.addEventListener("mouseup", this.onResizeTriggerStop);
-    } else if (tool === "collisions" && showCollisions) {
+    } else if (tool === "collisions") {
       const collisionIndex = scene.width * y + x;
       const collisionByteIndex = collisionIndex >> 3;
       const collisionByteOffset = collisionIndex & 7;
@@ -117,17 +117,14 @@ class SceneCursor extends Component {
       x,
       y,
       sceneId,
-      showCollisions,
       addCollisionTile,
       removeCollisionTile
     } = this.props;
     if (this.currentX !== x || this.currentY !== y) {
-      if (showCollisions) {
-        if (this.remove) {
-          removeCollisionTile(sceneId, x, y);
-        } else {
-          addCollisionTile(sceneId, x, y);
-        }
+      if (this.remove) {
+        removeCollisionTile(sceneId, x, y);
+      } else {
+        addCollisionTile(sceneId, x, y);
       }
       this.currentX = x;
       this.currentY = y;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When the global setting "Show Collisions" is turned off, collisions are still visible when using the Collisions tool but trying to place/remove collisions does not work.

* **What is the new behavior (if this is a feature change)?**
The collisions tool works as expected regardless of the "Show Collisions" setting. When "Show Collisions" is off and any other tool is selected the collisions will be hidden but if the collisions tool is selected the collisions will be visible and can be edited.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
