### PR TITLE
Walk all scripts for scene connection detection

### DIFF
--- a/src/components/world/Connections.js
+++ b/src/components/world/Connections.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { EVENT_SWITCH_SCENE } from "../../lib/compiler/eventTypes";
-import { walkEvents } from "../../lib/helpers/eventSystem";
+import { walkActorEvents, walkTriggerEvents, walkSceneSpecificEvents } from "../../lib/helpers/eventSystem";
 import {
   SceneShape,
   ActorShape,
@@ -17,9 +17,9 @@ import {
   getActorsLookup,
 } from "../../reducers/entitiesReducer";
 
-const scriptMapTransition = (script) => {
+const scriptMapTransition = (walkEventsFn) => (script) => {
   const sceneTransitions = [];
-  walkEvents(script, (action) => {
+  walkEventsFn(script, (action) => {
     if (action.command === EVENT_SWITCH_SCENE) {
       sceneTransitions.push(action);
     }
@@ -174,7 +174,7 @@ class Connections extends Component {
       // Actor Transitions
       scene.actors.forEach((entityId, entityIndex) => {
         const entity = actorsLookup[entityId];
-        const transitionEvents = scriptMapTransition(entity.script || []);
+        const transitionEvents = scriptMapTransition(walkActorEvents)(entity);
         transitionEvents.forEach((event) => {
           if (
             showConnections === "all" ||
@@ -205,7 +205,7 @@ class Connections extends Component {
       // Trigger Transitions
       scene.triggers.forEach((entityId, entityIndex) => {
         const entity = triggersLookup[entityId];
-        const transitionEvents = scriptMapTransition(entity.script || []);
+        const transitionEvents = scriptMapTransition(walkTriggerEvents)(entity);
         transitionEvents.forEach((event) => {
           if (
             showConnections === "all" ||
@@ -234,7 +234,7 @@ class Connections extends Component {
       });
 
       // Scene Event Transitions
-      const sceneTransitionEvents = scriptMapTransition(scene.script || []);
+      const sceneTransitionEvents = scriptMapTransition(walkSceneSpecificEvents)(scene);
       sceneTransitionEvents.forEach((event) => {
         if (
           showConnections === "all" ||

--- a/src/lib/helpers/eventSystem.js
+++ b/src/lib/helpers/eventSystem.js
@@ -110,6 +110,10 @@ const walkActorEvents = (actor, callback) => {
   walkEvents(actor.hit3Script, callback);
 }
 
+const walkTriggerEvents = (trigger, callback) => {
+  walkEvents(trigger.script, callback);
+}
+
 const normalizedWalkSceneEvents = (
   scene,
   actorsLookup,
@@ -378,6 +382,7 @@ export {
   walkSceneEvents,
   walkSceneSpecificEvents,
   walkActorEvents,
+  walkTriggerEvents,
   findSceneEvent,
   normalizedWalkSceneEvents,
   normalizedFindSceneEvent,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix. 

* **What is the current behavior?** (You can also link to an open issue here)

Connections within scenes aren't being detected for scripts other than the main one on each entity. Connectors aren't displayed in the World editor when `Change Scene` event is used on those scripts.

* **What is the new behavior (if this is a feature change)?**

Walk over all the scripts for each entity to detect `Change Scene` events.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. Although it might make things a bit slower?


* **Other information**:
