### PR TITLE
Don't pass labels definition to when compiling subscripts

### DIFF
--- a/src/lib/compiler/compileEntityEvents.js
+++ b/src/lib/compiler/compileEntityEvents.js
@@ -32,6 +32,7 @@ const compileEntityEvents = (input = [], options = {}) => {
         ...options,
         output: eventOutput || output,
         branch: eventBranch,
+        labels: eventBranch ? options.labels : {}
       }),
   };
   const location = Object.assign(


### PR DESCRIPTION
Labels defined outside subscripts (like timer or input script) where being passed to the compile. That made possible to use go to those labels without a compile error, leading to broken game behavior (see #484 )

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Labels defined outside subscripts (like timer or input script) where being passed to the compile. That made possible to use go to those labels without a compile error, leading to broken game behavior (see #484  )

* **What is the new behavior (if this is a feature change)?**

Subscripts (like timer or input script) receive an empty list of labels, so the scope of go to can only be inside the script.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Maybe. If somebody is using the wider scope for labels in a way that doesn't break the game. But I don't think that's possible.

