### PR TITLE
Add event If Actors Overlap 

### DIFF
--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -121,5 +121,6 @@ void Script_RemoveTimerScript_b();
 void Script_TextWithAvatar_b();
 void Script_TextMenu_b();
 void Script_ActorSetCollisions_b();
+void Script_IfActorsOverlap_b();
 
 #endif

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -116,7 +116,8 @@ SCRIPT_CMD script_cmds[] = {
     {Script_RemoveTimerScript_b, 0},  // 0x5A
     {Script_TextWithAvatar_b, 3},     // 0x5B
     {Script_TextMenu_b, 6},           // 0x5C
-    {Script_ActorSetCollisions_b, 1}  // 0x5D
+    {Script_ActorSetCollisions_b, 1}, // 0x5D
+    {Script_IfActorsOverlap_b, 4},    // 0x5E
 };
 
 UBYTE ScriptLastFnComplete();

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -1908,3 +1908,34 @@ void Script_TextWithAvatar_b()
   UIShowAvatar(script_cmd_args[2]);
   script_action_complete = FALSE;
 }
+
+/*
+ * Command: IfActorsOverlap
+ * ----------------------------
+ * Jump to new script pointer position if specified actors are overlapping.
+ *
+ *   arg0: Actor 1 index
+ *   arg1: Actor 2 index
+ *   arg2: High 8 bits for new pointer
+ *   arg3: Low 8 bits for new pointer
+ */
+void Script_IfActorsOverlap_b()
+{
+  #define OVERLAP_DIST    8
+  #define OVERLAP_DIST_2  (2*OVERLAP_DIST)
+
+  UBYTE actor1 = script_cmd_args[0];
+  UBYTE actor2 = script_cmd_args[1];
+
+  if ((actors[actor1].pos.x - actors[actor2].pos.x + OVERLAP_DIST) <= OVERLAP_DIST_2 &&
+      (actors[actor1].pos.y - actors[actor2].pos.y + OVERLAP_DIST) <= OVERLAP_DIST_2)
+  { // True path, jump to position specified by ptr
+    script_ptr = script_start_ptr + (script_cmd_args[2] * 256) + script_cmd_args[3];
+  }
+  else
+  { // False path, skip to next command
+    script_ptr += 1 + script_cmd_args_len;
+  }
+
+  script_continue = TRUE;
+}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -304,6 +304,7 @@
   "EVENT_MENU": "Text: Display Menu",
   "EVENT_ACTOR_COLLISIONS_ENABLE": "Actor: Collisions Enable",
   "EVENT_ACTOR_COLLISIONS_DISABLE": "Actor: Collisions Disable",
+  "EVENT_IF_ACTORS_OVERLAP": "If Actors Overlap",
 
   "// 10": "Menu -----------------------------------------------------",
 

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -67,6 +67,7 @@ import {
   IF_INPUT,
   IF_ACTOR_AT_POSITION,
   IF_ACTOR_DIRECTION,
+  IF_ACTORS_OVERLAP,
   IF_SAVED_DATA,
   AWAIT_INPUT,
   NEXT_FRAME,
@@ -726,6 +727,24 @@ class ScriptBuilder {
       output
     });
   };
+
+  ifActorsOverlap = (actor1, actor2, truePath = [], falsePath = []) => {
+    const output = this.output;
+    const { scene, entity } = this.options;
+    const index1 = actor1 === "$self$"
+      ? getActorIndex(entity.id, scene)
+      : getActorIndex(actor1, scene);
+    const index2 = actor2 === "$self$"
+      ? getActorIndex(entity.id, scene)
+      : getActorIndex(actor2, scene);
+    output.push(cmd(IF_ACTORS_OVERLAP));
+    output.push(index1);
+    output.push(index2);
+    compileConditional(truePath, falsePath, {
+      ...this.options,
+      output
+    });
+  }
 
   ifDataSaved = (truePath = [], falsePath = []) => {
     const output = this.output;

--- a/src/lib/events/eventIfActorsOverlap.js
+++ b/src/lib/events/eventIfActorsOverlap.js
@@ -1,0 +1,53 @@
+import l10n from "../helpers/l10n";
+
+export const id = "EVENT_IF_ACTORS_OVERLAP";
+
+export const fields = [
+  {
+    key: "actorId1",
+    type: "actor",
+    defaultValue: "player"
+  },
+  {
+    key: "actorId2",
+    type: "actor",
+    defaultValue: "player"
+  },
+  {
+    key: "true",
+    type: "events"
+  },
+  {
+    key: "__collapseElse",
+    label: l10n("FIELD_ELSE"),
+    type: "collapsable",
+    defaultValue: false,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ]
+  },
+  {
+    key: "false",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true
+      },
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ],
+    type: "events"
+  }
+];
+
+export const compile = (input, helpers) => {
+  const { ifActorsOverlap } = helpers;
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+  ifActorsOverlap(input.actorId1, input.actorId2, truePath, falsePath);
+};

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -92,6 +92,7 @@ export const TIMER_DISABLE = "TIMER_DISABLE";
 export const TEXT_WITH_AVATAR = "TEXT_WITH_AVATAR";
 export const MENU = "MENU";
 export const ACTOR_SET_COLLISIONS = "ACTOR_SET_COLLISIONS";
+export const IF_ACTORS_OVERLAP = "IF_ACTORS_OVERLAP";
 
 export const scriptCommands = [
   END,
@@ -187,7 +188,8 @@ export const scriptCommands = [
   TIMER_DISABLE,
   TEXT_WITH_AVATAR,
   MENU,
-  ACTOR_SET_COLLISIONS
+  ACTOR_SET_COLLISIONS,
+  IF_ACTORS_OVERLAP
 ];
 
 export const commandIndex = key => {


### PR DESCRIPTION
Add event called If Actors Overlap that tests if the two sprites are overlapping as rectangles.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature. It's an If event that takes two actors as inputs. It resolves as True if the two actors are partially or fully overlapping. 

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:

When combined with timer scripts this event can be used for projectiles in action/puzzle scenes.