### PR TITLE
Configurable cart size

### DIFF
--- a/appData/src/gb/Makefile
+++ b/appData/src/gb/Makefile
@@ -5,7 +5,7 @@ ROM_BUILD_DIR = build/rom
 OBJ_DIR = obj
 SOURCE_DIR = src
 
-CFLAGS = -Wl-yo64 -Wl-ya4 -Wl-yp0x143=0x80
+CFLAGS = -Wl-yo$(CART_SIZE) -Wl-ya4 -Wl-yp0x143=0x80
 
 SOURCES := $(shell find -L $(SOURCE_DIR) -name '*.c')
 SOURCES_ASM := $(shell find -L $(SOURCE_DIR) -name '*.s')

--- a/src/lib/compiler/buildMakeBat.js
+++ b/src/lib/compiler/buildMakeBat.js
@@ -1,14 +1,14 @@
 import fs from "fs-extra";
 import Path from "path";
 
-export default async (buildRoot, { CART_TYPE, customColorsEnabled, gbcFastCPUEnabled }) => {
+export default async (buildRoot, { CART_TYPE, CART_SIZE, customColorsEnabled, gbcFastCPUEnabled }) => {
   const cmds = ['set __COMPAT_LAYER=WIN7RTM'];
   const buildFiles = [];
   const objFiles = [];
   let musicFiles = [];
 
   const CC = `..\\_gbs\\gbdk\\bin\\lcc -Wa-l -Wl-m -Wl-j -Wl-yt${CART_TYPE} -Iinclude`;
-  const CFLAGS = `-DUSE_SFR_FOR_REG -Wl-yo64 -Wl-ya4`;
+  const CFLAGS = `-DUSE_SFR_FOR_REG -Wl-yo${CART_SIZE} -Wl-ya4`;
   const CGBFLAGS = `-Wl-yp0x143=0x80`;
 
   const srcRoot = `${buildRoot}/src`;

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -93,6 +93,7 @@ const makeBuild = ({
     env.GBDKDIR = `${tmpBuildToolsPath}/gbdk/`;
 
     env.CART_TYPE = parseInt(settings.cartType || "1B", 16);
+    env.CART_SIZE = settings.cartSize || 64;
     env.TMP = getTmp();
     env.TEMP = getTmp();
     
@@ -126,6 +127,7 @@ const makeBuild = ({
 
     const makeBat = await buildMakeBat(buildRoot, {
       CART_TYPE: env.CART_TYPE,
+      CART_SIZE: env.CART_SIZE,
       customColorsEnabled: settings.customColorsEnabled,
       gbcFastCPUEnabled: settings.gbcFastCPUEnabled
     });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature. Makes the `-Wl-yo` flag that controls the cart size in the makefile configurable via settings. 

* **What is the current behavior?** (You can also link to an open issue here)

Cart size flag is fixed to `64`

* **What is the new behavior (if this is a feature change)?**

Cart size defaults to `64` but can be updated by manually adding `"cartSize": XX` to the `settings` section of the project `gbsproj` file. XX has to be a power of 4.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. The default cart size value is still 64.
