### PR TITLE
Draw text buffer immediatly on menu dialogue

### DIFF
--- a/appData/src/gb/src/UI.c
+++ b/appData/src/gb/src/UI.c
@@ -29,7 +29,6 @@ UBYTE text_out_speed = 1;
 UBYTE text_draw_speed = 1;
 UBYTE tmp_text_in_speed = 1;
 UBYTE tmp_text_out_speed = 1;
-UBYTE tmp_text_draw_speed = 1;
 UBYTE text_num_lines = 0;
 
 UBYTE avatar_enabled = 0;
@@ -233,8 +232,6 @@ void UIShowMenu(UWORD flag_index, UWORD line, UBYTE layout, UBYTE cancel_config)
   menu_cancel_on_last_option = cancel_config & MENU_CANCEL_ON_LAST_OPTION;
   menu_cancel_on_b = cancel_config & MENU_CANCEL_ON_B_PRESSED;
   menu_layout = layout;
-  tmp_text_draw_speed = text_draw_speed;
-  text_draw_speed = 0;
   UIShowText(line);
   menu_num_options = tmp_text_lines[0];
   UIDrawMenuCursor();
@@ -335,7 +332,7 @@ void UIDrawTextBufferChar()
       text_y++;
     }
 
-    if (text_draw_speed == 0)
+    if (text_draw_speed == 0 || menu_enabled)
     {
       UIDrawTextBufferChar();
     }
@@ -343,9 +340,6 @@ void UIDrawTextBufferChar()
   else
   {
     text_drawn = TRUE;
-    // restore the user selected text draw speed as it 
-    // might have been override in UIShowMenu
-    text_draw_speed = tmp_text_draw_speed; 
   }
 }
 


### PR DESCRIPTION
Fixes a bug reported [on discord](https://discordapp.com/channels/554713715442712616/570925559346102273/669025434494828548) where the text speed is only respected on the first text event but to normal speed after. This bug was introduced with the fix for #361. 

To reproduce the bug run talk with the actor in this project using 1.2.1 [text_speed.zip](https://github.com/chrismaltby/gb-studio/files/4092084/text_speed.zip).

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Simplifies the code that makes Menu and Choice Events to render text immediately. 

* **What is the current behavior?** (You can also link to an open issue here)

Previously the text speed was hardcoded to zero for menus, the previous speed was stored in a temporary variable and, once the text was rendered, restored to that value.

* **What is the new behavior (if this is a feature change)?**

Text buffer is immediately rendered if what's being displayed is a menu, without changing the selected text speed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
