### PR TITLE
JavaScript emulator latency and landscape mode

### DIFF
--- a/appData/js-emulator/css/style.css
+++ b/appData/js-emulator/css/style.css
@@ -277,6 +277,7 @@ body {
   }
 }
 
+/* Small devices in landscape */
 @media only screen and (max-device-width: 300px) and (orientation: landscape) {
   html,
   body {
@@ -304,3 +305,13 @@ body {
     display: none;
   }
 }
+
+/* Devices large enough for landscape */
+@media only screen and (min-width: 300px) and (orientation: landscape) {
+  #controller {
+    bottom: 50%;
+    transform: translateY(50%);
+    opacity: 0.5;
+  }
+}
+

--- a/appData/js-emulator/css/style.css
+++ b/appData/js-emulator/css/style.css
@@ -27,7 +27,7 @@ body {
 }
 
 #controller {
-  display: block;
+  display: none;
   position: fixed;
   bottom: 0px;
   height: 210px;

--- a/appData/js-emulator/css/style.css
+++ b/appData/js-emulator/css/style.css
@@ -277,7 +277,7 @@ body {
   }
 }
 
-@media only screen and (max-device-width: 812px) and (orientation: landscape) {
+@media only screen and (max-device-width: 300px) and (orientation: landscape) {
   html,
   body {
     height: 100%;

--- a/appData/js-emulator/js/other/XAudioServer.js
+++ b/appData/js-emulator/js/other/XAudioServer.js
@@ -197,6 +197,10 @@ XAudioServer.prototype.initializeWebAudio = function () {
         XAudioJSWebAudioAudioNode.onaudioprocess = null;
         XAudioJSWebAudioAudioNode = null;
     }
+	//Android chrome exception has stuttery audio, firefox android is fine with 2048
+	if (navigator.userAgent.includes("Android") && navigator.userAgent.includes("Chrome")) {
+		XAudioJSSamplesPerCallback = 4096;
+	}
     try {
         XAudioJSWebAudioAudioNode = XAudioJSWebAudioContextHandle.createScriptProcessor(XAudioJSSamplesPerCallback, 0, XAudioJSChannelsAllocated);	//Create the js event node.
     }
@@ -432,7 +436,7 @@ var XAudioJSMediaStreamWorker = null;
 var XAudioJSMediaStreamBuffer = [];
 var XAudioJSMediaStreamSampleRate = 44100;
 var XAudioJSMozAudioSampleRate = 44100;
-var XAudioJSSamplesPerCallback = 4096;			//Has to be between 2048 and 4096 (If over, then samples are ignored, if under then silence is added, 4096 fixes chrome android).
+var XAudioJSSamplesPerCallback = 2048;			//Has to be between 2048 and 4096 (If over, then samples are ignored, if under then silence is added, 4096 fixes chrome android).
 var XAudioJSFlashTransportEncoder = null;
 var XAudioJSMediaStreamLengthAliasCounter = 0;
 var XAudioJSBinaryString = [];

--- a/appData/js-emulator/js/other/controls.js
+++ b/appData/js-emulator/js/other/controls.js
@@ -164,10 +164,8 @@ function bindDpad(el) {
 
 function bindTouchRestore() {
   window.addEventListener("touchstart", function(e) {
-    if(!isTouchEnabled) {
-      controller.style.display = "block";
-      isTouchEnabled = true;
-    }
+    controller.style.display = "block";
+    isTouchEnabled = true;
   })
 }
 
@@ -215,6 +213,7 @@ function bindClick() {
 }
 
 if (isTouchEnabled) {
+  controller.style.display = "block";
   bindButton(btnA, "a");
   bindButton(btnB, "b");
   bindButton(btnStart, "start");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
Bug fix, feature

* **What is the current behavior?** (You can also link to an open issue here)
Audio latency is high on all devices to specifically fix chrome on android,
If you try to play in landscape, you will be asked to rotate your screen on mobile, in some configurations with itch this is not possible.

* **What is the new behavior (if this is a feature change)?**
Audio latency is returned to 2048 as originally designed (most computers can go lower, but this is the limit for Firefox android). Exception for Chrome Android to set the buffer to 4096.
Putting the phone in landscape mode will no longer ask you to rotate, and instead uses a gba style layout, works great on ultra wide phones, and ok on regular width phones.


* **Does this PR introduce a breaking change?**
Requires user to re export for web if they want these improvements, Tested on medium and low end devices with chrome for android and Firefox for android, both function without audio stutter, and Firefox android + all pc browsers have slightly lower latency. 

* **Other information**:
