### PR TITLE
New event: if device supports color

### DIFF
--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -185,5 +185,6 @@ void Script_PalSetSprite_b();
 void Script_PalSetUI_b();
 void Script_ActorStopUpdate_b();
 void Script_ActorSetAnimate_b();
+void Script_IfColorSupported_b();
 
 #endif

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -149,6 +149,7 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_PalSetUI_b, 2},            // 0x66
     {Script_ActorStopUpdate_b, 0},     // 0x67
     {Script_ActorSetAnimate_b, 1},     // 0x68
+    {Script_IfColorSupported_b, 2},    // 0x69
 };
 
 void ScriptTimerUpdate_b() {
@@ -2261,4 +2262,10 @@ void Script_ActorStopUpdate_b() {
 
 void Script_ActorSetAnimate_b() {
   actors[active_script_ctx.script_actor].animate = script_cmd_args[0];
+}
+
+void Script_IfColorSupported_b() {
+  if (_cpu == CGB_TYPE) {
+    active_script_ctx.script_ptr = active_script_ctx.script_start_ptr + (script_cmd_args[0] * 256) + script_cmd_args[1];
+  }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -250,6 +250,7 @@
   "FIELD_PERSIST_BETWEEN_SCENES": "Persist Between Scenes",
   "FIELD_PERSIST_BETWEEN_SCENES_WARNING": "Note: Some events like projectiles and sprite sheet changes currently don't work when used in an input script that is persisted between scenes.",
   "FIELD_ALLOW_FASTFORWARD": "Fast forward text while buttons held",
+  "FIELD_IF_COLOR_SUPPORTED": "Run if the game is executing in a device that has color support.",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",
@@ -370,6 +371,7 @@
   "EVENT_PALETTE_SET_UI": "Palette: Set UI Palette",
   "EVENT_ACTOR_STOP_UPDATE": "Actor: Stop \"On Update\" Script",
   "EVENT_ACTOR_SET_ANIMATE": "Actor: Set Animate While Stationary",
+  "EVENT_IF_COLOR_SUPPORTED": "If Device Supports Color",
 
   "// 10": "Menu -----------------------------------------------------",
 

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -94,7 +94,8 @@ import {
   PALETTE_SET_ACTOR,
   PALETTE_SET_UI,
   ACTOR_STOP_UPDATE,
-  ACTOR_SET_ANIMATE
+  ACTOR_SET_ANIMATE,
+  IF_COLOR_SUPPORTED,
 } from "../events/scriptCommands";
 import {
   getActorIndex,
@@ -1178,6 +1179,18 @@ class ScriptBuilder {
     const output = this.output;
     output.push(cmd(TIMER_DISABLE));
   };
+
+  // Device
+
+  ifColorSupported = (truePath = [], falsePath = []) => {
+    const output = this.output;
+    output.push(cmd(IF_COLOR_SUPPORTED));
+    compileConditional(truePath, falsePath, {
+      ...this.options,
+      output,
+    });
+
+  }
 
   // Helpers
 

--- a/src/lib/events/eventIfColorSupported.js
+++ b/src/lib/events/eventIfColorSupported.js
@@ -1,0 +1,52 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_IF_COLOR_SUPPORTED";
+
+const fields = [
+  {
+    label: l10n("FIELD_IF_COLOR_SUPPORTED")
+  },
+  {
+    key: "true",
+    type: "events"
+  },
+  {
+    key: "__collapseElse",
+    label: l10n("FIELD_ELSE"),
+    type: "collapsable",
+    defaultValue: false,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ]
+  },
+  {
+    key: "false",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true
+      },
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ],
+    type: "events"
+  }
+];
+
+const compile = (input, helpers) => {
+  const { ifColorSupported } = helpers;
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+  ifColorSupported(truePath, falsePath);
+};
+
+module.exports = {
+  id,
+  fields,
+  compile
+};

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -103,6 +103,7 @@ export const PALETTE_SET_ACTOR = "PALETTE_SET_ACTOR";
 export const PALETTE_SET_UI = "PALETTE_SET_UI";
 export const ACTOR_STOP_UPDATE = "ACTOR_STOP_UPDATE";
 export const ACTOR_SET_ANIMATE = "ACTOR_SET_ANIMATE";
+export const IF_COLOR_SUPPORTED = "IF_COLOR_SUPPORTED";
 
 export const scriptCommands = [
   END,
@@ -209,7 +210,8 @@ export const scriptCommands = [
   PALETTE_SET_ACTOR,
   PALETTE_SET_UI,
   ACTOR_STOP_UPDATE,
-  ACTOR_SET_ANIMATE
+  ACTOR_SET_ANIMATE,
+  IF_COLOR_SUPPORTED,
 ];
 
 export const commandIndex = key => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature

* **What is the current behavior?** (You can also link to an open issue here)

Users can't differentiate if the device the game is running supports Color or not. Games with specific color features like animations using palette cycling look bad in non-color devices. Similarly for games that depend in 2xCPU as they'll run very slow in non-color devices.

* **What is the new behavior (if this is a feature change)?**

A new event that checks if the device supports color and runs scripts accordingly. 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/54246642/92656228-94be7400-f2ea-11ea-8912-e576d7ac8107.png">

<img src="https://user-images.githubusercontent.com/54246642/92655952-1f52a380-f2ea-11ea-8c9a-370092fcbc16.png" width=400/> <img src="https://user-images.githubusercontent.com/54246642/92655975-2a0d3880-f2ea-11ea-893f-a46d3e5752d2.png" width=400/>

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
