### PR TITLE
Fix for 567, keep event/plugin data as VM2 proxy

### DIFF
--- a/src/components/script/ScriptEditor.js
+++ b/src/components/script/ScriptEditor.js
@@ -148,14 +148,14 @@ class ScriptEditor extends Component {
     const input = prependEvent(
       root,
       id,
-      {
+      JSON.parse(JSON.stringify({
         id: uuid(),
           command,
           args: defaultArgs,
         ...childFields.length > 0 && {
           children
         }
-      }
+      }))
     );
     this.onChange(input);
   };

--- a/src/lib/events/index.js
+++ b/src/lib/events/index.js
@@ -38,10 +38,6 @@ const eventHandlers = {
     if (!handler.id) {
       throw new Error(`Event handler ${path} is missing id`);
     }
-    if (handler.fields) {
-      // Convert fields from proxy to plain javascript object
-      handler.fields = JSON.parse(JSON.stringify(handler.fields));
-    }
     return {
       ...memo,
       [handler.id]: handler

--- a/src/lib/plugins/plugins.js
+++ b/src/lib/plugins/plugins.js
@@ -67,10 +67,6 @@ const plugins = {
       return memo;
     }
     pluginEventFilepaths[path] = plugin.id;
-    if (plugin.fields) {
-      // Convert fields from proxy to plain javascript object
-      plugin.fields = JSON.parse(JSON.stringify(plugin.fields));
-    }    
     return {
       ...memo,
       [plugin.id]: plugin


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for #567 where javascript functions in events would no longer call due to a previous change in 84a836f9cf5585c804f7e2397f2f75944e88f711

* **What is the current behavior?** (You can also link to an open issue here)
Events have the option of hooking in javascript functions for some functionality (e.g. the updateFn used in text events to limit the amount of text displayed total and per line). Since 84a836f9cf5585c804f7e2397f2f75944e88f711 (including the Beta 3 release) this functionality is broken.

* **What is the new behavior (if this is a feature change)?**
Reverts the previous change in 84a836f9cf5585c804f7e2397f2f75944e88f711 and restores this functionality by moving where the conversion from a VM2 proxied object happens so that the functions are not converted to JSON and back.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Maybe, although the previous fix in 84a836f9cf5585c804f7e2397f2f75944e88f711 was only for development builds so prod builds should be fixed by this.
