### PR TITLE
Fix bad cursor when frame and cursor bank differ

### DIFF
--- a/appData/src/gb/src/UI_b.c
+++ b/appData/src/gb/src/UI_b.c
@@ -39,7 +39,7 @@ void UIInit_b()
   set_bkg_data(0xCA, 1, ui_black);
 
   ptr = ((UWORD)bank_data_ptrs[CURSOR_BANK]) + CURSOR_BANK_OFFSET;
-  SetBankedBkgData(FRAME_BANK, 0xCB, 1, ptr);
+  SetBankedBkgData(CURSOR_BANK, 0xCB, 1, ptr);
 }
 
 void UIUpdate_b()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Bug fix

* **What is the current behavior?**
If the cursor is dynamically allocated a bank before or after ui border, we would read garbage.
This has been a rare issue before this, where the cursor would be in the next bank over, but has been more apparent with dynamic filling as the tile is small.
#410

* **What is the new behavior (if this is a feature change)?**
Read the cursor bank, have the correct cursor, easy to do, hard to find.


* **Does this PR introduce a breaking change?** 
None!

* **Other information**:
