### PR TITLE
Fix crash when selecting property

### DIFF
--- a/src/components/forms/ScenePropertySelect.js
+++ b/src/components/forms/ScenePropertySelect.js
@@ -42,7 +42,7 @@ const Group = ({ label, actor, ...props }) => {
 };
 
 const GroupWithData = connect((state, ownProps) => {
-  const actorsLookup = getActorsLookup(state);
+  const actorsLookup = actorSelectors.selectEntities(state);
   const actorIds = getSceneActorIds(state, { id: state.editor.scene });
   const settings = getSettings(state);
   const playerSpriteSheetId = settings.playerSpriteSheetId;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

App shows blank page when trying to select an from the property dropdown (reported in #546)

* **What is the new behavior (if this is a feature change)?**

No crash :)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope

* **Other information**:
