### PR TITLE
Fix/sprite preview

### DIFF
--- a/src/components/world/SpriteSheetCanvas.worker.ts
+++ b/src/components/world/SpriteSheetCanvas.worker.ts
@@ -15,7 +15,7 @@ const indexColour = (g: number) => {
         return 3;
     }
     if (g < 130) {
-        return 2;
+        return 3;
     }
     if (g < 205) {
         return 1;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes issue seen in #480 where dark colours in sprites were incorrectly shown using the third palette colour when in game they use the fourth colour

* **What is the current behavior?** (You can also link to an open issue here)
Using this sprite 
![four-color](https://user-images.githubusercontent.com/16776042/91471112-85244180-e88d-11ea-97f4-78331efe7d39.png)
with the following colour palette

<img width="735" alt="Screenshot 2020-08-27 at 17 48 06" src="https://user-images.githubusercontent.com/16776042/91471147-8fded680-e88d-11ea-91f9-66cdb287cda1.png">

will appear in-editor like the following:
<img width="213" alt="Screenshot 2020-08-27 at 17 47 55" src="https://user-images.githubusercontent.com/16776042/91471174-9705e480-e88d-11ea-9ae9-1e03a2a9a5ed.png">

but as GB Color sprites can only contain 3 colours in game it will instead look like

<img width="67" alt="Screenshot 2020-08-27 at 17 50 13" src="https://user-images.githubusercontent.com/16776042/91471294-c583bf80-e88d-11ea-96e3-c18c7989bdf3.png">

* **What is the new behavior (if this is a feature change)?**

I've modified the sprite preview render function to return the same colour index for both the dark and black colors in a sprite causing the preview to match the ingame appearance.

<img width="248" alt="Screenshot 2020-08-27 at 17 47 40" src="https://user-images.githubusercontent.com/16776042/91471408-f663f480-e88d-11ea-9a92-77af5c48e9f0.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
