### PR TITLE
V2 Fix, Refresh UI before Scene switch (in case last bg 192+ overwrote it)

### DIFF
--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -227,6 +227,7 @@ int core_start() {
     BGP_REG = PAL_DEF(0U, 1U, 2U, 3U);
     OBP0_REG = OBP1_REG = PAL_DEF(0U, 0U, 1U, 3U);
 
+    UIInit();
     LoadScene(current_state);
 
     // Run scene type init function


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Unlike 1.2.1, if you load a background between 192-256 tiles, then a background with less than 192 tiles, the text box will be using garbage tiles from the last bg. #454 

* **What is the new behavior (if this is a feature change)?**
Reverts to 1.2.1 where UI tiles are loaded every time before the next scene, in case they were overwritten.
Dialogue still corrupt on scenes 192-256, but fine again once you move to a sub 192 unique tile map.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users must refresh their engine if ejected for this change to take effect.

* **Other information**:
