### PR TITLE
Fix instant compile

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -666,6 +666,8 @@ export const precompileVariables = (scenes) => {
   for (let i = 0; i < 100; i++) {
     variables.push(String(i));
   }
+  variables.push(TMP_VAR_1);
+  variables.push(TMP_VAR_2);
 
   walkScenesEvents(scenes, (cmd) => {
     if (eventHasArg(cmd, "variable")) {
@@ -687,8 +689,6 @@ export const precompileVariables = (scenes) => {
       }
     }
   });
-  variables.push(TMP_VAR_1);
-  variables.push(TMP_VAR_2);
   return variables;
 };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Adding any new local variable will force the engine to recompile (60+Seconds), due to TMP_VAR_1 and 2 being indexed at the end of the list, modifying in Data_ptrs.h

* **What is the new behavior (if this is a feature change)?**
INSTANT COMPILES EVERYWHERE!
TMP_VAR_1 and 2 are now added to variable list after the first 100 global variables, so will always be var 101-102, never causing an update when new variables are added.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Can't see how.


* **Other information**:
Thanks a ton to @pau-tomas For some super sleuthing while investigating the issue,
![image](https://user-images.githubusercontent.com/34431457/93832352-8c424200-fcc9-11ea-8ae1-c11af74bcb04.png)

