### PR TITLE
Fix Project path selector to select empty folder, not contents of folder

### DIFF
--- a/src/components/app/Splash.jsx
+++ b/src/components/app/Splash.jsx
@@ -11,6 +11,8 @@ import createProject, {
 import l10n from "../../lib/helpers/l10n";
 import "../../lib/helpers/handleFirstTab";
 
+const {dialog} = require('electron').remote;
+
 const getLastUsedPath = () => {
   const storedPath = localStorage.getItem("__lastUsedPath");
   if (storedPath) {
@@ -108,9 +110,12 @@ class Splash extends Component {
     }
   };
 
-  onSelectFolder = (e) => {
-    if (e.target.files && e.target.files[0]) {
-      const newPath = Path.normalize(`${e.target.files[0].path}/`);
+  onSelectFolder = async () => {
+    const path = await dialog.showOpenDialog({
+        properties: ['openDirectory']
+    });
+    if (path.filePaths[0]) {
+      const newPath = Path.normalize(`${path.filePaths}/`);
       setLastUsedPath(newPath);
       this.setState({
         path: newPath,
@@ -322,11 +327,8 @@ class Splash extends Component {
                   <DotsIcon />
                 </div>
                 <input
-                  type="file"
-                  directory=""
-                  webkitdirectory=""
                   className="Splash__InputButton"
-                  onChange={this.onSelectFolder}
+                  onClick={this.onSelectFolder}
                 />
               </label>
             </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#448 #467 #517 Users can not select a project path or are stuck building a project indefinitely.
Something about the tools changed causing webkitdirectory to provide an array of the file contents of a folder, and not the folder itself.


* **What is the new behavior (if this is a feature change)?**
Replaces default file dialogue with 
electron.remote dialouge.showOpenDialogue({ properties: ['openDirectory'] });
Which returns only the path of the selected folder, and is much faster than the method before it was broken.


* **Does this PR introduce a breaking change?** 


* **Other information**:
After days of searching, finally found the correct method
https://stackoverflow.com/questions/36152857/how-to-get-folder-path-using-electron
Figured out the await / async stuff from surrounding code myself :)