### PR TITLE
Fix/559

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix DE localisation
+- Fix issue where changing a scene's background image would not update the scene's dimensions until the project was reloaded.
 
 ## [2.0.0-beta2]
 

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -638,6 +638,9 @@ const editScene: CaseReducer<
         }
       }
 
+      patch.width = background.width;
+      patch.height = background.height;
+
       scene.actors.forEach((actorId) => {
         const actor = actors[actorId];
         if (actor) {

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -520,6 +520,56 @@ test("Should use collisions and colors from other scene if switched to use same 
   expect(newState.scenes.entities["scene2"]?.tileColors).toEqual([4, 5, 6]);
 });
 
+test("Should update scene dimensions to match new background", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          backgroundId: "bg1",
+          width: 20,
+          height: 18,
+          actors: [],
+          triggers: [],
+          collisions: [1, 2, 3],
+          tileColors: [4, 5, 6],
+        },
+      },
+      ids: ["scene1"],
+    },
+    backgrounds: {
+      entities: {
+        bg1: {
+          ...dummyBackground,
+          id: "bg1",
+          width: 20,
+          height: 18
+        },
+        bg2: {
+          ...dummyBackground,
+          id: "bg2",
+          width: 32,
+          height: 28
+        },
+      },
+      ids: ["bg1", "bg2"],
+    },
+  };
+
+  const action = actions.editScene({
+    sceneId: "scene1",
+    changes: {
+      backgroundId: "bg2",
+    },
+  });
+
+  const newState = reducer(state, action);
+  expect(newState.scenes.entities["scene1"]?.width).toEqual(32);
+  expect(newState.scenes.entities["scene1"]?.height).toEqual(28);
+});
+
 test("Should keep collisions but discard colors if switched to use different background of same width", () => {
   const state: EntitiesState = {
     ...initialState,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for #559 and #558 which I believe are the same issue

* **What is the current behavior?** (You can also link to an open issue here)
Since 2.0.0-beta2 changing the background image of a scene to an image with a different size does not update the stored width and height of the scene causing two issues

1. You're unable to drag actors/triggers outside of the previous scene bounds (as seen in #559)
2. When you open the project again the application detects the stored scene size is incorrect and resets the collisions/color values

On reloading a project the values are fixed again until the next image change.

* **What is the new behavior (if this is a feature change)?**
Switching the background image correctly resets the scene dimensions matching 2.0.0-beta1 and previous versions. Also included a test to make sure this shouldn't happen again.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Oh man, I guess I need to release beta3 sooner than I thought.