### PR TITLE
Custom Event name incorrectly set on update

### DIFF
--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -292,7 +292,7 @@ const patchCustomEventCallArgs = (
     if (event.args.customEventId !== customEventId) {
       return event;
     }
-    const newArgs = Object.assign({ ...event.args, __name: name });
+    const newArgs = Object.assign({ ...event.args });
     Object.keys(newArgs).forEach((k) => {
       if (
         k.startsWith("$") &&

--- a/src/store/features/entities/entitiesTypes.ts
+++ b/src/store/features/entities/entitiesTypes.ts
@@ -8,7 +8,7 @@ export type ScriptEvent = {
   id: string;
   command: string;
   args: any;
-  children: Dictionary<ScriptEvent[]>;
+  children?: Dictionary<ScriptEvent[]>;
 };
 
 export type Actor = {

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -6,6 +6,7 @@ import {
   Actor,
   Trigger,
   Palette,
+  CustomEvent,
 } from "../src/store/features/entities/entitiesTypes";
 import { ProjectData } from "../src/store/features/project/projectActions";
 import { RootState } from "../src/store/configureStore";
@@ -98,6 +99,15 @@ export const dummyMusic: Music = {
   filename: "",
   _v: 0,
   settings: {}
+};
+
+export const dummyCustomEvent: CustomEvent = {
+  id: "",
+  name: "",
+  description: "",
+  variables: {},
+  actors: {},
+  script: [],
 };
 
 export const dummyProjectData: ProjectData = {

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -20,6 +20,7 @@ import {
   dummyActor,
   dummyTrigger,
   dummyPalette,
+  dummyCustomEvent,
 } from "../../../dummydata";
 import { DMG_PALETTE } from "../../../../src/consts";
 
@@ -1436,4 +1437,149 @@ test("Should be able to add custom event", () => {
   expect(
     newState.customEvents.entities[action.payload.customEventId]?.script
   ).toEqual([]);
+});
+
+test("Editing a custom event name should propagate to instances of the event", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          actors: [],
+          triggers: [],
+          script: [{
+            id: "customevent1",
+            command: "EVENT_CALL_CUSTOM_EVENT",
+            args: {
+              customEventId: "customevent1",
+              __name: "Previous Name"
+            }
+          }]
+        },
+      },
+      ids: ["scene1"],
+    },
+    customEvents: {
+      entities: {
+        customevent1: {
+          ...dummyCustomEvent,
+          id: "customevent1",
+          name: "Previous Name"
+        }
+      },
+      ids: ["customevent1"]
+    }
+  };
+
+  const action = actions.editCustomEvent({
+    customEventId: "customevent1",
+    changes: {
+      name: "New Name"
+    }
+  });
+
+  const newState = reducer(state, action);
+  expect(newState.customEvents.entities["customevent1"]?.name).toBe("New Name");
+  expect(newState.scenes.entities["scene1"]?.script?.[0]?.args?.__name).toBe("New Name");
+});
+
+test("Edits to custom event description should not affect event instance names", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          actors: [],
+          triggers: [],
+          script: [{
+            id: "customevent1",
+            command: "EVENT_CALL_CUSTOM_EVENT",
+            args: {
+              customEventId: "customevent1",
+              __name: "Event Name"
+            }
+          }]
+        },
+      },
+      ids: ["scene1"],
+    },
+    customEvents: {
+      entities: {
+        customevent1: {
+          ...dummyCustomEvent,
+          id: "customevent1",
+          name: "Event Name",
+          description: "Old Description"
+        }
+      },
+      ids: ["customevent1"]
+    }
+  };
+
+  const action = actions.editCustomEvent({
+    customEventId: "customevent1",
+    changes: {
+      description: "New Description"
+    }
+  });
+
+  const newState = reducer(state, action);
+  expect(newState.customEvents.entities["customevent1"]?.description).toBe("New Description");
+  expect(newState.scenes.entities["scene1"]?.script?.[0]?.args?.__name).toBe("Event Name");
+});
+
+test("Edits to custom event script should not affect event instance names", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          actors: [],
+          triggers: [],
+          script: [{
+            id: "customevent1",
+            command: "EVENT_CALL_CUSTOM_EVENT",
+            args: {
+              customEventId: "customevent1",
+              __name: "Event Name"
+            }
+          }]
+        },
+      },
+      ids: ["scene1"],
+    },
+    customEvents: {
+      entities: {
+        customevent1: {
+          ...dummyCustomEvent,
+          id: "customevent1",
+          name: "Event Name",
+          description: "Old Description"
+        }
+      },
+      ids: ["customevent1"]
+    }
+  };
+
+  const action = actions.editCustomEvent({
+    customEventId: "customevent1",
+    changes: {
+      script: [{
+        id: "event66",
+        command: "EVENT_TEXT",
+        args: {
+          text: "Hello there"
+        }
+      }]
+    }
+  });
+
+  const newState = reducer(state, action);
+  expect(newState.scenes.entities["scene1"]?.script?.[0]?.args?.__name).toBe("Event Name");
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Very small fix for #563

* **What is the current behavior?** (You can also link to an open issue here)

Custom Event instances name changes to `EVENT_CALL_CUSTOM_EVENT` when editing the event

* **What is the new behavior (if this is a feature change)?**

Custom Events keep their name

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No