### PR TITLE
Remove string_bank_ptrs array, instead inject string_ptrs directly into script arguments

### DIFF
--- a/appData/src/gb/include/UI.h
+++ b/appData/src/gb/include/UI.h
@@ -35,8 +35,8 @@ void UIDrawFrame(UBYTE x, UBYTE y, UBYTE width, UBYTE height);
 void UIDrawDialogueFrame(UBYTE h);
 void UIDrawText(char *str, UBYTE x, UBYTE y);
 void UIDrawTextBkg(char *str, UBYTE x, UBYTE y);
-void UIShowText(UWORD line);
-void UIShowChoice(UWORD flag_index, UWORD line);
+void UIShowText(UBYTE bank, UWORD bank_offset);
+void UIShowChoice(UWORD flag_index, UBYTE bank, UWORD bank_offset);
 void UISetTextBuffer(unsigned char *text);
 void UIDrawTextBuffer();
 void UISetPos(UBYTE x, UBYTE y);
@@ -47,7 +47,7 @@ UBYTE UIAtDest();
 void UISetColor(UBYTE color);
 void UISetTextSpeed(UBYTE in, UBYTE out);
 void UIShowAvatar(UBYTE avatar_index);
-void UIShowMenu(UWORD flag_index, UWORD line, UBYTE layout, UBYTE cancel_config);
+void UIShowMenu(UWORD flag_index, UBYTE bank, UWORD bank_offset, UBYTE layout, UBYTE cancel_config);
 void UIDrawMenuCursor();
 
 #endif

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -13,7 +13,7 @@ UWORD script_ptr = 0;
 UWORD script_ptr_x = 0;
 UWORD script_ptr_y = 0;
 UWORD script_start_ptr = 0;
-UBYTE script_cmd_args[6] = {0};
+UBYTE script_cmd_args[7] = {0};
 UBYTE script_cmd_args_len;
 SCRIPT_CMD_FN last_fn;
 

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -24,7 +24,7 @@ UWORD script_start_stack[STACK_SIZE] = {0};
 
 SCRIPT_CMD script_cmds[] = {
     {Script_End_b, 0},                // 0x00
-    {Script_Text_b, 2},               // 0x01
+    {Script_Text_b, 3},               // 0x01
     {Script_Goto_b, 2},               // 0x02
     {Script_IfFlag_b, 4},             // 0x03
     {Script_Noop_b, 0},               // 0x04
@@ -62,7 +62,7 @@ SCRIPT_CMD script_cmds[] = {
     {Script_SetFlagValue_b, 3},       // 0x24
     {Script_IfValue_b, 6},            // 0x25
     {Script_IfInput_b, 3},            // 0x26
-    {Script_Choice_b, 4},             // 0x27
+    {Script_Choice_b, 5},             // 0x27
     {Script_ActorPush_b, 1},          // 0x28
     {Script_IfActorPos_b, 4},         // 0x29
     {Script_LoadData_b, 0},           // 0x2A
@@ -114,8 +114,8 @@ SCRIPT_CMD script_cmds[] = {
     {Script_SetTimerScript_b, 4},     // 0x58
     {Script_ResetTimer_b, 0},         // 0x59
     {Script_RemoveTimerScript_b, 0},  // 0x5A
-    {Script_TextWithAvatar_b, 3},     // 0x5B
-    {Script_TextMenu_b, 6},           // 0x5C
+    {Script_TextWithAvatar_b, 4},     // 0x5B
+    {Script_TextMenu_b, 7},           // 0x5C
     {Script_ActorSetCollisions_b, 1}  // 0x5D
 };
 

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -53,7 +53,7 @@ void Script_End_b()
 void Script_Text_b()
 {
   script_ptr += 1 + script_cmd_args_len;
-  UIShowText((script_cmd_args[0] * 256) + script_cmd_args[1]);
+  UIShowText(script_cmd_args[0], (script_cmd_args[1] * 256) + script_cmd_args[2]);
   script_action_complete = FALSE;
 }
 
@@ -655,7 +655,7 @@ void Script_IfInput_b()
 void Script_Choice_b()
 {
   script_ptr += 1 + script_cmd_args_len;
-  UIShowChoice((script_cmd_args[0] * 256) + script_cmd_args[1], (script_cmd_args[2] * 256) + script_cmd_args[3]);
+  UIShowChoice((script_cmd_args[0] * 256) + script_cmd_args[1], script_cmd_args[2], (script_cmd_args[3] * 256) + script_cmd_args[4]);
   script_action_complete = FALSE;
 }
 
@@ -667,7 +667,7 @@ void Script_Choice_b()
 void Script_TextMenu_b()
 {
   script_ptr += 1 + script_cmd_args_len;
-  UIShowMenu((script_cmd_args[0] * 256) + script_cmd_args[1], (script_cmd_args[2] * 256) + script_cmd_args[3], script_cmd_args[4], script_cmd_args[5]);
+  UIShowMenu((script_cmd_args[0] * 256) + script_cmd_args[1], script_cmd_args[2], (script_cmd_args[3] * 256) + script_cmd_args[4], script_cmd_args[5], script_cmd_args[6]);
   script_action_complete = FALSE;
 }
 
@@ -1904,7 +1904,7 @@ void Script_RemoveTimerScript_b()
 void Script_TextWithAvatar_b()
 {
   script_ptr += 1 + script_cmd_args_len;
-  UIShowText((script_cmd_args[0] * 256) + script_cmd_args[1]);
-  UIShowAvatar(script_cmd_args[2]);
+  UIShowText(script_cmd_args[0], (script_cmd_args[1] * 256) + script_cmd_args[2]);
+  UIShowAvatar(script_cmd_args[3]);
   script_action_complete = FALSE;
 }

--- a/appData/src/gb/src/UI.c
+++ b/appData/src/gb/src/UI.c
@@ -97,9 +97,8 @@ void UIDrawTextBkg(char *str, UBYTE x, UBYTE y)
   }
 }
 
-void UIShowText(UWORD line)
+void UIShowText(UBYTE bank, UWORD bank_offset)
 {
-  BANK_PTR bank_ptr;
   UWORD ptr, var_index;
   unsigned char value_string[6];
   UBYTE i, j, k;
@@ -107,10 +106,9 @@ void UIShowText(UWORD line)
 
   strcpy(tmp_text_lines, "");
 
-  ReadBankedBankPtr(DATA_PTRS_BANK, &bank_ptr, &string_bank_ptrs[line]);
-  ptr = ((UWORD)bank_data_ptrs[bank_ptr.bank]) + bank_ptr.offset;
+  ptr = ((UWORD)bank_data_ptrs[bank]) + bank_offset;
 
-  PUSH_BANK(bank_ptr.bank);
+  PUSH_BANK(bank);
   strcat(tmp_text_lines, ptr);
   POP_BANK;
 
@@ -219,12 +217,12 @@ void UIShowAvatar(UBYTE avatar_index)
   avatar_enabled = TRUE;
 }
 
-void UIShowChoice(UWORD flag_index, UWORD line)
+void UIShowChoice(UWORD flag_index, UBYTE bank, UWORD bank_offset)
 {
-  UIShowMenu(flag_index, line, 0, MENU_CANCEL_ON_B_PRESSED | MENU_CANCEL_ON_LAST_OPTION);
+  UIShowMenu(flag_index, bank, bank_offset, 0, MENU_CANCEL_ON_B_PRESSED | MENU_CANCEL_ON_LAST_OPTION);
 }
 
-void UIShowMenu(UWORD flag_index, UWORD line, UBYTE layout, UBYTE cancel_config)
+void UIShowMenu(UWORD flag_index, UBYTE bank, UWORD bank_offset, UBYTE layout, UBYTE cancel_config)
 {
   menu_index = 0;
   menu_flag = flag_index;
@@ -232,7 +230,7 @@ void UIShowMenu(UWORD flag_index, UWORD line, UBYTE layout, UBYTE cancel_config)
   menu_cancel_on_last_option = cancel_config & MENU_CANCEL_ON_LAST_OPTION;
   menu_cancel_on_b = cancel_config & MENU_CANCEL_ON_B_PRESSED;
   menu_layout = layout;
-  UIShowText(line);
+  UIShowText(bank, bank_offset);
   menu_num_options = tmp_text_lines[0];
   UIDrawMenuCursor();
 }

--- a/src/lib/compiler/bankedData.js
+++ b/src/lib/compiler/bankedData.js
@@ -134,6 +134,14 @@ class BankedData {
       bankNum => !!this.data[bankNum - this.bankOffset]
     );
   }
+
+  mutate(fn) {
+    for(let bank=0; bank<this.data.length; bank++) {
+      for(let offset=0; offset<this.data[bank].length; offset++) {
+        this.data[bank][offset] = fn(this.data[bank][offset]);
+      }
+    }
+  }
 }
 
 export default BankedData;

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -279,6 +279,28 @@ const compile = async (
     );
   });
 
+  // Replace ptrs in banked data
+  banked.mutate((data) => {
+    if(typeof data === "number") {
+      return data;
+    }
+    if(typeof data === "string" && data.startsWith("__REPLACE")) {
+      if(data.startsWith("__REPLACE:STRING_BANK:")) {
+        const index = parseInt(data.replace(/.*:/,''), 10);
+        return stringPtrs[index].bank;
+      }
+      if(data.startsWith("__REPLACE:STRING_HI:")) {
+        const index = parseInt(data.replace(/.*:/,''), 10);
+        return hi(stringPtrs[index].offset);
+      }
+      if(data.startsWith("__REPLACE:STRING_LO:")) {
+        const index = parseInt(data.replace(/.*:/,''), 10);
+        return lo(stringPtrs[index].offset);
+      }      
+    }
+    return 0;
+  })
+  
   let startSceneIndex = precompiled.sceneData.findIndex(
     m => m.id === projectData.settings.startSceneId
   );
@@ -314,7 +336,6 @@ const compile = async (
     background_bank_ptrs: fixEmptyDataPtrs(backgroundPtrs),
     sprite_bank_ptrs: fixEmptyDataPtrs(spritePtrs),
     scene_bank_ptrs: fixEmptyDataPtrs(scenePtrs),
-    string_bank_ptrs: fixEmptyDataPtrs(stringPtrs),
     avatar_bank_ptrs: fixEmptyDataPtrs(avatarPtrs)
   };
 

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -298,7 +298,12 @@ const compile = async (
         return lo(stringPtrs[index].offset);
       }      
     }
-    return 0;
+    const value = parseInt(data, 10);
+    if(!isNaN(value)) {
+      return value;
+    }
+    warnings(`Non numeric data found while processing banked data "${data}".`);
+    return data;
   })
   
   let startSceneIndex = precompiled.sceneData.findIndex(

--- a/src/lib/compiler/compileEntityEvents.js
+++ b/src/lib/compiler/compileEntityEvents.js
@@ -102,7 +102,7 @@ const compileEntityEvents = (input = [], options = {}) => {
           // If string was equivent to position integer then replace it
           // in output otherwise
           output[oi] = intCmd;
-        } else {
+        } else if(!(typeof output[oi] === "string" && output[oi].startsWith("__REPLACE:"))) {
           let reason = "";
           if (String(output[oi]).startsWith("goto:")) {
             reason = "Did you remember to define a label in the script?";

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -276,13 +276,15 @@ class ScriptBuilder {
     if (avatarId) {
       const avatarIndex = getSpriteIndex(avatarId, avatars);
       output.push(cmd(TEXT_WITH_AVATAR));
-      output.push(hi(stringIndex));
-      output.push(lo(stringIndex));
+      output.push(`__REPLACE:STRING_BANK:${stringIndex}`);
+      output.push(`__REPLACE:STRING_HI:${stringIndex}`);
+      output.push(`__REPLACE:STRING_LO:${stringIndex}`);
       output.push(avatarIndex);
     } else {
       output.push(cmd(TEXT));
-      output.push(hi(stringIndex));
-      output.push(lo(stringIndex));
+      output.push(`__REPLACE:STRING_BANK:${stringIndex}`);
+      output.push(`__REPLACE:STRING_HI:${stringIndex}`);
+      output.push(`__REPLACE:STRING_LO:${stringIndex}`);
     }
   };
 
@@ -300,8 +302,9 @@ class ScriptBuilder {
     output.push(cmd(CHOICE));
     output.push(hi(variableIndex));
     output.push(lo(variableIndex));
-    output.push(hi(stringIndex));
-    output.push(lo(stringIndex));
+    output.push(`__REPLACE:STRING_BANK:${stringIndex}`);
+    output.push(`__REPLACE:STRING_HI:${stringIndex}`);
+    output.push(`__REPLACE:STRING_LO:${stringIndex}`);
   };
 
   textMenu = (
@@ -326,8 +329,9 @@ class ScriptBuilder {
     output.push(cmd(MENU));
     output.push(hi(variableIndex));
     output.push(lo(variableIndex));
-    output.push(hi(stringIndex));
-    output.push(lo(stringIndex));
+    output.push(`__REPLACE:STRING_BANK:${stringIndex}`);
+    output.push(`__REPLACE:STRING_HI:${stringIndex}`);
+    output.push(`__REPLACE:STRING_LO:${stringIndex}`);
     output.push(layout === "menu" ? 1 : 0);
     output.push((cancelOnLastOption ? 1 : 0) | (cancelOnB ? 2 : 0));
   };

--- a/test/data/compiler/compileEntityEvents.test.js
+++ b/test/data/compiler/compileEntityEvents.test.js
@@ -129,7 +129,7 @@ test("should output text command", () => {
   ];
   const strings = ["HELLO WORLD"];
   const output = compileEntityEvents(input, { strings });
-  expect(output).toEqual([CMD_LOOKUP.TEXT, 0, 0, CMD_LOOKUP.END]);
+  expect(output).toEqual([CMD_LOOKUP.TEXT, "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0", CMD_LOOKUP.END]);
 });
 
 test("should output text command string pointers", () => {
@@ -155,11 +155,13 @@ test("should output text command string pointers", () => {
   const output = compileEntityEvents(input, { strings });
   expect(output).toEqual([
     CMD_LOOKUP.TEXT,
-    0,
-    10,
+    "__REPLACE:STRING_BANK:10",
+    "__REPLACE:STRING_HI:10",
+    "__REPLACE:STRING_LO:10",
     CMD_LOOKUP.TEXT,
-    1,
-    4,
+    "__REPLACE:STRING_BANK:260",
+    "__REPLACE:STRING_HI:260",
+    "__REPLACE:STRING_LO:260",
     CMD_LOOKUP.END
   ]);
 });
@@ -179,8 +181,9 @@ test("should output text with avatar command", () => {
   const output = compileEntityEvents(input, { strings, avatars });
   expect(output).toEqual([
     CMD_LOOKUP.TEXT_WITH_AVATAR,
-    0,
-    0,
+    "__REPLACE:STRING_BANK:0",
+    "__REPLACE:STRING_HI:0",
+    "__REPLACE:STRING_LO:0",
     0,
     CMD_LOOKUP.END
   ]);
@@ -212,12 +215,14 @@ test("should output text wit avatar command string pointers", () => {
   const output = compileEntityEvents(input, { strings, avatars });
   expect(output).toEqual([
     CMD_LOOKUP.TEXT_WITH_AVATAR,
-    0,
-    10,
+    "__REPLACE:STRING_BANK:10",
+    "__REPLACE:STRING_HI:10",
+    "__REPLACE:STRING_LO:10",
     0,
     CMD_LOOKUP.TEXT_WITH_AVATAR,
-    1,
-    4,
+    "__REPLACE:STRING_BANK:260",
+    "__REPLACE:STRING_HI:260",
+    "__REPLACE:STRING_LO:260",
     0,
     CMD_LOOKUP.END
   ]);
@@ -258,19 +263,21 @@ test("should allow conditional statements", () => {
     0, // 1 Variable ptr hi
     3, // 2 Variable ptr lo
     0, // 3 Jump ptr hi
-    11, // 4 Jump ptr lo
+    12, // 4 Jump ptr lo
     // False path
     CMD_LOOKUP.TEXT, // 5
-    0, // 6
-    2, // 7
-    CMD_LOOKUP.JUMP, // 8
-    0, // 9 Jump to end
-    14, // 10
+    "__REPLACE:STRING_BANK:2", // 6
+    "__REPLACE:STRING_HI:2", // 7
+    "__REPLACE:STRING_LO:2", // 8
+    CMD_LOOKUP.JUMP, // 9
+    0, // 10 Jump to end
+    16, // 11
     // True path
-    CMD_LOOKUP.TEXT, // 11
-    0, // 12
-    1, // 13
-    CMD_LOOKUP.END // 14
+    CMD_LOOKUP.TEXT, // 12
+    "__REPLACE:STRING_BANK:1", // 13
+    "__REPLACE:STRING_HI:1", // 14
+    "__REPLACE:STRING_LO:1", // 15
+    CMD_LOOKUP.END // 16
   ]);
 });
 
@@ -315,22 +322,25 @@ test("should allow commands after conditional", () => {
     0, // 1 Variable ptr hi
     3, // 2 Variable ptr lo
     0, // 3 Jump ptr hi
-    11, // 4 Jump ptr lo
+    12, // 4 Jump ptr lo
     // False path
     CMD_LOOKUP.TEXT, // 5
-    0, // 6
-    2, // 7
-    CMD_LOOKUP.JUMP, // 8
-    0, // 9 Jump to end
-    14, // 10
+    "__REPLACE:STRING_BANK:2", // 6
+    "__REPLACE:STRING_HI:2", // 7
+    "__REPLACE:STRING_LO:2", // 8
+    CMD_LOOKUP.JUMP, // 9
+    0, // 10 Jump to end
+    16, // 11
     // True path
-    CMD_LOOKUP.TEXT, // 11
-    0, // 12
-    1, // 13
-    CMD_LOOKUP.TEXT, // 14
-    0, // 15 After text hi ptr
-    3, // 16
-    CMD_LOOKUP.END // 17
+    CMD_LOOKUP.TEXT, // 12
+    "__REPLACE:STRING_BANK:1", // 13
+    "__REPLACE:STRING_HI:1", // 14
+    "__REPLACE:STRING_LO:1", // 15
+    CMD_LOOKUP.TEXT, // 16
+    "__REPLACE:STRING_BANK:3", // 17
+    "__REPLACE:STRING_HI:3", // 18
+    "__REPLACE:STRING_LO:3", // 19
+    CMD_LOOKUP.END // 20
   ]);
 });
 

--- a/test/data/compiler/scriptBuilder.test.js
+++ b/test/data/compiler/scriptBuilder.test.js
@@ -347,7 +347,7 @@ test("Should be able to display text", () => {
   const strings = ["First Text"];
   const sb = new ScriptBuilder(output, { strings });
   sb.textDialogue("First Text");
-  expect(output).toEqual([cmd(TEXT), 0, 0]);
+  expect(output).toEqual([cmd(TEXT), "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0"]);
   expect(strings).toEqual(["First Text"]);
 });
 
@@ -357,7 +357,7 @@ test("Should be able to add additional display text", () => {
   const sb = new ScriptBuilder(output, { strings });
   sb.textDialogue("First Text");
   sb.textDialogue("Second Text");
-  expect(output).toEqual([cmd(TEXT), 0, 0, cmd(TEXT), 0, 2]);
+  expect(output).toEqual([cmd(TEXT), "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0", cmd(TEXT), "__REPLACE:STRING_BANK:2", "__REPLACE:STRING_HI:2", "__REPLACE:STRING_LO:2"]);
   expect(strings).toEqual(["First Text", "Unused Text", "Second Text"]);
 });
 
@@ -366,7 +366,7 @@ test("Should default to empty display text", () => {
   const strings = [];
   const sb = new ScriptBuilder(output, { strings });
   sb.textDialogue();
-  expect(output).toEqual([cmd(TEXT), 0, 0]);
+  expect(output).toEqual([cmd(TEXT), "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0"]);
   expect(strings).toEqual([" "]);
 });
 
@@ -376,7 +376,7 @@ test("Should be able to display text with avatar", () => {
   const avatars = [{ id: "avatar-1" }, { id: "avatar-2" }];
   const sb = new ScriptBuilder(output, { strings, avatars });
   sb.textDialogue("First Text", "avatar-2");
-  expect(output).toEqual([cmd(TEXT_WITH_AVATAR), 0, 0, 1]);
+  expect(output).toEqual([cmd(TEXT_WITH_AVATAR), "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0", 1]);
   expect(strings).toEqual(["First Text"]);
 });
 
@@ -385,7 +385,7 @@ test("Should be able to display choice", () => {
   const strings = ["Hello World"];
   const sb = new ScriptBuilder(output, { variables: ["0", "1", "2"], strings });
   sb.textChoice("2", { trueText: "One", falseText: "Two" });
-  expect(output).toEqual([cmd(CHOICE), 0, 2, 0, 1]);
+  expect(output).toEqual([cmd(CHOICE), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1"]);
   expect(strings).toEqual(["Hello World", "One\nTwo"]);
 });
 
@@ -394,7 +394,7 @@ test("Should not store choice text multiple times", () => {
   const strings = ["One\nTwo"];
   const sb = new ScriptBuilder(output, { variables: ["0", "1", "2"], strings });
   sb.textChoice("2", { trueText: "One", falseText: "Two" });
-  expect(output).toEqual([cmd(CHOICE), 0, 2, 0, 0]);
+  expect(output).toEqual([cmd(CHOICE), 0, 2, "__REPLACE:STRING_BANK:0", "__REPLACE:STRING_HI:0", "__REPLACE:STRING_LO:0"]);
   expect(strings).toEqual(["One\nTwo"]);
 });
 
@@ -403,7 +403,7 @@ test("Should be able to display menu with default values", () => {
   const strings = ["Hello World"];
   const sb = new ScriptBuilder(output, { variables: ["0", "1", "2"], strings });
   sb.textMenu("2", [ "item1", "item2", "item3" ]);
-  expect(output).toEqual([cmd(MENU), 0, 2, 0, 1, 1, 0]);
+  expect(output).toEqual([cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 1, 0]);
   expect(strings).toEqual(["Hello World", "item1\nitem2\nitem3"]);
 });
 
@@ -431,15 +431,15 @@ test("Should be able to display menu with different config values", () => {
   sb.textMenu("2", [ "item1", "item2", "item3" ], "dialogue", true, true);
 
   expect(output).toEqual([
-    cmd(MENU), 0, 2, 0, 1, 1, 0,
-    cmd(MENU), 0, 2, 0, 1, 1, 1,
-    cmd(MENU), 0, 2, 0, 1, 1, 2,
-    cmd(MENU), 0, 2, 0, 1, 1, 3,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 1, 0,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 1, 1,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 1, 2,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 1, 3,
 
-    cmd(MENU), 0, 2, 0, 1, 0, 0,
-    cmd(MENU), 0, 2, 0, 1, 0, 1,
-    cmd(MENU), 0, 2, 0, 1, 0, 2,
-    cmd(MENU), 0, 2, 0, 1, 0, 3,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 0, 0,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 0, 1,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 0, 2,
+    cmd(MENU), 0, 2, "__REPLACE:STRING_BANK:1", "__REPLACE:STRING_HI:1", "__REPLACE:STRING_LO:1", 0, 3,
   ]);
   expect(strings).toEqual(["Hello World", "item1\nitem2\nitem3"]);
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for #404 where a project contained enough text to stop the `string_bank_ptrs` array from fitting within bank 5 causing an overflow.

* **What is the current behavior?** (You can also link to an open issue here)

Bank 5 contains an array of pointers to each string in memory. When displaying a string such is in a Display Dialogue event it is looked up by index in the array (16bit value) to find the bank it's stored in (8bit value) and it's offset in the bank (16bit value)

* **What is the new behavior (if this is a feature change)?**

The `string_bank_ptrs` array has been removed entirely and instead every time a string is needed the bank and offset is stored directly within the event.

So where previously a text command contained the following:
```CMD_TEXT, index_hi, index_lo```
where index_hi and index_lo were 8bit values used to construct the 16bit string index which would in turn be used to look up the string bank and offset

It will now contain
```CMD_TEXT, string_bank, string_offset_hi, string_offset_lo```

This adds an extra byte to every text command but greatly increases the amount of text that can be used in game as it no longer fills bank5 with each string added.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Hopefully not, from my testing it seems to work correctly and the project that was failing now compiles as expected.
