### PR TITLE
Add message to display background unique tile number when building

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -482,7 +482,7 @@ const precompile = async (
     projectData.scenes,
     projectRoot,
     tmpPath,
-    { warnings }
+    { progress, warnings }
   );
 
   progress(EVENT_MSG_PRE_UI_IMAGES);
@@ -622,7 +622,7 @@ export const precompileBackgrounds = async (
   scenes,
   projectRoot,
   tmpPath,
-  { warnings } = {}
+  { progress, warnings } = {}
 ) => {
   const eventImageIds = [];
   walkScenesEvents(scenes, cmd => {
@@ -641,7 +641,7 @@ export const precompileBackgrounds = async (
     projectRoot,
     tmpPath,
     {
-      warnings
+      progress, warnings
     }
   );
   const usedTilesets = [];

--- a/src/lib/compiler/compileImages.js
+++ b/src/lib/compiler/compileImages.js
@@ -5,7 +5,7 @@ const ggbgfx = require("./ggbgfx");
 const MAX_SIZE = 9999999999;
 const MAX_TILESET_TILES = 16 * 12;
 
-const compileImages = async (imgs, projectPath, tmpPath, { warnings }) => {
+const compileImages = async (imgs, projectPath, tmpPath, { progress, warnings }) => {
   const tilesetLookups = [];
   const tilesetIndexes = [];
   const output = {
@@ -28,6 +28,12 @@ const compileImages = async (imgs, projectPath, tmpPath, { warnings }) => {
           img.filename
         }' contains too many unique 8x8px tiles (${tilesetLength} where limit is ${MAX_TILESET_TILES}) meaning it may not display correctly. ` +
           `Consider reducing the amount of detail in this image.`
+      );
+    } else {
+      progress(
+        `Background '${
+          img.filename
+        }' contains (${tilesetLength} of ${MAX_TILESET_TILES}) unique 8x8px tiles`
       );
     }
     tilesetLookups.push(tilesetLookup);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- Tests for the changes have been added (for bug fixes / features) (N.A.)
- Docs have been added / updated (for bug fixes / features) (N.A.)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature: allow user to observe the number of unique tiles that are currently registered for a specific background. This helps development by enabling a prudent approach towards design versus available resources.


* **What is the current behavior?** (You can also link to an open issue here)
When building, the only mention of the number of unique tiles is made only when going over the 192 limit.


* **What is the new behavior (if this is a feature change)?**
Each build lists as progress the number of registered unique tiles out of the total, allowing a good overview on what is still possible in some scenes.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
![image](https://user-images.githubusercontent.com/14889947/81498470-dfdd6180-92cd-11ea-8440-77b2316982ab.png)
