### PR TITLE
Fix Invoke actor for scripts in other banks

### DIFF
--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -20,6 +20,7 @@ extern UBYTE script_actor;
 // Max call stack depth
 #define STACK_SIZE 8
 extern UWORD script_stack[STACK_SIZE];
+extern UWORD script_bank_stack[STACK_SIZE];
 extern UWORD script_start_stack[STACK_SIZE];
 extern UBYTE script_stack_ptr;
 

--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -20,7 +20,7 @@ extern UBYTE script_actor;
 // Max call stack depth
 #define STACK_SIZE 8
 extern UWORD script_stack[STACK_SIZE];
-extern UWORD script_bank_stack[STACK_SIZE];
+extern UBYTE script_bank_stack[STACK_SIZE];
 extern UWORD script_start_stack[STACK_SIZE];
 extern UBYTE script_stack_ptr;
 

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -19,7 +19,7 @@ SCRIPT_CMD_FN last_fn;
 
 UBYTE script_stack_ptr = 0;
 UWORD script_stack[STACK_SIZE] = {0};
-UWORD script_bank_stack[STACK_SIZE] = {0};
+UBYTE script_bank_stack[STACK_SIZE] = {0};
 UWORD script_start_stack[STACK_SIZE] = {0};
 
 SCRIPT_CMD script_cmds[] = {

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -19,6 +19,7 @@ SCRIPT_CMD_FN last_fn;
 
 UBYTE script_stack_ptr = 0;
 UWORD script_stack[STACK_SIZE] = {0};
+UWORD script_bank_stack[STACK_SIZE] = {0};
 UWORD script_start_stack[STACK_SIZE] = {0};
 
 SCRIPT_CMD script_cmds[] = {

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -1457,9 +1457,11 @@ void Script_ActorInvoke_b()
  * Command: StackPush
  * ----------------------------
  * Push the current script pointer to the stack
+ * Store script start ptr for if statements, script bank for long scripts.
  */
 void Script_StackPush_b()
 {
+  script_bank_stack[script_stack_ptr] = script_ptr_bank;
   script_stack[script_stack_ptr] = script_ptr;
   script_start_stack[script_stack_ptr] = script_start_ptr;
   script_stack[script_stack_ptr] += 1 + script_cmd_args_len;
@@ -1470,10 +1472,12 @@ void Script_StackPush_b()
  * Command: StackPop
  * ----------------------------
  * Pop the script pointer from the stack
+ * Retrieve script start ptr for if statements, script bank for long scripts.
  */
 void Script_StackPop_b()
 {
   script_stack_ptr--;
+  script_ptr_bank = script_bank_stack[script_stack_ptr];
   script_ptr = script_stack[script_stack_ptr];
   script_start_ptr = script_start_stack[script_stack_ptr];
   script_continue = TRUE;

--- a/src/lib/compiler/compileEntityEvents.js
+++ b/src/lib/compiler/compileEntityEvents.js
@@ -84,6 +84,17 @@ const compileEntityEvents = (input = [], options = {}) => {
   if (!branch) {
     output.push(0); // End script
 
+    if (output.length > 16383) {
+      warnings(
+        `This script is too big for 1 bank, was ${output.length} bytes, must be under 16384.
+        ${JSON.stringify( location )}
+        `
+      );
+      warnings(
+        'Try splitting this script across multiple actors with *Actor invoke*.'
+      );
+    }
+
     for (let oi = 0; oi < output.length; oi++) {
       if (typeof output[oi] === "string" || output[oi] < 0) {
         const intCmd = Number(output[oi]);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Bug fix for invoke actor, similar to the last invoke actor fix.

* **What is the current behavior?** (You can also link to an open issue here)
#369  Invoke actor will cause a crash on return if the actor scripts are in different script banks.
Rare bug, only dealing with large scripts that happen to be in different banks.

* **What is the new behavior (if this is a feature change)?**
 May be slightly slower for invoke actor events, but will fix a game crash that is not easy to work around. the demo in #369 will work now.

* **Does this PR introduce a breaking change?**
Scripts that call actor invoke frequently in a loop may notice more lag, but it's already pretty slow, label define and label go to will likely be faster if you don't run out of space for a single script. 

* **Other information**:
https://discordapp.com/channels/554713715442712616/570925559346102273/662789686598565888
https://discordapp.com/channels/554713715442712616/575070105919029295/662798184996667405
A check / warning for scripts that are too large and spill into another bank would help, as it creates a similar issue.