### PR TITLE
Fix/sprites not displaying

### DIFF
--- a/appData/src/gb/include/Scene.h
+++ b/appData/src/gb/include/Scene.h
@@ -40,7 +40,7 @@
 extern UINT8 scene_bank;
 extern POS map_next_pos;
 extern VEC2D map_next_dir;
-extern UBYTE map_next_sprite;
+extern UWORD map_next_sprite;
 extern ACTOR actors[MAX_ACTORS];
 extern TRIGGER triggers[MAX_TRIGGERS];
 extern UWORD scene_index;

--- a/appData/src/gb/src/Scene.c
+++ b/appData/src/gb/src/Scene.c
@@ -20,7 +20,7 @@ void SceneRenderActor_b(UBYTE i);
 
 POS map_next_pos;
 VEC2D map_next_dir;
-UBYTE map_next_sprite;
+UWORD map_next_sprite;
 ACTOR actors[MAX_ACTORS];
 TRIGGER triggers[MAX_TRIGGERS];
 UWORD scene_index;

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -116,7 +116,7 @@ void SceneInit_b2()
   for (i = 0; i != num_sprites; i++)
   {
     // LOG("LOAD SPRITE=%u k=%u\n", i, k);
-    sprite_index = ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr + i);
+    sprite_index = (UWORD)(ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr + (2 * i)) * 256) + ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr + (2 * i) + 1);
     // LOG("SPRITE INDEX=%u\n", sprite_index);
     ReadBankedBankPtr(DATA_PTRS_BANK, &sprite_bank_ptr, &sprite_bank_ptrs[sprite_index]);
     sprite_ptr = ((UWORD)bank_data_ptrs[sprite_bank_ptr.bank]) + sprite_bank_ptr.offset;
@@ -125,7 +125,7 @@ void SceneInit_b2()
     SetBankedSpriteData(sprite_bank_ptr.bank, k, sprite_len, sprite_ptr + 1);
     k += sprite_len;
   }
-  scene_load_ptr = scene_load_ptr + num_sprites;
+  scene_load_ptr = scene_load_ptr + (2 * num_sprites);
 
   // Load actors
   scene_num_actors = ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr) + 1;

--- a/appData/src/gb/src/Scene_b.c
+++ b/appData/src/gb/src/Scene_b.c
@@ -107,7 +107,7 @@ void SceneInit_b2()
 
   ReadBankedBankPtr(DATA_PTRS_BANK, &bank_ptr, &scene_bank_ptrs[scene_index]);
   scene_load_ptr = ((UWORD)bank_data_ptrs[bank_ptr.bank]) + bank_ptr.offset;
-  image_index = ReadBankedUWORD(bank_ptr.bank, scene_load_ptr);
+  image_index = (UWORD)(ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr) * 256) + ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr + 1);
   num_sprites = ReadBankedUBYTE(bank_ptr.bank, scene_load_ptr + 2);
 
   // Load sprites

--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -42,7 +42,7 @@ SCRIPT_CMD script_cmds[] = {
     {Script_ActorMoveTo_b, 2},        // 0x10
     {Script_ShowSprites_b, 0},        // 0x11
     {Script_HideSprites_b, 0},        // 0x12
-    {Script_PlayerSetSprite_b, 1},    // 0x13
+    {Script_PlayerSetSprite_b, 2},    // 0x13
     {Script_ActorShow_b, 0},          // 0x14
     {Script_ActorHide_b, 0},          // 0x15
     {Script_ActorSetEmote_b, 1},      // 0x16

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -680,10 +680,11 @@ void Script_PlayerSetSprite_b()
 {
   BANK_PTR sprite_bank_ptr;
   UWORD sprite_ptr;
-  UBYTE sprite_index, sprite_frames, sprite_len;
+  UWORD sprite_index;
+  UBYTE sprite_frames, sprite_len;
 
   // Load Player Sprite
-  sprite_index = script_cmd_args[0];
+  sprite_index = (script_cmd_args[0] * 256) + script_cmd_args[1];
   ReadBankedBankPtr(DATA_PTRS_BANK, &sprite_bank_ptr, &sprite_bank_ptrs[sprite_index]);
   sprite_ptr = ((UWORD)bank_data_ptrs[sprite_bank_ptr.bank]) + sprite_bank_ptr.offset;
   sprite_frames = ReadBankedUBYTE(sprite_bank_ptr.bank, sprite_ptr);

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -799,30 +799,32 @@ void Script_SaveData_b()
   RAMPtr[0] = TRUE; // Flag to determine if data has been stored
 
   // Save current scene
-  RAMPtr[1] = scene_index;
+  RAMPtr[1] = scene_index >> 8;
+  RAMPtr[2] = scene_index & 0xFF;
 
   // Save player position
-  RAMPtr[2] = actors[0].pos.x;
-  RAMPtr[3] = actors[0].pos.y;
+  RAMPtr[3] = actors[0].pos.x;
+  RAMPtr[4] = actors[0].pos.y;
   if (actors[0].dir.x < 0)
   {
-    RAMPtr[4] = 2;
+    RAMPtr[5] = 2;
   }
   else if (actors[0].dir.x > 0)
   {
-    RAMPtr[4] = 4;
+    RAMPtr[5] = 4;
   }
   else if (actors[0].dir.y < 0)
   {
-    RAMPtr[4] = 8;
+    RAMPtr[5] = 8;
   }
   else
   {
-    RAMPtr[4] = 1;
+    RAMPtr[5] = 1;
   }
 
   // Save player sprite
-  RAMPtr[5] = map_next_sprite;
+  RAMPtr[6] = map_next_sprite >> 8;
+  RAMPtr[7] = map_next_sprite & 0xFF;
 
   // Save variable values
   RAMPtr = (UBYTE *)RAM_START_VARS_PTR;
@@ -853,7 +855,7 @@ void Script_LoadData_b()
   {
     // Set scene index
     RAMPtr++;
-    scene_next_index = *RAMPtr;
+    scene_next_index = (UWORD)((*(RAMPtr++)) * 256) + *RAMPtr;
     scene_index = scene_next_index + 1;
 
     // Position player
@@ -869,7 +871,7 @@ void Script_LoadData_b()
 
     // Load player sprite
     RAMPtr++;
-    map_next_sprite = *RAMPtr;
+    map_next_sprite = (UWORD)((*(RAMPtr++)) * 256) + *RAMPtr;
 
     // Load variable values
     RAMPtr = (UBYTE *)RAM_START_VARS_PTR;

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -258,7 +258,7 @@ const compile = async (
         hi(scene.backgroundIndex),
         lo(scene.backgroundIndex),
         scene.sprites.length,
-        scene.sprites,
+        flatten(scene.sprites.map((spriteIndex)=> [hi(spriteIndex), lo(spriteIndex)])),
         scene.actors.length,
         compileActors(scene.actors, {
           eventPtrs: eventPtrs[sceneIndex].actors,

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -247,7 +247,8 @@ class ScriptBuilder {
     const { sprites } = this.options;
     const spriteIndex = getSpriteIndex(spriteSheetId, sprites);
     output.push(cmd(PLAYER_SET_SPRITE));
-    output.push(spriteIndex);
+    output.push(hi(spriteIndex));
+    output.push(lo(spriteIndex));
   };
 
   // Sprites

--- a/test/data/compiler/scriptBuilder.test.js
+++ b/test/data/compiler/scriptBuilder.test.js
@@ -325,7 +325,7 @@ test("Should be able to change player sprite", () => {
     sprites: [{ id: "def" }]
   });
   sb.playerSetSprite("def");
-  expect(output).toEqual([cmd(PLAYER_SET_SPRITE), 0]);
+  expect(output).toEqual([cmd(PLAYER_SET_SPRITE), 0, 0]);
 });
 
 test("Should be able to hide all sprites", () => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes for the issues seen in #419 where sprites and backgrounds were sometimes corrupted.

* **What is the current behavior?** (You can also link to an open issue here)
A project referenced in #419 came across two issues caused by errors in handling large projects.

1. **Sprites were appearing corrupted in some scenes**
  This was caused by an inbuilt limit of 256 unique sprites in GB Studio, though if you went over this limit there were no warnings and the sprites would appear either using incorrect data or corrupted data.

2. **Some scenes were loading incorrect background images**
 While GB Studio did have support for over 256 unique background images there was a bug with the function `ReadBankedUWORD` which causes it to sometimes returns an incorrect value (I believe it's when the value isn't aligned correctly in memory)

* **What is the new behavior (if this is a feature change)?**

I have added support for theoretically 65,536 unique sprites and have fixed the issues with large numbers of backgrounds again giving a limit of 65,536, though I'm sure the ROM would run out of space long before these limits are hit.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It shouldn't, I need to do some more testing on a range of projects before merging though

* **Other information**:
