### PR TITLE
Fix for #368. Strip invalid filename characters when creating project

### DIFF
--- a/src/lib/helpers/stripInvalidFilenameCharacters.js
+++ b/src/lib/helpers/stripInvalidFilenameCharacters.js
@@ -1,4 +1,4 @@
 const stripInvalidFilenameCharacters = string =>
-  string.replace(/[:/\\?*|"><]/g, "");
+  string.replace(/[:/\\?*|"><[\]#%&{}\b\0$!'@‘`“+^]/g, "");
 
 export default stripInvalidFilenameCharacters;

--- a/test/helpers/stripInvalidFilenameCharacters.test.js
+++ b/test/helpers/stripInvalidFilenameCharacters.test.js
@@ -1,0 +1,16 @@
+import stripInvalidFilenameCharacters from "../../src/lib/helpers/stripInvalidFilenameCharacters";
+
+test("should allow valid filenames", () => {
+  const filename = "ValidFilename";
+  expect(stripInvalidFilenameCharacters(filename)).toBe(filename);
+});
+
+test("should remove square brackets from filename", () => {
+  const filename = "Invalid[]Filename";
+  expect(stripInvalidFilenameCharacters(filename)).toBe("InvalidFilename");
+});
+
+test("should strip all invalid characters from filename", () => {
+  const filename = ":/\\?*|\"><[]#%&{}\b\0$!'@‘`“+^";
+  expect(stripInvalidFilenameCharacters(filename)).toBe("");
+});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix adding additional checks in `stripInvalidFilenameCharacters` helper preventing broken profile filenames being created on Windows (seen in #368)

* **What is the current behavior?** (You can also link to an open issue here)
The characters `[` and `]` as well as a few others that are invalid are allowed in project file names causing GB Studio to try to create a project with an invalid filename on Windows

* **What is the new behavior (if this is a feature change)?**
Additional characters have been added to the `stripInvalidFilenameCharacters` function preventing them from being used when creating the project.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No