### PR TITLE
Add support for property fields in Custom Events

### DIFF
--- a/src/components/forms/CustomEventPropertySelect.js
+++ b/src/components/forms/CustomEventPropertySelect.js
@@ -1,3 +1,226 @@
-import React from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import Select, { components } from "react-select";
+import ActorCanvas from "../world/ActorCanvas";
+import { ActorShape } from "../../reducers/stateShape";
+import {
+  getSettings,
+} from "../../reducers/entitiesReducer";
+import { getCachedObject } from "../../lib/helpers/cache";
+import l10n from "../../lib/helpers/l10n";
 
-export default () => <div>Not implemented yet...</div>;
+const menuPortalEl = document.getElementById("MenuPortal");
+
+const allCustomEventActors = Array.from(Array(10).keys()).map(i => ({
+  id: String(i),
+  name: `Actor ${String.fromCharCode("A".charCodeAt(0) + i)}`
+}));
+
+const properties = {
+  xpos: l10n("FIELD_X_POSITION"),
+  ypos: l10n("FIELD_Y_POSITION"),
+  direction: l10n("FIELD_DIRECTION"),
+  moveSpeed: l10n("FIELD_MOVEMENT_SPEED"),
+  animSpeed: l10n("FIELD_ANIMATION_SPEED"),
+  frame: l10n("FIELD_ANIMATION_FRAME"),
+};
+
+// Group
+
+const Group = ({ label, actor, ...props }) => {
+  if (!actor) {
+    return <components.Group {...props} />;
+  }
+  return (
+    <components.Group
+      {...props}
+      label={
+        <>
+          {label}
+          <div style={{ position: "absolute", right: 5, marginTop: 7 }}>
+            <ActorCanvas actor={actor} />
+          </div>
+        </>
+      }
+    />
+  );
+};
+
+const GroupWithData = connect((state, ownProps) => {
+  const customEventId = state.editor.entityId;
+  const actorsLookup = state.entities.present.entities.customEvents[customEventId].actors;
+  const actorIds = allCustomEventActors.map((a) => a.id);
+  const settings = getSettings(state);
+  const playerSpriteSheetId = settings.playerSpriteSheetId;
+  const {
+    data: { actorId },
+  } = ownProps;
+  const actor =
+    actorsLookup[actorId] || 
+    allCustomEventActors[actorId] ||
+    getCachedObject({
+      id: "player",
+      name: "Player",
+      spriteSheetId: playerSpriteSheetId,
+    });
+  const actorIndex = actorIds.indexOf(actor.id);
+  const actorName = actor ? actor.name || `Actor ${actorIndex + 1}` : "";
+  let label = actorName;
+  if (actorId === "player") {
+    label = "Player";
+  }
+
+  return {
+    label,
+    actor,
+  };
+})(Group);
+
+// Dropdown Indicator ---------------------------------------------------------
+
+const DropdownIndicator = ({ actor, ...props }) => {
+  if (!actor) {
+    return <components.DropdownIndicator {...props} />;
+  }
+  return (
+    <components.DropdownIndicator {...props}>
+      <ActorCanvas actor={actor} />
+    </components.DropdownIndicator>
+  );
+};
+
+DropdownIndicator.propTypes = {
+  actor: ActorShape,
+  direction: PropTypes.string,
+  frame: PropTypes.number,
+};
+
+DropdownIndicator.defaultProps = {
+  actor: undefined,
+  direction: undefined,
+  frame: undefined,
+};
+
+const DropdownIndicatorWithData = (actorId) =>
+  connect((state) => {
+    const customEventId = state.editor.entityId;
+    const actorsLookup = state.entities.present.entities.customEvents[customEventId].actors;
+    const settings = getSettings(state);
+    const playerSpriteSheetId = settings.playerSpriteSheetId;
+    const actor =
+      actorsLookup[actorId] || allCustomEventActors[actorId] ||
+      getCachedObject({
+        id: "player",
+        spriteSheetId: playerSpriteSheetId,
+      });
+    return {
+      actor,
+    };
+  })(DropdownIndicator);
+
+// Select -------------------------------------------------------------------
+
+class CustomEventPropertySelect extends Component {
+  render() {
+    const {
+      actorIds,
+      id,
+      label,
+      value,
+      onChange,
+    } = this.props;
+
+    const actorValue = value && value.replace(/:.*/, "");
+
+    const generateActorOptions = (id) => {
+      return Object.keys(properties).map((property) => ({
+        label: properties[property],
+        value: `${id}:${property}`,
+      }));
+    };
+
+    const selectedActorId = actorValue;
+
+    const options = [].concat(
+      {
+        actorId: "player",
+        options: generateActorOptions("player"),
+      },
+      actorIds.map((actorId) => ({
+        actorId,
+        options: generateActorOptions(actorId),
+      }))
+    );
+
+    return (
+      <Select
+        id={id}
+        className="ReactSelectContainer"
+        classNamePrefix="ReactSelect"
+        options={options}
+        value={{
+          label,
+          value,
+        }}
+        onChange={(data) => {
+          onChange(data.value);
+        }}
+        components={{
+          DropdownIndicator: DropdownIndicatorWithData(selectedActorId),
+          Group: GroupWithData,
+        }}
+        grouped
+        menuPlacement="auto"
+        menuPortalTarget={menuPortalEl}
+        blurInputOnSelect
+      />
+    );
+  }
+}
+
+CustomEventPropertySelect.propTypes = {
+  id: PropTypes.string,
+  value: PropTypes.string,
+  label: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  actorIds: PropTypes.arrayOf(PropTypes.string).isRequired
+};
+
+CustomEventPropertySelect.defaultProps = {
+  id: "",
+  label: "",
+  value: "",
+};
+
+function mapStateToProps(state, ownProps) {
+  const customEventId = state.editor.entityId;
+  const actorsLookup = state.entities.present.entities.customEvents[customEventId].actors;
+  const actorIds = allCustomEventActors.map((a) => a.id);
+
+  const value = ownProps.value;
+  const actorValue = value && value.replace(/:.*/, "");
+  const propertyValue = value && value.replace(/.*:/, "");
+
+  const actorId = actorValue;
+  console.log(actorValue, actorsLookup);
+  const actor =
+    actorsLookup[actorId] || allCustomEventActors[actorId] ||
+    getCachedObject({
+      id: "player",
+    });
+  console.log(actor);
+  const actorName = actor ? actor.name : "";
+  let actorLabel = actorName;
+  if (actorValue === "player") {
+    actorLabel = "Player";
+  }
+  const label = `${properties[propertyValue]} : ${actorLabel}`;
+
+  return {
+    label,
+    actorIds,
+  };
+}
+
+export default connect(mapStateToProps)(CustomEventPropertySelect);

--- a/src/lib/compiler/compileEntityEvents.js
+++ b/src/lib/compiler/compileEntityEvents.js
@@ -1,5 +1,5 @@
 import ScriptBuilder from "./scriptBuilder";
-import { isVariableField } from "../helpers/eventSystem";
+import { isVariableField, isPropertyField } from "../helpers/eventSystem";
 
 const STRING_NOT_FOUND = "STRING_NOT_FOUND";
 const VARIABLE_NOT_FOUND = "VARIABLE_NOT_FOUND";
@@ -27,6 +27,7 @@ const compileEntityEvents = (input = [], options = {}) => {
   const helpers = {
     ...options,
     isVariableField,
+    isPropertyField,
     compileEvents: (childInput, eventOutput = null, eventBranch = true) =>
       compileEntityEvents(childInput, {
         ...options,

--- a/src/lib/compiler/helpers.js
+++ b/src/lib/compiler/helpers.js
@@ -177,6 +177,22 @@ export const replaceInvalidCustomEventActors = (actor) => {
   return actor;
 };
 
+export const replaceInvalidCustomEventProperties = (property) => {
+  const getValidPropertyValue = (p) => {
+    const actorValue = p.replace(/:.*/, "");
+    return p.replace(/.*:/, `${replaceInvalidCustomEventActors(actorValue)}:`);
+  }
+
+  // Support the case for "union" values
+  if (property !== null && property.type === "property") {
+    return {
+      ...property,
+      value: getValidPropertyValue(property.value)
+    }
+  }
+  return getValidPropertyValue(property);
+}
+
 export const collisionGroupDec = (group) => {
   if(group === "player") {
     return 1;

--- a/src/lib/events/eventCallCustomEvent.js
+++ b/src/lib/events/eventCallCustomEvent.js
@@ -18,7 +18,7 @@ const fields = [
 ];
 
 const compile = (input, helpers) => {
-  const { isVariableField } = helpers;
+  const { isVariableField, isPropertyField } = helpers;
   const script = JSON.parse(JSON.stringify(input.script));
   walkEvents(script, e => {
     if (!e.args) return;
@@ -40,6 +40,26 @@ const compile = (input, helpers) => {
           }
         } else {
           e.args[arg] = input[`$variable[${argValue}]$`];
+        }
+      }
+
+      if (isPropertyField(e.command, arg, argValue)) {
+        const replacePropertyValueActor = (p) => {
+          const actorValue = p.replace(/:.*/, "");
+          if (actorValue === "player") {
+            return p;
+          }
+          const newActorValue = input[`$actor[${actorValue}]$`];
+          return p.replace(/.*:/, `${newActorValue}:`);
+        }
+
+        if (argValue !== null && argValue.type === "property") {
+          e.args[arg] = {
+            ...argValue,
+            value: replacePropertyValueActor(argValue.value)
+          }
+        } else {
+          e.args[arg] = replacePropertyValueActor(argValue);          
         }
       }
     });

--- a/src/lib/helpers/eventSystem.js
+++ b/src/lib/helpers/eventSystem.js
@@ -338,6 +338,18 @@ const isVariableField = (cmd, fieldName, fieldValue) => {
   )
 };
 
+const isPropertyField = (cmd, fieldName, fieldValue) => {
+  const event = events[cmd];
+  if (!event) return false;
+  const field = event.fields.find((f) => f.key === fieldName)
+  return (
+    field && (
+      field.type === "property" ||
+      (field.type === "union" && fieldValue.type === "property")
+    )
+  )
+};
+
 const getCustomEventIdsInEvents = (events) => {
   const customEventIds = [];
   walkEvents(events, (event) => {
@@ -390,6 +402,7 @@ export {
   findEvent,
   eventHasArg,
   isVariableField,
+  isPropertyField,
   getCustomEventIdsInEvents,
   getCustomEventIdsInScene,
   getCustomEventIdsInActor

--- a/src/reducers/entitiesReducer.js
+++ b/src/reducers/entitiesReducer.js
@@ -54,11 +54,12 @@ import {
   regenerateEventIds,
   mapEvents,
   walkEvents,
-  isVariableField
+  isVariableField,
+  isPropertyField
 } from "../lib/helpers/eventSystem";
 import initialState from "./initialState";
 import { EVENT_CALL_CUSTOM_EVENT } from "../lib/compiler/eventTypes";
-import { replaceInvalidCustomEventVariables, replaceInvalidCustomEventActors } from "../lib/compiler/helpers";
+import { replaceInvalidCustomEventVariables, replaceInvalidCustomEventActors, replaceInvalidCustomEventProperties } from "../lib/compiler/helpers";
 import { paint, paintLine, floodFill } from "../lib/helpers/paint";
 import { DMG_PALETTE, SPRITE_TYPE_STATIC, SPRITE_TYPE_ACTOR, TILE_PROPS, COLLISION_ALL } from "../consts";
 
@@ -579,23 +580,31 @@ const editCustomEvent = (state, action) => {
     // Fix invalid variables in script
     const fix = replaceInvalidCustomEventVariables;
     const fixActor = replaceInvalidCustomEventActors;
+    const fixProperty = replaceInvalidCustomEventProperties;
     patch.script = mapEvents(patch.script, event => {
       if (event.args) {
-        const fixedEventVariableArgs = Object.keys(event.args).reduce((memo, arg) => {
-          const fixedVarArgs = memo;
+        const fixedEventArgs = Object.keys(event.args).reduce((memo, arg) => {
+          const fixedArgs = memo;
           if (isVariableField(event.command, arg, event.args[arg])) {
-            fixedVarArgs[arg] = fix(event.args[arg]);
+            fixedArgs[arg] = fix(event.args[arg]);
           } else {
-            fixedVarArgs[arg] = event.args[arg];
+            fixedArgs[arg] = event.args[arg];
           }
-          return fixedVarArgs;
+
+          if (isPropertyField(event.command, arg, event.args[arg])) {
+            fixedArgs[arg] = fixProperty(event.args[arg]);
+          } else {
+            fixedArgs[arg] = event.args[arg];
+          }
+
+          return fixedArgs;
         }, {});
 
         return {
           ...event,
           args: {
             ...event.args,
-            ...fixedEventVariableArgs,
+            ...fixedEventArgs,
             actorId: event.args.actorId && fixActor(event.args.actorId),
             otherActorId: event.args.otherActorId && fixActor(event.args.otherActorId)
           }
@@ -657,6 +666,29 @@ const editCustomEvent = (state, action) => {
             addVariable(variable.value);
           } else {
             addVariable(variable);
+          }
+        }
+
+        if (isPropertyField(e.command, arg, args[arg])) {
+          const addPropertyActor = (property) => {
+            const actor = property && property.replace(/:.*/, "");
+            if (actor !== "player") {
+              const letter = String.fromCharCode(
+                "A".charCodeAt(0) + parseInt(actor)
+              );
+              actors[actor] = {
+                id: actor,
+                name: oldActors[actor]
+                  ? oldActors[actor].name
+                  : `Actor ${letter}`
+              };
+            }
+          }
+          const property = args[arg];
+          if (property != null && property.type === "property") {
+            addPropertyActor(property.value);
+          } else {
+            addPropertyActor(property);
           }
         }
       });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds support for Property fields in unions to Custom Events.

* **What is the current behavior?** (You can also link to an open issue here)

Property fields aren't supported

* **What is the new behavior (if this is a feature change)?**

When property is selected in an union field inside a Custom Event a selector appears that allow to choose between the properties of the Custom Events actors (A to J) and the Player. If an actor that isn't the player is selected it gets added to the parameter list.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I think I tested most of the cases (`$self$`, copy and paste events with actors, etc.) but would be good if somebody else run some more tests.