### PR TITLE
V2 Fix, when a scene has changed size, clear colours like collisions

### DIFF
--- a/src/reducers/entitiesReducer.js
+++ b/src/reducers/entitiesReducer.js
@@ -316,7 +316,8 @@ const fixSceneCollisions = state => {
             ...scene,
             width: background ? background.width : 32,
             height: background ? background.height: 32,
-            collisions: []
+            collisions: [],
+            tileColors: []
           };
         } else {
           // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, colours were not cleared like collisions if a scene is resized.
Easy way out, no dynamic padding to try and keep data.

* **What is the current behavior?** (You can also link to an open issue here)
Color data is garbled after scene resize #450 

* **What is the new behavior (if this is a feature change)?**
Color data is cleared after scene resize.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope

* **Other information**:
Migrating pull requests over to main repo.