### PR TITLE
Fix #343 where paste event button getting stuck when switching window while holding Alt key

### DIFF
--- a/src/components/script/AddCommandButton.js
+++ b/src/components/script/AddCommandButton.js
@@ -33,11 +33,13 @@ class AddCommandButton extends Component {
   componentDidMount() {
     window.addEventListener("keydown", this.detectPasteMode);
     window.addEventListener("keyup", this.detectPasteMode);
+    window.addEventListener("blur", this.onBlur);
   }
 
   componentWillUnmount() {
     window.removeEventListener("keydown", this.detectPasteMode);
     window.removeEventListener("keyup", this.detectPasteMode);
+    window.removeEventListener("blur", this.onBlur);
   }
 
   detectPasteMode = e => {
@@ -45,6 +47,10 @@ class AddCommandButton extends Component {
       return;
     }
     this.setState({ pasteMode: e.altKey });
+  };
+
+  onBlur = e => {
+    this.setState({ pasteMode: false });
   };
 
   onOpen = () => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Holding the Alt key while switching to another application away from GB Studio then releasing the Alt key before returning (as may happen when using Alt+Tab on Windows but issue is on all platforms) will cause "Add Event" buttons to become stuck as "Paste Event" buttons until Alt is pressed and released again or the selected entity is changed.

* **What is the new behavior (if this is a feature change)?**
When the GB Studio window becomes blurred the "Paste Event" buttons become "Add Event" buttons again.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No