### PR TITLE
Custom Events 2

### DIFF
--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -185,5 +185,7 @@ void Script_PalSetSprite_b();
 void Script_PalSetUI_b();
 void Script_ActorStopUpdate_b();
 void Script_ActorSetAnimate_b();
+void Script_CustomScriptInvoke_b();
+void Script_ActorActivateVar_b();
 
 #endif

--- a/appData/src/gb/include/data_ptrs.h
+++ b/appData/src/gb/include/data_ptrs.h
@@ -33,6 +33,7 @@ extern const BankPtr sprite_bank_ptrs[];
 extern const BankPtr scene_bank_ptrs[];
 extern const BankPtr collision_bank_ptrs[];
 extern const BankPtr avatar_bank_ptrs[];
+extern const BankPtr custom_events_bank_ptrs[];
 extern const unsigned int bank_data_ptrs[];
 extern const unsigned int music_tracks[];
 extern const unsigned char music_banks[];

--- a/src/components/editors/CustomEventEditor.js
+++ b/src/components/editors/CustomEventEditor.js
@@ -124,7 +124,7 @@ class CustomEventEditor extends Component {
               return (
                 <FormField key={variable.id}>
                   <input
-                    id={`variable[${i}]`}
+                    id={`__parameter_V${variable.id}`}
                     value={variable.name}
                     placeholder="Variable Name"
                     onChange={this.onEditVariableName(variable.id)}
@@ -141,7 +141,7 @@ class CustomEventEditor extends Component {
               return (
                 <FormField key={actor.id}>
                   <input
-                    id={`actor[${i}]`}
+                    id={`__parameter_A${actor.id}`}
                     value={actor.name}
                     placeholder="Actor Name"
                     onChange={this.onEditActorName(actor.id)}

--- a/src/components/forms/CustomEventVariableSelect.js
+++ b/src/components/forms/CustomEventVariableSelect.js
@@ -6,25 +6,26 @@ import { VariableShape } from "../../reducers/stateShape";
 
 const menuPortalEl = document.getElementById("MenuPortal");
 
-const allVariables = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+const allVariables = ["V0", "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9"];
 
 class CustomEventVariableSelect extends Component {
-  variableName = index => {
+  variableName = variable => {
     const { variables } = this.props;
+    const index = allVariables.findIndex(v => v === variable);
     const letter = String.fromCharCode("A".charCodeAt(0) + parseInt(index, 10));
     return variables[index] ? variables[index].name : `Variable ${letter}`;
   };
 
-  variableLabel = index => {
-    return `$V${index}$ : ${this.variableName(index)}`;
+  variableLabel = variable => {
+    return `$${variable}$ : ${this.variableName(variable)}`;
   };
 
   render() {
     const { id, value, onChange } = this.props;
     const options = allVariables.map((variable, index) => {
       return {
-        value: String(index),
-        label: this.variableLabel(index)
+        value: variable,
+        label: this.variableLabel(variable, index)
       };
     });
     let val = options.find((o) => o.value === value) || options[0];
@@ -53,7 +54,7 @@ CustomEventVariableSelect.propTypes = {
 
 CustomEventVariableSelect.defaultProps = {
   id: undefined,
-  value: "0"
+  value: "V0"
 };
 
 function mapStateToProps(state) {

--- a/src/components/script/AddCommandButton.js
+++ b/src/components/script/AddCommandButton.js
@@ -168,9 +168,6 @@ class AddCommandButton extends Component {
             customEventId: customEvent.id,
             __name: customEventName
           },
-          children: {
-            script: customEvent.script
-          },
           name,
           searchName,
           key: `EVENT_CALL_CUSTOM_EVENT_${index}`

--- a/src/components/script/ScriptEventForm.js
+++ b/src/components/script/ScriptEventForm.js
@@ -35,7 +35,7 @@ class ScriptEventForm extends Component {
           return {
             label: `${v.name}`,
             defaultValue: "LAST_VARIABLE",
-            key: `$variable[${v.id}]$`,
+            key: `__parameter_V${v.id}`,
             type: "variable"
           };
         }) || [];
@@ -44,7 +44,7 @@ class ScriptEventForm extends Component {
           return {
             label: `${a.name}`,
             defaultValue: "player",
-            key: `$actor[${a.id}]$`,
+            key: `__parameter_A${a.id}`,
             type: "actor"
           };
         }) || [];

--- a/src/lib/compiler/compileEntityEvents.js
+++ b/src/lib/compiler/compileEntityEvents.js
@@ -48,7 +48,10 @@ const compileEntityEvents = (input = [], options = {}) => {
     },
     entityType === "trigger" && {
       actor: entity.name || `Trigger ${entityIndex + 1}`,
-    }
+    },
+    entityType === "customEvent" && {
+      customEvent: entity.name || `Event ${entityIndex + 1}`
+    },
   );
 
   const scriptBuilder = new ScriptBuilder(output, helpers);

--- a/src/lib/compiler/helpers.js
+++ b/src/lib/compiler/helpers.js
@@ -153,11 +153,11 @@ export const isMBC1 = (cartType) => cartType === "03" || cartType === "02";
 
 export const replaceInvalidCustomEventVariables = (variable) => {
   const getValidVariableIndex = (v) => {
-    const variableIndex = parseInt(String(v).replace(/^L|^T/, ""), 10);
+    const variableIndex = parseInt(String(v).replace(/^L|^T|^V/, ""), 10);
     if (variableIndex >= 10 || isNaN(variableIndex)) {
-      return "0";
+      return "V0";
     }
-    return String(variableIndex);  
+    return `V${variableIndex}`;
   }
 
   // Support the case for "union" values

--- a/src/lib/events/eventCallCustomEvent.js
+++ b/src/lib/events/eventCallCustomEvent.js
@@ -1,15 +1,6 @@
-const walkEvents = require("../helpers/eventSystem").walkEvents;
-const compileEntityEvents = require("../compiler/compileEntityEvents").default;
-
 const id = "EVENT_CALL_CUSTOM_EVENT";
 
 const fields = [
-  {
-    type: "events",
-    key: "script",
-    hide: true,
-    defaultValue: []
-  },
   {
     type: "text",
     hide: true,
@@ -18,34 +9,27 @@ const fields = [
 ];
 
 const compile = (input, helpers) => {
-  const { isVariableField } = helpers;
-  const script = JSON.parse(JSON.stringify(input.script));
-  walkEvents(script, e => {
-    if (!e.args) return;
+  const { customEventInvoke, variableCopy, variableSetToValue, scene } = helpers;
 
-    if (e.args.actorId && e.args.actorId !== "player") {
-      e.args.actorId = input[`$actor[${e.args.actorId}]$`] || "$self$";
-    }
-    if (e.args.otherActorId && e.args.otherActorId !== "player") {
-      e.args.otherActorId = input[`$actor[${e.args.otherActorId}]$`] || "$self$";
+  for (let i = 0; i < 10; i++) {
+    if (input[`__parameter_V${i}`]) {
+      variableCopy(`${input.customEventId}__V${i}`, input[`__parameter_V${i}`]);
     }
 
-    Object.keys(e.args).forEach((arg) => {
-      const argValue = e.args[arg];
-      if (isVariableField(e.command, arg, argValue)) {
-        if (argValue !== null && argValue.type === "variable") {
-          e.args[arg] = {
-            ...argValue,
-            value: input[`$variable[${argValue.value}]$`]
-          }
-        } else {
-          e.args[arg] = input[`$variable[${argValue}]$`];
-        }
-      }
-    });
-  });
+    if (input[`__parameter_A${i}`]) {
+      const actorId = (input[`__parameter_A${i}`] === '$self$') ? helpers.entity.id : input[`__parameter_A${i}`];
+      const actorIndex = scene.actors.findIndex(a => actorId === a.id) + 1;
+      variableSetToValue(`${input.customEventId}__A${i}`, actorIndex);
+    }
+  }
+    
+  customEventInvoke(input.customEventId, input.__name);
 
-  compileEntityEvents(script, { ...helpers, branch: true });
+  for (let i = 0; i < 9; i++) {
+    if (input[`__parameter_V${i}`]) {
+      variableCopy(input[`__parameter_V${i}`], `${input.customEventId}__V${i}`);
+    }
+  }
 };
 
 module.exports = {

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -103,6 +103,8 @@ export const PALETTE_SET_ACTOR = "PALETTE_SET_ACTOR";
 export const PALETTE_SET_UI = "PALETTE_SET_UI";
 export const ACTOR_STOP_UPDATE = "ACTOR_STOP_UPDATE";
 export const ACTOR_SET_ANIMATE = "ACTOR_SET_ANIMATE";
+export const CUSTOM_EVENT_INVOKE = "CUSTOM_EVENT_INVOKE";
+export const ACTOR_SET_ACTIVE_VAR = "ACTOR_SET_ACTIVE_VAR";
 
 export const scriptCommands = [
   END,
@@ -209,7 +211,9 @@ export const scriptCommands = [
   PALETTE_SET_ACTOR,
   PALETTE_SET_UI,
   ACTOR_STOP_UPDATE,
-  ACTOR_SET_ANIMATE
+  ACTOR_SET_ANIMATE,
+  CUSTOM_EVENT_INVOKE,
+  ACTOR_SET_ACTIVE_VAR
 ];
 
 export const commandIndex = key => {

--- a/src/reducers/entitiesReducer.js
+++ b/src/reducers/entitiesReducer.js
@@ -785,20 +785,35 @@ const updateEntitiesCustomEventScript = (state, type, id, entities, patch) => {
   const usedActors = Object.keys(actors).map((i) => `__parameter_A${i}`); 
   
   const patchCustomEventScript = event => {
-    if (event.command !== EVENT_CALL_CUSTOM_EVENT) {
+    if (event.command !== EVENT_CALL_CUSTOM_EVENT ||
+      event.args.customEventId !== id) {
       return event;
     }
-    if (event.args.customEventId !== id) {
-      return event;
-    }
-    const newArgs = {...event.args};
+    const newArgs = {
+      ...event.args,
+    };
+
+    usedVariables.forEach((v) => {
+      // If the variable already exists in the arguments
+      // use the existing value
+      newArgs[v] = event.args[v] || 0;
+    });
+
+    usedActors.forEach((a) => {
+      // If the actor already exists in the arguments
+      // use the existing value
+      newArgs[a] = event.args[a] || "player"
+    });
+
     Object.keys(newArgs).forEach((k) => {
+      // If the argument isn't used, delete it
       if (k.startsWith("__parameter_") &&
         !usedVariables.find((v) => v === k) &&
         !usedActors.find((a) => a === k)) {
         delete newArgs[k];
       }
     });
+
     return {
       ...event,
       args: newArgs

--- a/test/data/compiler/compileData.test.js
+++ b/test/data/compiler/compileData.test.js
@@ -9,7 +9,8 @@ import {
   EVENT_TEXT,
   EVENT_IF_TRUE,
   EVENT_SET_TRUE,
-  EVENT_END
+  EVENT_END,
+  EVENT_CALL_CUSTOM_EVENT
 } from "../../../src/lib/compiler/eventTypes";
 
 test("should compile simple project into files object", async () => {
@@ -82,8 +83,24 @@ test("should compile simple project into files object", async () => {
                 args: {
                   text: "TRIGGER TEST"
                 }
+              },
+              {
+                command: EVENT_CALL_CUSTOM_EVENT,
+                args: {
+                  customEventId: "CE1",
+                  __name: "Test"
+                }
               }
             ]
+          }
+        ],
+        script: [
+          {
+            command: EVENT_CALL_CUSTOM_EVENT,
+            args: {
+              customEventId: "CE1",
+              __name: "Test"
+            }
           }
         ]
       },
@@ -262,7 +279,16 @@ test("should compile simple project into files object", async () => {
         filename: "sprite_3.png"
       }
     ],
-    music: []
+    music: [],
+    customEvents: [
+      {
+        id: "CE1",
+        variables: {},
+        actors: {},
+        name: "Test",
+        description: "Test"
+      }
+    ]  
   };
   const compiled = await compile(project, {
     projectRoot: `${__dirname}/_files`

--- a/test/migrate/migrate120To200.test.js
+++ b/test/migrate/migrate120To200.test.js
@@ -1,4 +1,4 @@
-import { migrateFrom120To200Collisions, migrateFrom120To200Event, migrateFrom120To200Actors } from "../../src/lib/project/migrateProject";
+import { migrateFrom120To200CustomEvents, migrateFrom120To200Collisions, migrateFrom120To200Event, migrateFrom120To200Actors } from "../../src/lib/project/migrateProject";
 
 test("should migrate collisions from 1.2.0 to 2.0.0", () => {
   const oldProject = {
@@ -362,3 +362,285 @@ test("should migrate player set sprite with persist=true to match old default", 
     }    
   })
 })
+
+test("should migrate custom events from 1.2.0 to 2.0.0", () => {
+  const oldProject = {
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_CALL_CUSTOM_EVENT",
+            args: {
+              customEventId: "CE1",
+              __name: "Custom Event 1",
+              "$variable[0]$": "1",
+              "$variable[1]$": "4",
+              "$variable[2]$": "6",
+              "$variable[3]$": "13",
+              "$variable[4]$": "8",
+              "$variable[5]$": "123",
+              "$variable[6]$": "L1",
+              "$variable[7]$": "123",
+              "$variable[8]$": "L3",
+              "$variable[9]$": "234",
+              "$actor[0]$": "actor_1",
+              "$actor[1]$": "actor_12",
+              "$actor[2]$": "actor_21",
+              "$actor[3]$": "actor_21",
+              "$actor[4]$": "actor_24",
+              "$actor[5]$": "actor_1",
+              "$actor[6]$": "actor_22",
+              "$actor[7]$": "$self$",
+              "$actor[8]$": "actor_42",
+              "$actor[9]$": "actor_12"
+            },
+            children: {
+              script: [
+                {
+                  id: 1000
+                }
+              ]
+            }
+          },
+        ]
+      }
+    ],
+    customEvents: [
+      {
+        id: "CE1",
+        variables: {
+          "0": {
+              id: "0",
+              name: "Initial Time"
+          },
+          "1": {
+              id: "1",
+              name: "Frame Helper"
+          }
+        },
+        actors: {
+            "0": {
+                id: "0",
+                name: "Actor Tens"
+            },
+            "1": {
+                id: "1",
+                name: "Actor Unit"
+            }
+        },
+        script: [
+          {
+            id: "S0",
+            command: "command_0"
+          },
+          {
+            id: "S1",
+            command: "command_1",
+            args: {
+              foo: "bar",
+              variable: "1"
+            },
+            children: {
+              true: [
+                {
+                  args: {
+                    vectorX: "2",
+                    vectorY: "3"
+                  }
+                },
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  };
+  const newProject = migrateFrom120To200CustomEvents(oldProject);
+  expect(newProject).toEqual(
+    {
+      scenes: [
+        {
+          actors: [],
+          triggers: [],
+          collisions: [],
+          playerHit1Script: [],
+          playerHit2Script: [],
+          playerHit3Script: [],
+          script: [
+            {
+              id: "abc",
+              command: "EVENT_CALL_CUSTOM_EVENT",
+              args: {
+                customEventId: "CE1",
+                __name: "Custom Event 1",
+                __parameter_A0: "actor_1",
+                __parameter_A1: "actor_12",
+                __parameter_A2: "actor_21",
+                __parameter_A3: "actor_21",
+                __parameter_A4: "actor_24",
+                __parameter_A5: "actor_1",
+                __parameter_A6: "actor_22",
+                __parameter_A7: "$self$",
+                __parameter_A8: "actor_42",
+                __parameter_A9: "actor_12",
+                __parameter_V0: "1",
+                __parameter_V1: "4",
+                __parameter_V2: "6",
+                __parameter_V3: "13",
+                __parameter_V4: "8",
+                __parameter_V5: "123",
+                __parameter_V6: "L1",
+                __parameter_V7: "123",
+                __parameter_V8: "L3",
+                __parameter_V9: "234"
+              },
+              children: {}
+            }
+          ],
+        }
+      ],
+      customEvents: [
+        {
+          id: "CE1",
+          variables: {
+            "0": {
+                id: "0",
+                name: "Initial Time"
+            },
+            "1": {
+                id: "1",
+                name: "Frame Helper"
+            }
+          },
+          actors: {
+              "0": {
+                  id: "0",
+                  name: "Actor Tens"
+              },
+              "1": {
+                  id: "1",
+                  name: "Actor Unit"
+              }
+          },
+          script: [
+            {
+              id: "S0",
+              command: "command_0"
+            },
+            {
+              id: "S1",
+              command: "command_1",
+              args: {
+                foo: "bar",
+                variable: "V1"
+              },
+              children: {
+                true: [
+                  {
+                    args: {
+                      vectorX: "V2",
+                      vectorY: "V3"
+                    }
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      ]    
+    }
+  );
+});
+
+test("should migrate custom events from 1.2.0 to 2.0.0 even if the called custom event doesn't exist", () => {
+  const oldProject = {
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_CALL_CUSTOM_EVENT",
+            args: {
+              customEventId: "CE1",
+              __name: "Custom Event 1",
+              "$variable[0]$": "1",
+              "$variable[1]$": "4",
+              "$variable[2]$": "6",
+              "$variable[3]$": "13",
+              "$variable[4]$": "8",
+              "$variable[5]$": "123",
+              "$variable[6]$": "L1",
+              "$variable[7]$": "123",
+              "$variable[8]$": "L3",
+              "$variable[9]$": "234",
+              "$actor[0]$": "actor_1",
+              "$actor[1]$": "actor_12",
+              "$actor[2]$": "actor_21",
+              "$actor[3]$": "actor_21",
+              "$actor[4]$": "actor_24",
+              "$actor[5]$": "actor_1",
+              "$actor[6]$": "actor_22",
+              "$actor[7]$": "$self$",
+              "$actor[8]$": "actor_42",
+              "$actor[9]$": "actor_12"
+            },
+            children: {
+              script: [
+                {
+                  id: 1000
+                }
+              ]
+            }
+          },
+        ]
+      }
+    ],
+    customEvents: []
+  };
+  const newProject = migrateFrom120To200CustomEvents(oldProject);
+  expect(newProject).toEqual(
+    {
+      scenes: [
+        {
+          actors: [],
+          triggers: [],
+          collisions: [],
+          playerHit1Script: [],
+          playerHit2Script: [],
+          playerHit3Script: [],
+          script: [
+            {
+              id: "abc",
+              command: "EVENT_GROUP",
+              args: {
+                __label: "Custom Event 1"
+              },
+              children: {
+                true: [
+                  {
+                    command: "EVENT_COMMENT",
+                    args: {
+                      text: "This Event Group was created during the migration to 2.0.0. It contains the script of a Custom Event that doesn't exist in this project anymore.",
+                      __collapse: true
+                    },
+                  },
+                  {
+                    id: 1000
+                  }
+                ]
+              }  
+            }
+          ],
+        }
+      ],
+      customEvents: []    
+    }
+  );
+});


### PR DESCRIPTION
Bringing Custom Events 2 to GB Studio 2

**TODO**

- [ ] **New in CE2** Compile error when `Set Actor Sprite` is used inside Custom Event
- [ ] **New in CE2** Wrong sprite used when `Item: Launch Projectile` or `Item: Attack` are used inside a Custom Event
- [ ] **New in CE2** Game crashes/glitch when `Text: Display Dialogue` with avatar is used inside Custom Event
- [ ] **New in CE2** `otherActorId` doesn't work as parameter
- [x] **Happens with CE1** invalid variable value when selecting `variable` from the `number|variable|property` dropdown (for example in `Variable: Set To Value`)
- [x] **Happens with CE1** Custom Events contained in Hit scripts aren't updated when Custom Event is updated
- [x] **Happens with CE1** `direction` doesn't work as parameter

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Invisible feature change that updates the Custom Events to use a single scripts rather than duplicate the script on each Event call.

* **What is the current behavior?** (You can also link to an open issue here)

The first version of Custom Events worked by duplicating the script
inside the Event on each of its instances. This meant that scripts
could grow too big without users even noticing.

* **What is the new behavior (if this is a feature change)?**

This update makes Custom Events single scripts in memory and each
call to them jumps the script execution to the memory position and
bank where the script is located. Before that, the parameter values
are copied into "local" variables. Once the script is executed the
local variable values are copied back to the parameter ones,

For actors, a new internal C script has been introduced that allows
to set the active actor from a variable value.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes. A migration script is included in the PR. It updates existing scripts, as the field names for the parameter on the `EVENT_CUSTOM_EVENT_CALL` Event have been updated.

It also tries to take care of some edge cases that happened due to copy and pasting EVENT_CUSTOM_EVENT_CALL events between projects without copying the called Custom Event. In 1.2.0 the game will run as expected using the `script` embedded in the Call event. But since that's not the case with Custom Events 2. The migration script transforms those EVENT_CUSTOM_EVENT_CALL evens into Event Groups containing the script and adding a comment trying to explain what happened. _maybe is a bit overkill for an edge case but I'm a bit concerned about breaking the migration script due to an unexpected edge case like this 😓_ 

Other than that the feature should be invisible to the users other than reducing the size of the project.

* **Other information**:

TODO:
- [ ] Further testing

This change also opens the door to Custom Events inside Custom Events. It still poses some implementation challenges (ie: for recursive Custom Events as it'll require a variable stack for parameters) but should be simpler to implement than with the old method.
