### PR TITLE
Music Bank Dynamic Allocation Feature/Bugfix

### DIFF
--- a/src/lib/compiler/buildProject.js
+++ b/src/lib/compiler/buildProject.js
@@ -31,6 +31,7 @@ const buildProject = async (
   });
   await compileMusic({
     music: compiledData.music,
+    musicBanks: compiledData.musicBanks,
     projectRoot,
     buildRoot: outputRoot,
     progress,
@@ -40,7 +41,7 @@ const buildProject = async (
   compiledData.music.forEach(track => {
     trackMaxBank = Math.max(track.bank,trackMaxBank)
   });
-  console.log(trackMaxBank); //You need this to auto expand the rom
+  console.log('The last bank with music data is ' + trackMaxBank); // for cartSize, 0 if no music...
   await makeBuild({
     buildRoot: outputRoot,
     buildType,

--- a/src/lib/compiler/buildProject.js
+++ b/src/lib/compiler/buildProject.js
@@ -36,6 +36,11 @@ const buildProject = async (
     progress,
     warnings
   });
+  var trackMaxBank = 0;
+  compiledData.music.forEach(track => {
+    trackMaxBank = Math.max(track.bank,trackMaxBank)
+  });
+  console.log(trackMaxBank); //You need this to auto expand the rom
   await makeBuild({
     buildRoot: outputRoot,
     buildType,

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -43,7 +43,7 @@ import { assetFilename } from "../helpers/gbstudio";
 const indexById = indexBy("id");
 
 const DATA_PTRS_BANK = 5;
-const NUM_MUSIC_BANKS = 8;
+const NUM_MUSIC_BANKS = 1;//Auto expands, needed to calculate first music bank.
 
 export const EVENT_START_DATA_COMPILE = "EVENT_START_DATA_COMPILE";
 export const EVENT_DATA_COMPILE_PROGRESS = "EVENT_DATA_COMPILE_PROGRESS";
@@ -435,9 +435,8 @@ const compile = async (
       .map(track => `${track.dataName}_Data`)
       .join(", ") || "0"}, 0` +
     `\n};\n\n` +
-    `const unsigned char music_banks[] = {\n${music
-      .map(track => track.bank)
-      .join(", ") || "0"}, 0` +
+    `const unsigned char music_banks[] = {\n` +
+      //${music.map(track => track.bank).join(", ") || "0"}, 0` + // Replaced in CompileMusic.js
     `\n};\n\n` +
     `unsigned char script_variables[${precompiled.variables.length +
       1}] = { 0 };\n`;
@@ -817,7 +816,7 @@ export const precompileMusic = (scenes, music) => {
     .map((track, index) => {
       return {
         ...track,
-        dataName: `music_${uuid().replace(/-.*/, "")}${index}`
+        dataName: (`music_track_`+ (index + 101) + '_')//`music_${uuid().replace(/-.*/, "")}${index}`
       };
     });
   return { usedMusic };

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1,5 +1,4 @@
 import { copy } from "fs-extra";
-import uuid from "uuid/v4";
 import BankedData, {
   MIN_DATA_BANK,
   GB_MAX_BANK_SIZE,
@@ -43,7 +42,7 @@ import { assetFilename } from "../helpers/gbstudio";
 const indexById = indexBy("id");
 
 const DATA_PTRS_BANK = 5;
-const NUM_MUSIC_BANKS = 1;//Auto expands, needed to calculate first music bank.
+const NUM_MUSIC_BANKS = 30; // To calculate usable banks if MBC1
 
 export const EVENT_START_DATA_COMPILE = "EVENT_START_DATA_COMPILE";
 export const EVENT_DATA_COMPILE_PROGRESS = "EVENT_DATA_COMPILE_PROGRESS";
@@ -436,7 +435,6 @@ const compile = async (
       .join(", ") || "0"}, 0` +
     `\n};\n\n` +
     `const unsigned char music_banks[] = {\n` +
-      //${music.map(track => track.bank).join(", ") || "0"}, 0` + // Replaced in CompileMusic.js
     `\n};\n\n` +
     `unsigned char script_variables[${precompiled.variables.length +
       1}] = { 0 };\n`;
@@ -450,7 +448,8 @@ const compile = async (
 
   return {
     files: output,
-    music
+    music,
+    musicBanks
   };
 };
 
@@ -816,7 +815,7 @@ export const precompileMusic = (scenes, music) => {
     .map((track, index) => {
       return {
         ...track,
-        dataName: (`music_track_`+ (index + 101) + '_')//`music_${uuid().replace(/-.*/, "")}${index}`
+        dataName: (`music_track_`+ (index + 101) + '_')
       };
     });
   return { usedMusic };

--- a/src/lib/compiler/compileMusic.js
+++ b/src/lib/compiler/compileMusic.js
@@ -15,6 +15,8 @@ const compileMusic = async ({
   warnings = () => {}
 } = {}) => {
   const buildToolsPath = await ensureBuildTools();
+  var banksize = [];
+  const musicBanksStart = music[0].bank-1;
 
   for (let i = 0; i < music.length; i++) {
     const track = music[i];
@@ -25,7 +27,37 @@ const compileMusic = async ({
       progress,
       warnings
     });
+    // Modify Music_Track_x.c to improve bank allocation
+    // TODO Recursive bank allocation.
+    let musicTrackTemp = await fs.readFile(`${buildRoot}/src/music/${track.dataName}.c`, "utf8");
+
+    // Approximate data size by dividing file lenth, over estimates, better than underestimate.
+    var musicSize = Math.floor(musicTrackTemp.length/5.5);
+    progress(track.dataName + ' aprox size in bytes: ' + musicSize);
+
+    if (musicSize + banksize[banksize.length-1] < 16384) {
+      // fill bank, replaces bank=8 with current bank
+      banksize[banksize.length-1] = (banksize[banksize.length-1] + musicSize);
+      musicTrackTemp = musicTrackTemp.replace('#pragma bank=8', '#pragma bank='+ (musicBanksStart+banksize.length));
+    } else {
+      // new bank, replaces bank=8 with current bank
+      banksize.push(musicSize);
+      musicTrackTemp = musicTrackTemp.replace('#pragma bank=8', '#pragma bank='+ (musicBanksStart+banksize.length));
+    }
+    progress('Put ' + track.dataName + ' in bank '+ (musicBanksStart+banksize.length));
+    music[i].bank = (musicBanksStart+banksize.length);
+    await fs.writeFile(`${buildRoot}/src/music/${track.dataName}.c`, musicTrackTemp, "utf8");
   }
+
+  // Modify data_ptrs for new music banks
+  let dataptrTemp = await fs.readFile(`${buildRoot}/src/data/data_ptrs.c`, "utf8");
+  dataptrTemp = dataptrTemp.replace(`const unsigned char music_banks[] = {\n`, 
+    `const unsigned char music_banks[] = {\n${music.map(track => track.bank).join(", ") || "0"}, 0`);
+  await fs.writeFile(`${buildRoot}/src/data/data_ptrs.c`, dataptrTemp, "utf8");
+  // Great for debugging build errors
+  progress('Approximate Music bank sizes: ' + banksize);
+  progress(`Music bank for each track: ${music.map(track => track.bank).join(", ") || "0"}`);
+  progress('data_ptrs.c rewritten with new song banks\n\n');
 };
 
 const compileTrack = async (
@@ -48,7 +80,8 @@ const compileTrack = async (
 
   const modPath = assetFilename(projectRoot, "music", track);
   const outputFile = process.platform === "win32" ? "output.c" : "music.c";
-  const args = [`"${modPath}"`, track.dataName, "-c", track.bank];
+  const args = [`"${modPath}"`, track.dataName, "-c", 8]; // Replace bank 8 later
+  progress(`Convert "${modPath}" to "${track.dataName}"`);
 
   const options = {
     cwd: buildRoot,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Feature and bugfix!

* **What is the current behavior?** (You can also link to an open issue here)
Too much music causes bad bank allocation, current system just loops over 8 banks without care.
#388 wrote twice at addr, similar to #404 too.

* **What is the new behavior (if this is a feature change)?**
Estimates music size after compile and modify bank_ptrs.c to fit more tracks in.
Helps tremendously with lots of smaller tracks and a few big tracks.
Music size is currently an approximate based on output file length, will overestimate for safty
Auto expands properly, log in place to hook in to #410 for auto cart size.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Only tested on windows 10 so far, but fixes a few projects that had issues.

* **Other information**:
Not recursive / backwards lookup, yet, could be added for additional space savings.
@chrismaltby This took a while!
Edit: Should have made a pull request into feature/dynamic_rom_sizing 