### PR TITLE
Add actor-player collision in topdown when player not moving

### DIFF
--- a/appData/src/gb/src/states/TopDown.c
+++ b/appData/src/gb/src/states/TopDown.c
@@ -101,6 +101,14 @@ void Update_TopDown() {
       player.hit_actor = hit_actor;
     }
 
+    hit_actor = ActorOverlapsPlayer(FALSE);
+    if (hit_actor && hit_actor != NO_ACTOR_COLLISON && player_iframes == 0) {
+      if (actors[hit_actor].collision_group) {
+        player.hit_actor = 0;
+        player.hit_actor = hit_actor;
+      }
+    }
+
     if (INPUT_A_PRESSED) {
       // Find actor in front of player
       hit_actor = ActorInFrontOfPlayer();

--- a/appData/src/gb/src/states/TopDown.c
+++ b/appData/src/gb/src/states/TopDown.c
@@ -102,7 +102,7 @@ void Update_TopDown() {
     }
 
     hit_actor = ActorOverlapsPlayer(FALSE);
-    if (hit_actor && hit_actor != NO_ACTOR_COLLISON && player_iframes == 0) {
+    if (hit_actor && hit_actor != NO_ACTOR_COLLISON) {
       if (actors[hit_actor].collision_group) {
         player.hit_actor = 0;
         player.hit_actor = hit_actor;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add passive collisions to top down as mentioned in #451 

* **What is the current behavior?** (You can also link to an open issue here)

In TopDown mode actors don't collide with the player when it's not moving. Other scene types like Platformer or Adventure support passive collisions.

* **What is the new behavior (if this is a feature change)?**

If an actor collides with a player, even if the player isn't moving `On Player Hit` and the Actor `On Hit > Player` are triggered.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Maybe. Depends if the lack of collision is important for your project.

* **Other information**:

The solution adds feature parity between TopDown and the other scene types in passive collisions so it should be good to merge. However, while investigating I realized a couple of inconsistencies happening in all types:

- The collision only works when the actor is coming from left or right but not from up or down. 
- Passive collision works if the Actor is moving using `Move To` with `Use collisions` disabled.

I've been using this project to test: [GBS Showcase.zip](https://github.com/chrismaltby/gb-studio/files/5143616/GBS.Showcase.zip).
