### PR TITLE
Fix/platformer collision

### DIFF
--- a/appData/src/gb/src/states/Platform.c
+++ b/appData/src/gb/src/states/Platform.c
@@ -81,7 +81,7 @@ void Update_Platform() {
   pl_pos_y = ((player.pos.y) << 4) + (pl_pos_y & 0xF);
 
   tile_x = DIV_8(player.pos.x);
-  tile_x_mid = tile_x + 1;
+  tile_x_mid = DIV_8(player.pos.x+4u);
   tile_y = DIV_8(player.pos.y);
 
   // Move


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Jumping while pressing left into a wall would not let you jump
Ladders would work almost 2 tiles off to the right side of the ladder, but not at all left.
Jumping into the ceiling would snap the player down 1 tile more than expected.

* **What is the new behavior (if this is a feature change)?**

- [x] Jumping while walking left in a wall now works the same as right.
- [x] Ladder collision now work 1/2 a tile to the left, (compromise between centered which was 1 tile each side but looked bad) This works great if your ladder collision is only on the left side of a 2 tile wide ladder. This still seems preferable over the original implementation.
- [x] Ladder collision is detected and used from the same coordinates, making it more reliable.
- [x] Jumping into the ceiling won't snap you down 1 extra tile
- [x] Jumping into the ceiling while running is smooth by checking the tile 1 *pixel* lower for left right collision tests.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users with an Ejected Engine must re eject, ladder solution inelegant, but better than before.

* **Other information**:
**This does not fix Actor interactions being more difficult from the left, related to platformer using 1 tile center, and other modes using 2 tile center for actor facing.**
