### PR TITLE
Fix/color dialog modal

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -535,7 +535,7 @@
   "DIALOG_EJECT_ENGINE_REPLACE_DESCRIPTION": "You have already ejected the GB Studio engine to your project.\n\nIf you continue the previously ejected files will be replaced and any changes you made will be lost.",
   "DIALOG_EJECT_REPLACE": "Replace Engine",
   "DIALOG_ENABLE_COLOR_MODE": "Enable Color Mode?",
-  "DIALOG_ENABLE_COLOR_MODE_DESCRIPTION": "Your project current has color mode disabled, would you like to enable it?",
+  "DIALOG_ENABLE_COLOR_MODE_DESCRIPTION": "Your project currently has color mode disabled, would you like to enable it?\n\nColor mode projects will work with both GB and GBC devices.\n\nYou can disable this later in 'Settings'.",
   "DIALOG_ENABLE_COLOR": "Enable Color",
   "DIALOG_REPLACE_CUSTOM_EVENT": "Replace Custom Event \"{name}\"?",
   "DIALOG_REPLACE_CUSTOM_EVENT_DESCRIPTION": "The pasted script contains a modified version of an existing custom event. Would you like to replace the custom event with the version on your clipboard or keep your existing custom event?",

--- a/src/lib/electron/dialog/confirmEnableColorDialog.ts
+++ b/src/lib/electron/dialog/confirmEnableColorDialog.ts
@@ -1,6 +1,7 @@
 import electron from "electron";
 
 const dialog = electron.remote ? electron.remote.dialog : electron.dialog;
+const win = electron.remote.getCurrentWindow();
 
 export default () => {
     // eslint-disable-next-line global-require
@@ -15,5 +16,5 @@ export default () => {
         detail: l10n("DIALOG_ENABLE_COLOR_MODE_DESCRIPTION")
     };
 
-    return dialog.showMessageBoxSync(dialogOptions);
+    return dialog.showMessageBoxSync(win, dialogOptions);
 };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix: As noticed in #492 "Enable Color Mode" modal was not acting as a modal correctly in Windows and allowed some interaction with main window while opened.


* **What is the current behavior?** (You can also link to an open issue here)
When the modal was opened clicking the main window in Windows would give the window focus, while the UI would be locked it would register clicks that would stack up and all be fired after the modal was closed.
Found a similar issue listed here https://stackoverflow.com/questions/46327538/electron-dialog-box-not-preventing-interaction-with-page

* **What is the new behavior (if this is a feature change)?**
As with the answer from the above link the solution is to use the optional browserWindow argument of the Electron function `dialog.showMessageBoxSync` passing in the main window which forces the dialog box to act as a modal correctly.

I've also changed some of the wording in response to #492 to make it clearer that GB support won't be lost and that you can revert the change later in Settings.

<img width="559" alt="Screenshot 2020-08-27 at 21 05 08" src="https://user-images.githubusercontent.com/16776042/91490350-35a03e80-e8aa-11ea-802f-28f7093c1787.png">

On macOS the dialog box was already acting as a modal and this new change alters the styling to be a sheet rather than a separate window.

<img width="516" alt="Screenshot 2020-08-27 at 21 14 03" src="https://user-images.githubusercontent.com/16776042/91490372-3e911000-e8aa-11ea-89fd-fc94db6aaab6.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

There's a few other modals in `src/lib/electron/dialog` I'll have to go through these and determine which others may need the same update making