### PR TITLE
Fix convert hex to take into account color palette transform occurring in GBC emulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "forge": "./forge.config.js"
   },
   "dependencies": {
+    "3x3-equation-solver": "^1.2.18",
     "@babel/core": "^7.4.5",
     "@babel/plugin-transform-modules-commonjs": "^7.4.4",
     "@babel/plugin-transform-react-jsx": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"3x3-equation-solver@^1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/3x3-equation-solver/-/3x3-equation-solver-1.2.18.tgz#0991179f00a3da7ff55bbb34c85e4282634cb3c0"
+  integrity sha512-iTrI50JhqYd10f9ShY4a7i57Nq5NhpCp+QrfSR19kBgWhwvSPe/Upi7feCvbM1yxxIU7PL5NOt9BMrkFweVoKw==
+
 "7zip@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
@@ -4720,7 +4725,7 @@ gonzales-pe@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
-graceful-fs@^4.1.11:
+graceful-fs@^4.1.11, graceful-fs@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -4729,11 +4734,6 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4,
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
-
-graceful-fs@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 graceful-fs@~3.0.5:
   version "3.0.11"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
In the colour palette picker, entering a hex code and clicking "Convert Hex" will result in a slightly different colour being used in game than the hex code represents. This is because the in game emulator uses a function to tint the colours to match the GBC display.

* **What is the new behavior (if this is a feature change)?**
The "Convert Hex" now calls an inverse of the tint function to find the closest matching hex that will display in game as the intended colour. An equation solver was added to determine the closest value and as the tint function is lossy it's not 100% guaranteed that passing a value through the tint and then through the inverse will return the original value but it will be very close.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Issue was first noticed in a comment in #341 