### PR TITLE
Add Actor parenting

### DIFF
--- a/appData/src/gb/include/Actor.h
+++ b/appData/src/gb/include/Actor.h
@@ -55,6 +55,7 @@ typedef struct {
   BankPtr hit_2_ptr; // 39
   BankPtr hit_3_ptr; // 42  
   UBYTE movement_ctx; // 45
+  UBYTE parent_actor; // 46
 } Actor;
 
 typedef enum {

--- a/appData/src/gb/include/ParentedActors.h
+++ b/appData/src/gb/include/ParentedActors.h
@@ -1,0 +1,8 @@
+#ifndef PARENTED_ACTORS_H
+#define PARENTED_ACTORS_H
+
+#include <gb/gb.h>
+
+void PositionParentedActors();
+
+#endif

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -19,6 +19,7 @@
 #include "gbt_player.h"
 #include "data_ptrs.h"
 #include "main.h"
+#include "ParentedActors.h"
 
 UBYTE game_time;
 UINT16 next_state;
@@ -170,6 +171,7 @@ int core_start() {
 
     UpdateCamera();
     RefreshScroll_b();
+    PositionParentedActors();
     UpdateActors();
     UpdateProjectiles_b();
     UIOnInteract_b();

--- a/appData/src/gb/src/core/DataManager.c
+++ b/appData/src/gb/src/core/DataManager.c
@@ -13,6 +13,7 @@
 #include "UI.h"
 #include "Input.h"
 #include "data_ptrs.h"
+#include "ParentedActors.h"
 
 #define MAX_PLAYER_SPRITE_SIZE 24
 
@@ -260,11 +261,19 @@ void LoadScene(UINT16 index) {
     actors[i].hit_3_ptr.offset = *(data_ptr++) + (*(data_ptr++) * 256);
 
     actors[i].movement_ctx = 0;
+    actors[i].parent_actor = *(data_ptr++);
     actors[i].script_control = FALSE;
   }
 
   actors_active[0] = 0;
   actors_active_size = 1;
+  for (i = 1; i != actors_len; i++) {
+    if (actors[i].parent_actor != i) {
+      actors[i].start_pos.x = actors[i].pos.x - actors[actors[i].parent_actor].pos.x;
+      actors[i].start_pos.y = actors[i].pos.y - actors[actors[i].parent_actor].pos.y;
+    }
+  }
+  PositionParentedActors();
 
   // Load triggers
   for (i = 0; i != triggers_len; i++) {

--- a/appData/src/gb/src/core/DataManager.c
+++ b/appData/src/gb/src/core/DataManager.c
@@ -267,13 +267,14 @@ void LoadScene(UINT16 index) {
 
   actors_active[0] = 0;
   actors_active_size = 1;
+
+  // set actor start positions to relative position from parent (where applicable)
   for (i = 1; i != actors_len; i++) {
     if (actors[i].parent_actor != i) {
       actors[i].start_pos.x = actors[i].pos.x - actors[actors[i].parent_actor].pos.x;
       actors[i].start_pos.y = actors[i].pos.y - actors[actors[i].parent_actor].pos.y;
     }
   }
-  PositionParentedActors();
 
   // Load triggers
   for (i = 0; i != triggers_len; i++) {

--- a/appData/src/gb/src/core/ParentedActors.c
+++ b/appData/src/gb/src/core/ParentedActors.c
@@ -1,0 +1,25 @@
+
+#include "ParentedActors.h"
+#include "Actor.h"
+#include "DataManager.h"
+#include "data_ptrs.h"
+
+void PositionParentedActors() {
+	  // Linked sprite magic
+  for (UBYTE i = 1; i != actors_len; ++i) // loop through the actors
+  {
+	const UBYTE parent_actor = actors[i].parent_actor;
+	if (parent_actor != i) {
+		if (actors[i].sprite_index == 0 && actors[parent_actor].sprite_index != 0) {
+			ActivateActor(i);
+		}
+		actors[i].pos.x = actors[parent_actor].pos.x + actors[i].start_pos.x;
+		actors[i].pos.y = actors[parent_actor].pos.y + actors[i].start_pos.y;
+		actors[i].dir.x = actors[parent_actor].dir.x;
+		actors[i].dir.y = actors[parent_actor].dir.y;
+		actors[i].frame = actors[parent_actor].frame;
+		actors[i].enabled = parent_actor != 0 ? actors[parent_actor].enabled : TRUE;
+		actors[i].rerender = TRUE;
+	}
+  }
+}

--- a/appData/src/gb/src/core/ParentedActors.c
+++ b/appData/src/gb/src/core/ParentedActors.c
@@ -10,6 +10,7 @@ void PositionParentedActors() {
   {
 	const UBYTE parent_actor = actors[i].parent_actor;
 	if (parent_actor != i) {
+		// quick and dirty check if parent actor is active
 		if (actors[i].sprite_index == 0 && actors[parent_actor].sprite_index != 0) {
 			ActivateActor(i);
 		}

--- a/appData/src/gb/src/core/ParentedActors.c
+++ b/appData/src/gb/src/core/ParentedActors.c
@@ -18,9 +18,9 @@ void PositionParentedActors() {
 		actors[i].pos.y = actors[parent_actor].pos.y + actors[i].start_pos.y;
 		actors[i].dir.x = actors[parent_actor].dir.x;
 		actors[i].dir.y = actors[parent_actor].dir.y;
-		actors[i].frame = actors[parent_actor].frame;
+		actors[i].frame = actors[i].frames_len == actors[parent_actor].frames_len ? actors[parent_actor].frame : actors[i].frame;
 		actors[i].enabled = parent_actor != 0 ? actors[parent_actor].enabled : TRUE;
-		actors[i].rerender = TRUE;
+		actors[i].rerender = actors[parent_actor].rerender;
 	}
   }
 }

--- a/src/components/editors/ActorEditor.js
+++ b/src/components/editors/ActorEditor.js
@@ -32,6 +32,7 @@ import { actorSelectors, sceneSelectors, spriteSheetSelectors } from "../../stor
 import editorActions from "../../store/features/editor/editorActions";
 import clipboardActions from "../../store/features/clipboard/clipboardActions";
 import entitiesActions from "../../store/features/entities/entitiesActions";
+import ActorSelect from "../forms/ActorSelect";
 
 const defaultTabs = {
   interact: l10n("SIDEBAR_ON_INTERACT"),
@@ -445,6 +446,18 @@ class ActorEditor extends Component {
                 />
                 <div className="FormCheckbox" />
                 Pin to screen
+              </label>
+            </FormField>
+
+            <FormField>
+              <label htmlFor="actorParent">
+                <ActorSelect
+                  id="actorParent"
+                  value={actor.actorParent}
+                  //direction={argValue(args.direction)}
+                  //frame={argValue(args.frame)}
+                  onChange={this.onEdit("actorParent")}
+                />
               </label>
             </FormField>
 

--- a/src/components/editors/ActorEditor.js
+++ b/src/components/editors/ActorEditor.js
@@ -451,6 +451,7 @@ class ActorEditor extends Component {
 
             <FormField>
               <label htmlFor="actorParent">
+                Parent Actor
                 <ActorSelect
                   id="actorParent"
                   value={actor.actorParent}

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1207,7 +1207,6 @@ export const compileActors = (actors, { eventPtrs, movementPtrs, hit1Ptrs, hit2P
     return lookup;
   };
 
-
   return flatten(
     actors.map((actor, actorIndex) => {
       const sprite = sprites.find((s) => s.id === actor.spriteSheetId);
@@ -1217,6 +1216,11 @@ export const compileActors = (actors, { eventPtrs, movementPtrs, hit1Ptrs, hit2P
       const initialFrame =
         actor.spriteType === SPRITE_TYPE_STATIC ? actor.frame % actorFrames : 0;
       const collisionGroup = collisionGroupDec(actor.collisionGroup);
+      const actorParent = 
+        actor.actorParent === "player" ? 0 : actor.actorParent === "$self$" ? actorIndex + 1 : actors.findIndex(a => a.id === actor.actorParent) + 1;
+      const rel_x = actor.x - actors[actorParent].x;
+      const rel_y = actor.y - actors[actorParent].y;
+      console.log(rel_x, rel_y);
       return [
         getSpriteOffset(actor.spriteSheetId), // Sprite sheet id // Should be an offset index from map sprites not overall sprites
         actorPaletteIndexes[actor.id] || 0, // Offset into scene actor palettes
@@ -1243,7 +1247,8 @@ export const compileActors = (actors, { eventPtrs, movementPtrs, hit1Ptrs, hit2P
         hi(hit2Ptrs[actorIndex].offset),   
         hit3Ptrs[actorIndex].bank, // Hit collision group 3 bank ptr
         lo(hit3Ptrs[actorIndex].offset), // Hit collision group 3 offset ptr
-        hi(hit3Ptrs[actorIndex].offset)
+        hi(hit3Ptrs[actorIndex].offset),
+        actorParent
       ];
     })
   );

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1218,9 +1218,6 @@ export const compileActors = (actors, { eventPtrs, movementPtrs, hit1Ptrs, hit2P
       const collisionGroup = collisionGroupDec(actor.collisionGroup);
       const actorParent = 
         actor.actorParent === "player" ? 0 : actor.actorParent === "$self$" ? actorIndex + 1 : actors.findIndex(a => a.id === actor.actorParent) + 1;
-      const rel_x = actor.x - actors[actorParent].x;
-      const rel_y = actor.y - actors[actorParent].y;
-      console.log(rel_x, rel_y);
       return [
         getSpriteOffset(actor.spriteSheetId), // Sprite sheet id // Should be an offset index from map sprites not overall sprites
         actorPaletteIndexes[actor.id] || 0, // Offset into scene actor palettes


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature for setting a parent actor for a given actor, allowing them to move in unison.

* **What is the current behavior?** (You can also link to an open issue here)

Actors are entirely independent of each other, and there is no reliable means to 
make them move synchronously to simulate a larger sprite.

* **What is the new behavior (if this is a feature change)?**

Adds a "Parent" field to all actors, which, when set, will make that actor move
synchronously with the selected actor, maintaining its relative position as saved
in the editor. It also matches direction and animation frame.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Possibly, it will certainly invalidate ejected engines. A default value for the parent field
has not been explicitly configured, but it seems to default to self anyways, which will maintain
existing behavior.

* **Other information**:

Current implementation is entirely in C, and results in a noticeable slowdown in DMG (non-color) mode. I think this could be remedied by migrating it to assembly code, but currently that is just beyond the borders of my skill set.