### PR TITLE
Engine improvements for 1.2/Dragonborne, Sfx, Script Perf, B fast forward dialogue

### DIFF
--- a/appData/src/gb/src/ScriptRunner.c
+++ b/appData/src/gb/src/ScriptRunner.c
@@ -135,7 +135,7 @@ void ScriptStart(BANK_PTR *events_ptr)
 
 void ScriptRunnerUpdate()
 {
-  UBYTE i, script_cmd_index;
+  UBYTE script_cmd_index;
   // SCRIPT_CMD_FN script_cmd_fn;
 
   if (!script_action_complete)
@@ -148,12 +148,12 @@ void ScriptRunnerUpdate()
     return;
   }
 
-  script_cmd_index = ReadBankedUBYTE(script_ptr_bank, script_ptr);
-
-  LOG("SCRIPT CMD INDEX WAS %u not=%u, zero=%u\n", script_cmd_index, !script_cmd_index, script_cmd_index == 0);
+  PUSH_BANK(script_ptr_bank);
+  script_cmd_index = *(UBYTE *)script_ptr;
 
   if (!script_cmd_index)
-  {
+  { 
+  POP_BANK;
     if (script_stack_ptr)
     {
       // Return from Actor Invocation
@@ -162,7 +162,6 @@ void ScriptRunnerUpdate()
       POP_BANK;
       return;
     }
-    LOG("SCRIPT FINISHED\n");
     script_ptr_bank = 0;
     script_ptr = 0;
     return;
@@ -171,13 +170,8 @@ void ScriptRunnerUpdate()
   script_cmd_args_len = script_cmds[script_cmd_index].args_len;
   // script_cmd_fn = script_cmds[script_cmd_index].fn;
 
-  LOG("SCRIPT cmd [%u - %u] = %u (%u)\n", script_ptr_bank, script_ptr, script_cmd_index, script_cmd_args_len);
-
-  for (i = 0; i != script_cmd_args_len; i++)
-  {
-    script_cmd_args[i] = ReadBankedUBYTE(script_ptr_bank, script_ptr + i + 1);
-    LOG("SCRIPT ARG-%u = %u\n", i, script_cmd_args[i]);
-  }
+  memcpy(script_cmd_args, script_ptr + 1, 7);
+  POP_BANK;
 
   PUSH_BANK(scriptrunner_bank);
   // if(script_cmd_fn) {

--- a/appData/src/gb/src/ScriptRunner_b.c
+++ b/appData/src/gb/src/ScriptRunner_b.c
@@ -12,9 +12,12 @@
 #include "Macros.h"
 #include "game.h"
 #include "Math.h"
+#include "gbt_player.h"
 
 #define RAM_START_PTR 0xA000
 #define RAM_START_VARS_PTR 0xA0FF
+
+extern UINT8 music_mute_frames;
 
 UINT8 scriptrunner_bank = 4;
 
@@ -1800,6 +1803,14 @@ void Script_SoundStartTone_b()
   // enable sound
   NR52_REG = 0x80;
 
+  if (music_mute_frames != 0) {
+	  // mute music on channel 1 & 4
+	  gbt_enable_channels(0x6);
+  } else {
+	  // mute music on channel 1
+	  gbt_enable_channels(0xE);
+  }
+
   // play tone on channel 1
   NR10_REG = 0x00;
   NR11_REG = (0x00 << 6) | 0x01;
@@ -1825,6 +1836,15 @@ void Script_SoundStopTone_b()
 {
   // stop tone on channel 1
   NR12_REG = 0x00;
+  
+  if (music_mute_frames != 0) {
+	  // keem mute music on channel 4
+	  gbt_enable_channels(0x7);
+  } else {
+	// Unmute music on all ch
+  gbt_enable_channels(0xF);
+  }
+  
 
   script_ptr += 1 + script_cmd_args_len;
   script_continue = TRUE;
@@ -1840,6 +1860,10 @@ void Script_SoundPlayBeep_b()
 
   // enable sound
   NR52_REG = 0x80;
+
+  // mute music on channel 4  
+  music_mute_frames = 15u;
+  gbt_enable_channels(0x7);
 
   // play beep sound on channel 4
   NR41_REG = 0x01;
@@ -1866,6 +1890,10 @@ void Script_SoundPlayCrash_b()
 {
   // enable sound
   NR52_REG = 0x80;
+
+  // mute music on channel 4
+  music_mute_frames = 28u;
+  gbt_enable_channels(0x7);
 
   // play crash sound on channel 4
   NR41_REG = 0x01;

--- a/appData/src/gb/src/UI.c
+++ b/appData/src/gb/src/UI.c
@@ -4,6 +4,7 @@
 #include "data_ptrs.h"
 #include "Macros.h"
 #include "BankData.h"
+#include "gbt_player.h"
 
 void UIInit_b();
 void UIUpdate_b();
@@ -164,6 +165,7 @@ void UIShowText(UBYTE bank, UWORD bank_offset)
     }
     ++k;
   }
+  gbt_update();
 
   if (menu_layout)
   {

--- a/appData/src/gb/src/UI.c
+++ b/appData/src/gb/src/UI.c
@@ -250,7 +250,7 @@ void UISetTextBuffer(unsigned char *text)
 
 void UIDrawTextBuffer()
 {
-  if ((time & 0x1) == 0)
+  if ( (joy & J_B) | ((time & 0x1) == 0))
   {
     UIDrawTextBufferChar();
   }

--- a/appData/src/gb/src/game.c
+++ b/appData/src/gb/src/game.c
@@ -26,10 +26,17 @@ UBYTE scene_stack_ptr = 0;
 SCENE_STATE scene_stack[MAX_SCENE_STATES] = {{0}};
 
 void game_loop();
+UINT8 music_mute_frames = 0;
 
 void vbl_update() {
   SCX_REG = scroll_x;
   SCY_REG = scroll_y;
+  if(music_mute_frames != 0) {
+		music_mute_frames --;
+		if(music_mute_frames == 0) {
+			gbt_enable_channels(0xF);
+		}
+	}
 }
 
 int main()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Legacy bug fix/features


* **What is the current behavior?** (You can also link to an open issue here)
Sound effects could be interrupted by music easily, music lag was considerably high for most scripts


* **What is the new behavior (if this is a feature change)?**
Sound effects mute the appropriate music channels to not be overwritten, 
Improvements to script runner performance brought over from 2.0, some extreme music slowdowns reduced 10-40%, but are still moderate...
Added default Hold B to fast forward text similar to 2.0


* **Does this PR introduce a breaking change?**
No way to disable Hold B to fast forward text in 1.2, as the event would require migration.
This **does not** disable "B for option 2" as is default with multi choice.

* **Other information**:
The features were developed to improve Dragonborne, a large 2mb game nearing release.
Methods to replace engine and rebuild the rom in the tmp folder builds are being used by dragonborne, so these changes are not urgent, but may improve a 1.2.2 legacy release before 2.0 is standard, if that was a consideration (and if is, the ctrl+z fix would be a good cherry-pick).
The research into music mute will advance progress in 2.0's sound effects code, but is tailored for 1.2 in scope/reliability.
