### PR TITLE
Fix timer script with show overlay, faster min speed, and performance improvement.

### DIFF
--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -725,12 +725,6 @@ void SceneUpdateTimer_b()
     return;
   }
 
-  // Don't update timer when UI is open
-  if (!UIIsClosed())
-  {
-    return;
-  }
-
   // Check if timer is enabled
   if (timer_script_duration != 0)
   {

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -720,7 +720,7 @@ void SceneUpdateTimer_b()
   }
 
   // Don't update timer while script is running
-  if (script_ptr != 0 || emote_timer != 0 || fade_running)
+  if (script_ptr != 0 || fade_running)
   {
     return;
   }
@@ -845,7 +845,8 @@ static void SceneHandleInput()
   }
 
   // Can't move while script is running
-  if (script_ptr != 0 || emote_timer != 0 || fade_running)
+  // (removed "emote_timer != 0" as it should only happen if script was set)
+  if (script_ptr != 0 || fade_running)
   {
     actors[0].moving = FALSE;
     return;

--- a/src/lib/events/eventTimerScriptSet.js
+++ b/src/lib/events/eventTimerScriptSet.js
@@ -10,9 +10,9 @@ export const fields = [
     key: "duration",
     type: "number",
     label: l10n("FIELD_TIMER_DURATION"),
-    min: 0.50,
+    min: 0.25,
     max: 60,
-    step: 0.05,
+    step: 0.25,
     defaultValue: 10.0
   },
   {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Bug fix & feature


* **What is the current behavior?** (You can also link to an open issue here)
#353 Show overlay halts timerscript
https://discordapp.com/channels/554713715442712616/585023243732123676/652881193359900695
Timer script faster please? https://discordapp.com/channels/554713715442712616/570925583421276160/654859741788504106

* **What is the new behavior (if this is a feature change)?**

1. Allows show overlay at the end of a script, timer script still pauses for dialogue or anything during script.

2. Change the minimum timer script speed to 0.25 seconds and step in 0.25 increments instead of 0.05. 
Timer script ticks every 16 frames, about 0.26 seconds, so this is the fastest it will go. 
You can still type 6.712 or anything arbitrary between min max into the field. 
Seems to work fine @gregtour 

3. Performance change, removes checks for emote_timer on movement and timer script, as this should always need a script_ptr to be active, seems to run identically with this not checked.
Any issues you can think of with this change @chrismaltby ?

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
