### PR TITLE
Fix !!!! being interpreted as a !S2! command and getting stuck

### DIFF
--- a/appData/src/gb/src/core/UI_b.c
+++ b/appData/src/gb/src/core/UI_b.c
@@ -284,6 +284,8 @@ void UIShowText_b() {
         value = (tmp_text_lines[i + 2] - '0');
         text_lines[k] = 0x10 + value;  
         i += 3;
+      } else {
+        text_lines[k] = tmp_text_lines[i];
       }
     } else {
       text_lines[k] = tmp_text_lines[i];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
Using ! in dialogue, it is possible to trigger the !S2! speed commands unintentionally, causing missing dialogue, random characters, or the game to get stuck on 1 textbox. Reported on discord.
https://discord.com/channels/554713715442712616/570925559346102273/751042234761085079


* **What is the new behavior (if this is a feature change)?**
If "!" check fails, it prints the character normally as part of a mini else.
Might fix some other slightly weird text cases, but be on the look out for more.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users must update their ejected engine.

* **Other information**:
