### PR TITLE
Fix platformer direction change rerender

### DIFF
--- a/appData/src/gb/src/states/Platform.c
+++ b/appData/src/gb/src/states/Platform.c
@@ -125,6 +125,7 @@ void Update_Platform() {
         pl_vel_x -= WALK_ACC;
         pl_vel_x = CLAMP(pl_vel_x, -MAX_WALK_VEL, -MIN_WALK_VEL);
       }
+      player.rerender = TRUE;
     } else if (INPUT_RIGHT) {
       player.dir.x = 1;
       if (INPUT_A) {
@@ -134,6 +135,7 @@ void Update_Platform() {
         pl_vel_x += WALK_ACC;
         pl_vel_x = CLAMP(pl_vel_x, MIN_WALK_VEL, MAX_WALK_VEL);
       }
+      player.rerender = TRUE;
     } else if (grounded) {
       if (pl_vel_x < 0) {
         pl_vel_x += RELEASE_DEC;

--- a/appData/src/gb/src/states/Platform.c
+++ b/appData/src/gb/src/states/Platform.c
@@ -116,6 +116,7 @@ void Update_Platform() {
       player.dir.y = -1;
       player.rerender = TRUE;
     }
+ 
     if (INPUT_LEFT) {
       player.dir.x = -1;
       if (INPUT_A) {
@@ -124,8 +125,10 @@ void Update_Platform() {
       } else {
         pl_vel_x -= WALK_ACC;
         pl_vel_x = CLAMP(pl_vel_x, -MAX_WALK_VEL, -MIN_WALK_VEL);
+      } 
+      if (INPUT_LEFT_PRESSED) { // update player facing direction if button pressed this frame
+        player.rerender = TRUE;
       }
-      player.rerender = TRUE;
     } else if (INPUT_RIGHT) {
       player.dir.x = 1;
       if (INPUT_A) {
@@ -135,7 +138,9 @@ void Update_Platform() {
         pl_vel_x += WALK_ACC;
         pl_vel_x = CLAMP(pl_vel_x, MIN_WALK_VEL, MAX_WALK_VEL);
       }
-      player.rerender = TRUE;
+      if (INPUT_RIGHT_PRESSED) { // update player facing direction if button pressed this frame
+        player.rerender = TRUE;
+      }
     } else if (grounded) {
       if (pl_vel_x < 0) {
         pl_vel_x += RELEASE_DEC;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes a bug where the player in platformer mode would not update its facing direction until a few frames after reversing its direction of movement.

* **What is the current behavior?** (You can also link to an open issue here)

If you walk in a direction in platformer mode, then quickly switch to the other direction, you character will start moving in the new direction, but it will take a few frames for the sprite to change the direction it is facing. This is due to a missing player.rerender = TRUE in the left and right input sections of the script.

* **What is the new behavior (if this is a feature change)?**

The player sprite reverses direction immediately.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not that I can imagine

* **Other information**:
