### PR TITLE
Add compile warning if player sprite sheet isn't set

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1040,6 +1040,9 @@ export const precompileSprites = async (
 
   if(playerSpriteSheetId) {
     const spriteSheet = spriteLookup[playerSpriteSheetId];
+    if (!spriteSheet) {
+      warnings(`Player Sprite Sheet isn't set. Please, make sure to select a Sprite Sheet in the Project editor.`);
+    }
     usedSprites.push(spriteSheet);
     usedSpriteLookup[playerSpriteSheetId] = spriteSheet;    
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add compile warning if player sprite sheet is set to `None`.

* **What is the current behavior?** (You can also link to an open issue here)

Compile fails with `TypeError: Cannot read property 'plugin' of undefined` when no sprite sheet has been selected for the Player. See #447 

* **What is the new behavior (if this is a feature change)?**

A more clear `Player Sprite Sheet isn't set. Please, make sure to select a Sprite Sheet in the Project editor.` error is shown on compile.

<img width="807" alt="image" src="https://user-images.githubusercontent.com/54246642/90986802-6ec07200-e57d-11ea-8fd9-a73a4ea15588.png">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

This doesn't solve the core issue of #447 (how did the player sprite sheet ended up being `None`?). But it should help users to fix the issue by themselves if they get there.
