### PR TITLE
Use streams instead of read/writes for copying files; may help with #398

### DIFF
--- a/src/lib/helpers/fsCopy.js
+++ b/src/lib/helpers/fsCopy.js
@@ -28,8 +28,16 @@ const copyFile = async (src, dest, options = {}) => {
       // Didn't exist so copy it
     }
   }
-  const fileData = await fs.readFile(src);
-  await fs.writeFile(dest, fileData, { mode });
+  await new Promise((resolve, reject) => {
+    const inputStream = fs.createReadStream(src);
+    const outputStream = fs.createWriteStream(dest, { mode });
+    inputStream.once('error', (err) => {
+      outputStream.close();
+      reject(new Error(`Could not write file ${dest}`));
+    });
+    inputStream.once('end', () => { resolve(); });
+    inputStream.pipe(outputStream);
+  });
 };
 
 const copy = async (src, dest, options) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features) <- Note that formulating a test for this scenario in particular may be a tad difficult; perhaps a test for copy() as a whole could be useful?
- [ ] Docs have been added / updated (for bug fixes / features) <- After the patch's fix is verified.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

After debugging #398 , I found that the application was getting stuck during the recursive copying of build tools. Noticing that using a combination of fs.readFile/fs.writeFile is sub-optimal, I rewrote it to utilize streams instead - which also happened to fix the problem for me.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. This PR should be invisible to the end-user.