### PR TITLE
Add 'Clamp' option in Add/Subtract.

### DIFF
--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -102,8 +102,8 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_MathMul_b, 3},             // 0x37
     {Script_MathDiv_b, 3},             // 0x38
     {Script_MathMod_b, 3},             // 0x39
-    {Script_MathAddVal_b, 0},          // 0x3A
-    {Script_MathSubVal_b, 0},          // 0x3B
+    {Script_MathAddVal_b, 1},          // 0x3A
+    {Script_MathSubVal_b, 1},          // 0x3B
     {Script_MathMulVal_b, 0},          // 0x3C
     {Script_MathDivVal_b, 0},          // 0x3D
     {Script_MathModVal_b, 0},          // 0x3E
@@ -1683,7 +1683,14 @@ void Script_MathMod_b() {
 void Script_MathAddVal_b() {
   UBYTE a = script_variables[active_script_ctx.script_ptr_x];
   UBYTE b = script_variables[active_script_ctx.script_ptr_y];
-  script_variables[active_script_ctx.script_ptr_x] = a + b;
+  UBYTE noWrap = script_cmd_args[0];
+
+  if (!noWrap || a < 255 - b) {
+    script_variables[active_script_ctx.script_ptr_x] = a + b;
+  } else {
+    script_variables[active_script_ctx.script_ptr_x] = 255;
+  }
+  
 }
 
 /*
@@ -1694,7 +1701,13 @@ void Script_MathAddVal_b() {
 void Script_MathSubVal_b() {
   UBYTE a = script_variables[active_script_ctx.script_ptr_x];
   UBYTE b = script_variables[active_script_ctx.script_ptr_y];
-  script_variables[active_script_ctx.script_ptr_x] = a - b;
+  UBYTE noWrap = script_cmd_args[0];
+
+  if (!noWrap || a > b) {
+    script_variables[active_script_ctx.script_ptr_x] = a - b;
+  } else {
+    script_variables[active_script_ctx.script_ptr_x] = 0;
+  }
 }
 
 /*

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -1683,9 +1683,9 @@ void Script_MathMod_b() {
 void Script_MathAddVal_b() {
   UBYTE a = script_variables[active_script_ctx.script_ptr_x];
   UBYTE b = script_variables[active_script_ctx.script_ptr_y];
-  UBYTE noWrap = script_cmd_args[0];
+  UBYTE clamp = script_cmd_args[0];
 
-  if (!noWrap || a < 255 - b) {
+  if (!clamp || a < 255 - b) {
     script_variables[active_script_ctx.script_ptr_x] = a + b;
   } else {
     script_variables[active_script_ctx.script_ptr_x] = 255;
@@ -1701,9 +1701,9 @@ void Script_MathAddVal_b() {
 void Script_MathSubVal_b() {
   UBYTE a = script_variables[active_script_ctx.script_ptr_x];
   UBYTE b = script_variables[active_script_ctx.script_ptr_y];
-  UBYTE noWrap = script_cmd_args[0];
+  UBYTE clamp = script_cmd_args[0];
 
-  if (!noWrap || a > b) {
+  if (!clamp || a > b) {
     script_variables[active_script_ctx.script_ptr_x] = a - b;
   } else {
     script_variables[active_script_ctx.script_ptr_x] = 0;

--- a/src/components/script/ScriptEventForm.js
+++ b/src/components/script/ScriptEventForm.js
@@ -71,7 +71,8 @@ class ScriptEventForm extends Component {
             (!condition.gt || keyValue > condition.gt) &&
             (!condition.gte || keyValue >= condition.gte) &&
             (!condition.lt || keyValue > condition.lt) &&
-            (!condition.lte || keyValue >= condition.lte)
+            (!condition.lte || keyValue >= condition.lte) &&
+            (!condition.in || condition.in.indexOf(keyValue) >= 0)
           );
         }, true);
         if (!showField) {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -105,6 +105,7 @@
   "FIELD_VALUE": "Value",
   "FIELD_MIN_VALUE": "Min value",
   "FIELD_MAX_VALUE": "Max value",
+  "FIELD_NO_WRAP": "No Wrap",
   "FIELD_RENAME": "Rename",
   "FIELD_SAVE": "Save",
   "FIELD_VARIABLE_NAME": "Variable Name",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -105,7 +105,7 @@
   "FIELD_VALUE": "Value",
   "FIELD_MIN_VALUE": "Min value",
   "FIELD_MAX_VALUE": "Max value",
-  "FIELD_NO_WRAP": "No Wrap",
+  "FIELD_CLAMP": "Clamp",
   "FIELD_RENAME": "Rename",
   "FIELD_SAVE": "Save",
   "FIELD_VARIABLE_NAME": "Variable Name",

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -564,18 +564,18 @@ class ScriptBuilder {
     output.push(range);
   };
 
-  variablesAdd = (setVariable, otherVariable, noWrap) => {
+  variablesAdd = (setVariable, otherVariable, clamp) => {
     const output = this.output;
     this.vectorsLoad(setVariable, otherVariable);
     output.push(cmd(MATH_ADD_VALUE));
-    output.push(noWrap ? 1 : 0);
+    output.push(clamp ? 1 : 0);
   };
 
-  variablesSub = (setVariable, otherVariable, noWrap) => {
+  variablesSub = (setVariable, otherVariable, clamp) => {
     const output = this.output;
     this.vectorsLoad(setVariable, otherVariable);
     output.push(cmd(MATH_SUB_VALUE));
-    output.push(noWrap ? 1 : 0);
+    output.push(clamp ? 1 : 0);
   };
 
   variablesMul = (setVariable, otherVariable) => {

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -564,16 +564,18 @@ class ScriptBuilder {
     output.push(range);
   };
 
-  variablesAdd = (setVariable, otherVariable) => {
+  variablesAdd = (setVariable, otherVariable, noWrap) => {
     const output = this.output;
     this.vectorsLoad(setVariable, otherVariable);
     output.push(cmd(MATH_ADD_VALUE));
+    output.push(noWrap ? 1 : 0);
   };
 
-  variablesSub = (setVariable, otherVariable) => {
+  variablesSub = (setVariable, otherVariable, noWrap) => {
     const output = this.output;
     this.vectorsLoad(setVariable, otherVariable);
     output.push(cmd(MATH_SUB_VALUE));
+    output.push(noWrap ? 1 : 0);
   };
 
   variablesMul = (setVariable, otherVariable) => {

--- a/src/lib/events/eventVariableMath.js
+++ b/src/lib/events/eventVariableMath.js
@@ -90,6 +90,18 @@ const fields = [
     width: "50%"
   },
   {
+    key: "noWrap",
+    type: "checkbox",
+    label: l10n("FIELD_NO_WRAP"),
+    conditions: [
+      {
+        key: "operation",
+        in: ["add", "sub"],
+      }
+    ],
+    defaultValue: false,
+  },
+  {
     label: l10n("FIELD_MATH_NOTE")
   }
 ];
@@ -131,10 +143,10 @@ const compile = (input, helpers) => {
   }
   switch (input.operation) {
     case "add":
-      variablesAdd(input.vectorX, tmp1);
+      variablesAdd(input.vectorX, tmp1, input.noWrap);
       break;
     case "sub":
-      variablesSub(input.vectorX, tmp1);
+      variablesSub(input.vectorX, tmp1, input.noWrap);
       break;
     case "mul":
       variablesMul(input.vectorX, tmp1);

--- a/src/lib/events/eventVariableMath.js
+++ b/src/lib/events/eventVariableMath.js
@@ -90,9 +90,9 @@ const fields = [
     width: "50%"
   },
   {
-    key: "noWrap",
+    key: "clamp",
     type: "checkbox",
-    label: l10n("FIELD_NO_WRAP"),
+    label: l10n("FIELD_CLAMP"),
     conditions: [
       {
         key: "operation",
@@ -143,10 +143,10 @@ const compile = (input, helpers) => {
   }
   switch (input.operation) {
     case "add":
-      variablesAdd(input.vectorX, tmp1, input.noWrap);
+      variablesAdd(input.vectorX, tmp1, input.clamp);
       break;
     case "sub":
-      variablesSub(input.vectorX, tmp1, input.noWrap);
+      variablesSub(input.vectorX, tmp1, input.clamp);
       break;
     case "mul":
       variablesMul(input.vectorX, tmp1);

--- a/test/data/compiler/scriptBuilder.test.js
+++ b/test/data/compiler/scriptBuilder.test.js
@@ -518,14 +518,14 @@ test("Should be able to set variable to random number", () => {
 
 test("Should be able to add variables", () => {
   const output = [];
-  const sb = new ScriptBuilder(output, { variables: ["0", "1"], noWrap: true });
+  const sb = new ScriptBuilder(output, { variables: ["0", "1"], clamp: true });
   sb.variablesAdd("0", "1", true);
   expect(output).toEqual([cmd(LOAD_VECTORS), 0, 0, 0, 1, cmd(MATH_ADD_VALUE), 1]);
 });
 
 test("Should be able to subtract variables", () => {
   const output = [];
-  const sb = new ScriptBuilder(output, { variables: ["0", "1"], noWrap: true });
+  const sb = new ScriptBuilder(output, { variables: ["0", "1"], clamp: true });
   sb.variablesSub("1", "0", true);
   expect(output).toEqual([cmd(LOAD_VECTORS), 0, 1, 0, 0, cmd(MATH_SUB_VALUE), 1]);
 });

--- a/test/data/compiler/scriptBuilder.test.js
+++ b/test/data/compiler/scriptBuilder.test.js
@@ -518,16 +518,16 @@ test("Should be able to set variable to random number", () => {
 
 test("Should be able to add variables", () => {
   const output = [];
-  const sb = new ScriptBuilder(output, { variables: ["0", "1"] });
-  sb.variablesAdd("0", "1");
-  expect(output).toEqual([cmd(LOAD_VECTORS), 0, 0, 0, 1, cmd(MATH_ADD_VALUE)]);
+  const sb = new ScriptBuilder(output, { variables: ["0", "1"], noWrap: true });
+  sb.variablesAdd("0", "1", true);
+  expect(output).toEqual([cmd(LOAD_VECTORS), 0, 0, 0, 1, cmd(MATH_ADD_VALUE), 1]);
 });
 
 test("Should be able to subtract variables", () => {
   const output = [];
-  const sb = new ScriptBuilder(output, { variables: ["0", "1"] });
-  sb.variablesSub("1", "0");
-  expect(output).toEqual([cmd(LOAD_VECTORS), 0, 1, 0, 0, cmd(MATH_SUB_VALUE)]);
+  const sb = new ScriptBuilder(output, { variables: ["0", "1"], noWrap: true });
+  sb.variablesSub("1", "0", true);
+  expect(output).toEqual([cmd(LOAD_VECTORS), 0, 1, 0, 0, cmd(MATH_SUB_VALUE), 1]);
 });
 
 test("Should be able to multiply variables", () => {

--- a/test/events/eventVariableMath.test.js
+++ b/test/events/eventVariableMath.test.js
@@ -133,6 +133,7 @@ test("Should be able to add value to variable", () => {
       vectorX: "2",
       other: "val",
       value: 5,
+      noWrap: true,
       operation: "add"
     },
     {
@@ -142,7 +143,7 @@ test("Should be able to add value to variable", () => {
     }
   );
   expect(mockVariableSetToValue).toBeCalledWith("tmp1", 5);
-  expect(mockVariablesAdd).toBeCalledWith("2", "tmp1");
+  expect(mockVariablesAdd).toBeCalledWith("2", "tmp1", true);
 });
 
 test("Should be able to subtract value from variable", () => {
@@ -154,6 +155,7 @@ test("Should be able to subtract value from variable", () => {
       vectorX: "2",
       other: "val",
       value: 5,
+      noWrap: true,
       operation: "sub"
     },
     {
@@ -163,7 +165,7 @@ test("Should be able to subtract value from variable", () => {
     }
   );
   expect(mockVariableSetToValue).toBeCalledWith("tmp1", 5);
-  expect(mockVariablesSub).toBeCalledWith("2", "tmp1");
+  expect(mockVariablesSub).toBeCalledWith("2", "tmp1", true);
 });
 
 test("Should be able to multiply variable by value", () => {

--- a/test/events/eventVariableMath.test.js
+++ b/test/events/eventVariableMath.test.js
@@ -133,7 +133,7 @@ test("Should be able to add value to variable", () => {
       vectorX: "2",
       other: "val",
       value: 5,
-      noWrap: true,
+      clamp: true,
       operation: "add"
     },
     {
@@ -155,7 +155,7 @@ test("Should be able to subtract value from variable", () => {
       vectorX: "2",
       other: "val",
       value: 5,
-      noWrap: true,
+      clamp: true,
       operation: "sub"
     },
     {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: Allow add and subtract with no 'wrap' but 'clamp' from 0-255.
If 'Clamp' option is true, the sum will be up to 255, and the difference will be down to 0.
If 'Clamp' option is false, nothing changes.
I think it's handy in some combat system or loot system.

* **What is the current behavior?** (You can also link to an open issue here)
255 + 1 = 0
0 - 1 = 255


* **What is the new behavior (if this is a feature change)?**
If 'clamp' is true:
255 + 1 = 255
0 - 1 = 0


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
L10n not completely yet. The 'Notes' text need to be update.