### PR TITLE
Feature/player sprite persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add additional Animation Speed option "None". Setting this will prevent actor from animating at all. Static actors will now cycle through frames while moving unless this value is set.
 - Add support for macOS full screen mode
 - Add menu item and keyboard shortcut to switch project, opening the recent projects list [@patrickmollohan](https://github.com/patrickmollohan)
+- Add option to persist player sprite changes between scenes (was previously always persisted) unchecking this will cause the sprite change to only be temporary for the current scene, useful for menus or switching genre
 
 ### Fixed
 

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -63,7 +63,7 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_ActorMoveTo_b, 4},         // 0x10
     {Script_ShowSprites_b, 0},         // 0x11
     {Script_HideSprites_b, 0},         // 0x12
-    {Script_PlayerSetSprite_b, 2},     // 0x13
+    {Script_PlayerSetSprite_b, 3},     // 0x13
     {Script_ActorShow_b, 0},           // 0x14
     {Script_ActorHide_b, 0},           // 0x15
     {Script_ActorSetEmote_b, 1},       // 0x16
@@ -1175,7 +1175,9 @@ void Script_PlayerSetSprite_b() {
   player.rerender = TRUE;
 
   // Keep new sprite when switching scene
-  map_next_sprite = sprite_index;
+  if (script_cmd_args[2]) {
+    map_next_sprite = sprite_index;
+  }
 }
 
 /*

--- a/appData/templates/gbs2/project.gbsproj
+++ b/appData/templates/gbs2/project.gbsproj
@@ -26815,7 +26815,8 @@
                     "id": "f50ee3e6-09a8-4507-a531-ed6297e2208a",
                     "command": "EVENT_PLAYER_SET_SPRITE",
                     "args": {
-                        "spriteSheetId": "2f2d492c-dba2-434c-93c9-d1301e88d5e9"
+                        "spriteSheetId": "2f2d492c-dba2-434c-93c9-d1301e88d5e9",
+                        "persist": false
                     }
                 },
                 {
@@ -27610,7 +27611,8 @@
                     "id": "43c8491f-9604-4041-9678-bb2ab3445972",
                     "command": "EVENT_PLAYER_SET_SPRITE",
                     "args": {
-                        "spriteSheetId": "a827b612-578f-4cb9-a2bf-fd54b197b83f"
+                        "spriteSheetId": "a827b612-578f-4cb9-a2bf-fd54b197b83f",
+                        "persist": false
                     }
                 },
                 {
@@ -35613,14 +35615,6 @@
                     }
                 },
                 {
-                    "id": "84f05843-4602-4888-873a-1ce94000b962",
-                    "command": "EVENT_PLAYER_SET_SPRITE",
-                    "args": {
-                        "spriteSheetId": "ac1e8ef4-ffe6-47cd-b16f-9af5da77ec26",
-                        "__collapse": false
-                    }
-                },
-                {
                     "id": "8ee11d7f-7d70-47b2-b1a2-9866c27011d2",
                     "command": "EVENT_SET_VALUE",
                     "args": {
@@ -37021,13 +37015,6 @@
                                 "command": "EVENT_END"
                             }
                         ]
-                    }
-                },
-                {
-                    "id": "3f805f9b-8fd6-4f80-bfcc-d58e50b94cae",
-                    "command": "EVENT_PLAYER_SET_SPRITE",
-                    "args": {
-                        "spriteSheetId": "ac1e8ef4-ffe6-47cd-b16f-9af5da77ec26"
                     }
                 },
                 {

--- a/appData/templates/gbs2/project.gbsproj
+++ b/appData/templates/gbs2/project.gbsproj
@@ -40480,6 +40480,7 @@
         }
     ],
     "_version": "2.0.0",
+    "_release": "2",
     "author": "___AUTHOR___",
     "name": "___PROJECT_NAME___",
     "variables": [

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -294,13 +294,14 @@ class ScriptBuilder {
 
   // Player
 
-  playerSetSprite = (spriteSheetId) => {
+  playerSetSprite = (spriteSheetId, persist) => {
     const output = this.output;
     const { sprites } = this.options;
     const spriteIndex = getSpriteIndex(spriteSheetId, sprites);
     output.push(cmd(PLAYER_SET_SPRITE));
     output.push(hi(spriteIndex));
     output.push(lo(spriteIndex));
+    output.push(persist ? 1 : 0);
   };
 
   playerBounce = (height) => {

--- a/src/lib/events/eventPlayerSetSprite.js
+++ b/src/lib/events/eventPlayerSetSprite.js
@@ -1,20 +1,28 @@
+const l10n = require("../helpers/l10n").default;
+
 const id = "EVENT_PLAYER_SET_SPRITE";
 
 const fields = [
   {
     key: "spriteSheetId",
     type: "sprite",
-    defaultValue: "LAST_SPRITE"
-  }
+    defaultValue: "LAST_SPRITE",
+  },
+  {
+    key: "persist",
+    label: l10n("FIELD_PERSIST_BETWEEN_SCENES"),
+    type: "checkbox",
+    defaultValue: false,
+  },
 ];
 
 const compile = (input, helpers) => {
   const { playerSetSprite } = helpers;
-  playerSetSprite(input.spriteSheetId);
+  playerSetSprite(input.spriteSheetId, input.persist);
 };
 
 module.exports = {
   id,
   fields,
-  compile
+  compile,
 };

--- a/src/lib/project/migrateProject.js
+++ b/src/lib/project/migrateProject.js
@@ -493,6 +493,15 @@ export const migrateFrom120To200Event = event => {
       }
     });
   }  
+  if(event.args && event.command === "EVENT_PLAYER_SET_SPRITE") {
+    return migrateMeta({
+      ...event,
+      args: {
+        ...event.args,
+        persist: true
+      }
+    });
+  }
   
   return event;
 };

--- a/src/lib/project/migrateProject.js
+++ b/src/lib/project/migrateProject.js
@@ -12,6 +12,8 @@ export const LATEST_PROJECT_VERSION = "2.0.0";
 const migrateProject = project => {
   let data = { ...project };
   let version = project._version || "1.0.0";
+  let release = project._release || "1";
+
   if (version === "1") {
     version = "1.0.0";
   }
@@ -33,6 +35,13 @@ const migrateProject = project => {
     data = migrateFrom120To200Events(data);
     data = migrateFrom120To200Collisions(data);
     version = "2.0.0";
+    release = "2";    
+  }
+  if (version === "2.0.0") {
+    if (release === "1") {
+      data = migrateFrom200r1To200r2Events(data);
+      release = "2";
+    }
   }
 
   if (process.env.NODE_ENV !== "production") {
@@ -42,6 +51,8 @@ const migrateProject = project => {
   }
 
   data._version = version;
+  data._release = release;
+
   return data;
 };
 
@@ -567,6 +578,48 @@ export const migrateFrom120To200Collisions = data => {
         ...scene,
         collisions: collisions.slice(0, collisionsSize)
       };
+    })
+  };
+};
+
+/*
+ * Version 2.0.0 r1 had no persist field on EVENT_PLAYER_SET_SPRITE
+ * this migration updates already migrated events from that release 
+ * to use the new default
+ */
+export const migrateFrom200r1To200r2Event = (event) => {
+  const migrateMeta = (newEvent) => {
+    return {
+      ...newEvent,
+      args: {
+        ...newEvent.args,
+        __comment: event.args.__comment,
+        __label: event.args.__label,
+      },
+    };
+  };
+  if (event.args && event.command === "EVENT_PLAYER_SET_SPRITE") {
+    return migrateMeta({
+      ...event,
+      args: {
+        ...event.args,
+        persist: true,
+      },
+    });
+  }
+
+  return event;
+};
+
+const migrateFrom200r1To200r2Events = data => {
+  return {
+    ...data,
+    scenes: mapScenesEvents(data.scenes, migrateFrom200r1To200r2Event),
+    customEvents: (data.customEvents || []).map((customEvent) => {
+      return {
+        ...customEvent,
+        script: mapEvents(customEvent.script, migrateFrom200r1To200r2Event)
+      }
     })
   };
 };

--- a/test/data/compiler/scriptBuilder.test.js
+++ b/test/data/compiler/scriptBuilder.test.js
@@ -321,13 +321,22 @@ test("Should be able to show active actor", () => {
   expect(output).toEqual([cmd(ACTOR_SHOW)]);
 });
 
-test("Should be able to change player sprite", () => {
+test("Should be able to change player sprite without persist", () => {
   const output = [];
   const sb = new ScriptBuilder(output, {
     sprites: [{ id: "def" }]
   });
-  sb.playerSetSprite("def");
-  expect(output).toEqual([cmd(PLAYER_SET_SPRITE), 0, 0]);
+  sb.playerSetSprite("def", false);
+  expect(output).toEqual([cmd(PLAYER_SET_SPRITE), 0, 0, 0]);
+});
+
+test("Should be able to change player sprite with persist", () => {
+  const output = [];
+  const sb = new ScriptBuilder(output, {
+    sprites: [{ id: "def" }]
+  });
+  sb.playerSetSprite("def", true);
+  expect(output).toEqual([cmd(PLAYER_SET_SPRITE), 0, 0, 1]);
 });
 
 test("Should be able to hide all sprites", () => {

--- a/test/events/eventPlayerSetSprite.test.js
+++ b/test/events/eventPlayerSetSprite.test.js
@@ -4,11 +4,12 @@ test("Should be able to set player sprite sheet", () => {
   const mockPlayerSetSprite = jest.fn();
   compile(
     {
-      spriteSheetId: "abc"
+      spriteSheetId: "abc",
+      persist: false
     },
     {
       playerSetSprite: mockPlayerSetSprite
     }
   );
-  expect(mockPlayerSetSprite).toBeCalledWith("abc");
+  expect(mockPlayerSetSprite).toBeCalledWith("abc", false);
 });

--- a/test/migrate/migrate120To200.test.js
+++ b/test/migrate/migrate120To200.test.js
@@ -344,3 +344,21 @@ test("should migrate actors with movementType=static and animate=true should kee
     ],
   });
 });
+
+test("should migrate player set sprite with persist=true to match old default", () => {
+  const oldEvent = {
+    id: "abc",
+    command: "EVENT_PLAYER_SET_SPRITE",
+    args: {
+      spriteSheetId: "def"
+    }
+  };
+  expect(migrateFrom120To200Event(oldEvent)).toEqual({
+    id: "abc",
+    command: "EVENT_PLAYER_SET_SPRITE",
+    args: {
+      spriteSheetId: "def",
+      persist: true,
+    }    
+  })
+})

--- a/test/migrate/migrate200releases.test.js
+++ b/test/migrate/migrate200releases.test.js
@@ -1,0 +1,106 @@
+import migrateProject, {
+  migrateFrom200r1To200r2Event,
+} from "../../src/lib/project/migrateProject";
+
+test("should migrate player set sprite with persist=true to match old default", () => {
+  const oldEvent = {
+    id: "abc",
+    command: "EVENT_PLAYER_SET_SPRITE",
+    args: {
+      spriteSheetId: "def",
+    },
+  };
+  expect(migrateFrom200r1To200r2Event(oldEvent)).toEqual({
+    id: "abc",
+    command: "EVENT_PLAYER_SET_SPRITE",
+    args: {
+      spriteSheetId: "def",
+      persist: true,
+    },
+  });
+});
+
+test("should migrate EVENT_PLAYER_SET_SPRITE events from 2.0.0 r1 to 2.0.0 r2", () => {
+  const oldProject = {
+    _version: "2.0.0",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_PLAYER_SET_SPRITE",
+            args: {
+              spriteSheetId: "def",
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  };
+  const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
+  expect(newProject).toEqual({
+    _version: "2.0.0",
+    _release: "2",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_PLAYER_SET_SPRITE",
+            args: {
+              spriteSheetId: "def",
+              persist: true,
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  });
+});
+
+test("should not migrate EVENT_PLAYER_SET_SPRITE events if already on 2.0.0 r2", () => {
+  const oldProject = {
+    _version: "2.0.0",
+    _release: "2",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_PLAYER_SET_SPRITE",
+            args: {
+              spriteSheetId: "def",
+              persist: false,
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  };
+  const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
+  expect(newProject).toEqual(oldProject);
+});

--- a/test/migrate/migrateProject.test.js
+++ b/test/migrate/migrateProject.test.js
@@ -36,6 +36,7 @@ test("should migrate conditional events from 1.0.0 to 2.0.0", () => {
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
     _version: "2.0.0",
+    _release: "2",
     scenes: [
       {
         width: 32,
@@ -115,6 +116,7 @@ test("should migrate conditional events from 1.2.0 to 2.0.0", () => {
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
     _version: "2.0.0",
+    _release: "2",
     scenes: [
       {
         width: 32,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: Adds the ability to choose if a change to the player sprite persists between scene changes. Mentioned in #458

* **What is the current behavior?** (You can also link to an open issue here)
Internally GB Studio stores the current player sprite index as `map_next_sprite` which is used on every scene change to make sure the correct player sprite is used. Each time a call to the "Set Player Sprite Sheet" happens `map_next_sprite` is updated to the new value so when changing scene the new player sprite will persist.

* **What is the new behavior (if this is a feature change)?**

I've added an additional checkbox matching the one on "Attach Script To Button" which allows this behaviour to be configurable per event.

<img width="340" alt="Screenshot 2020-08-26 at 18 56 11" src="https://user-images.githubusercontent.com/16776042/91339050-d0771b00-e7cd-11ea-9a5f-d289c6cefcff.png">

Unticking this will change the current player sprite but will leave the current value of `map_next_sprite` as is. 

This is useful for scenes where you only temporarily want to change the sprite such as the cursor on the "Player's House" scene or the ship on the "Space Battle" scene where previously a second event was needed to restore the player's sprite when leaving these scenes they can now be set as temporary changes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Any projects already migrated to 2.0.0 will not migrate their events to have the new persist field and will need manually updating. Newly migrated projects will have the value set to true automatically to match the old default.

* **Other information**:
Should the scene stack also be keeping track of this value?