### PR TITLE
Reduce GBSProj file size using Nano ID and zlib for tile data

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "image-size": "^0.7.1",
     "json-loader": "^0.5.7",
     "lodash": "^4.17.14",
+    "nanoid": "^3.1.12",
     "normalizr": "^3.4.0",
     "prop-types": "^15.7.2",
     "raw-loader": "^4.0.0",
@@ -79,7 +80,6 @@
     "rimraf": "^2.6.3",
     "semver": "7",
     "ts-flood-fill": "^1.0.2",
-    "uuid": "^3.3.2",
     "vm2": "3.9.2"
   },
   "devDependencies": {
@@ -98,7 +98,6 @@
     "@types/react": "^16.9.14",
     "@types/react-dom": "^16.9.4",
     "@types/rimraf": "^2.0.3",
-    "@types/uuid": "^3.4.6",
     "@types/webpack-env": "^1.14.1",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",

--- a/src/bin/gb-studio-cli.ts
+++ b/src/bin/gb-studio-cli.ts
@@ -1,8 +1,8 @@
 import { readFile, copy } from "fs-extra";
 import buildProject from "../lib/compiler/buildProject";
 import Path from "path";
-import uuid from "uuid";
 import os from "os";
+import makeId from "../lib/helpers/makeId";
 
 const usage = () => {
     console.log("usage: gb-studio-cli <command> [<args>]");
@@ -15,7 +15,7 @@ const usage = () => {
 
 const compile = async (projectFile: string, buildType: string = "rom") => {
     console.log(projectFile);
-    const buildUUID = uuid();
+    const buildUUID = makeId();
     const projectRoot = Path.resolve(Path.dirname(projectFile));
     const project = JSON.parse(await readFile(projectFile, "utf8"));
     const outputRoot = process.env.GBS_OUTPUT_ROOT || Path.normalize(`${os.tmpdir()}/${buildUUID}`);

--- a/src/components/script/ScriptEditor.js
+++ b/src/components/script/ScriptEditor.js
@@ -2,7 +2,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import uuid from "uuid/v4";
 import debounce from "lodash/debounce";
 import {
   EVENT_END
@@ -21,6 +20,7 @@ import l10n from "../../lib/helpers/l10n";
 import { sceneSelectors, spriteSheetSelectors, musicSelectors } from "../../store/features/entities/entitiesState";
 import editorActions from "../../store/features/editor/editorActions";
 import clipboardActions from "../../store/features/clipboard/clipboardActions";
+import makeId from "../../lib/helpers/makeId";
 
 class ScriptEditor extends Component {
 
@@ -135,7 +135,7 @@ class ScriptEditor extends Component {
         ? defaultChildren[field.key]
         : [
             {
-              id: uuid(),
+              id: makeId(),
               command: EVENT_END
             }
           ];
@@ -149,7 +149,7 @@ class ScriptEditor extends Component {
       root,
       id,
       JSON.parse(JSON.stringify({
-        id: uuid(),
+        id: makeId(),
           command,
           args: defaultArgs,
         ...childFields.length > 0 && {
@@ -264,7 +264,7 @@ ScriptEditor.defaultProps = Object.create(
       enumerable: true,
       get: () => [
         {
-          id: uuid(),
+          id: makeId(),
           command: EVENT_END
         }
       ]

--- a/src/components/script/ScriptEditorDropdownButton.js
+++ b/src/components/script/ScriptEditorDropdownButton.js
@@ -3,13 +3,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { clipboard } from "electron";
 import { connect } from "react-redux";
-import uuid from "uuid/v4";
 import { EVENT_END } from "../../lib/compiler/eventTypes";
 import { regenerateEventIds } from "../../lib/helpers/eventSystem";
 import { DropdownButton } from "../library/Button";
 import { MenuItem, MenuDivider } from "../library/Menu";
 import l10n from "../../lib/helpers/l10n";
 import clipboardActions from "../../store/features/clipboard/clipboardActions";
+import makeId from "../../lib/helpers/makeId";
 
 class ScriptEditorDropdownButton extends Component {
   constructor() {
@@ -41,7 +41,7 @@ class ScriptEditorDropdownButton extends Component {
   onRemoveScript = (e) => {
     this.onChange([
       {
-        id: uuid(),
+        id: makeId(),
         command: EVENT_END,
       },
     ]);
@@ -58,7 +58,7 @@ class ScriptEditorDropdownButton extends Component {
             clipboardEvent,
             !Array.isArray(clipboardEvent)
               ? {
-                  id: uuid(),
+                  id: makeId(),
                   command: EVENT_END,
                 }
               : []
@@ -150,7 +150,7 @@ ScriptEditorDropdownButton.defaultProps = Object.create(
       enumerable: true,
       get: () => [
         {
-          id: uuid(),
+          id: makeId(),
           command: EVENT_END,
         },
       ],

--- a/src/components/script/ScriptEditorEvent.js
+++ b/src/components/script/ScriptEditorEvent.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { clipboard } from "electron";
 import cx from "classnames";
-import uuid from "uuid/v4";
 import { DragSource, DropTarget } from "react-dnd";
 import { TriangleIcon } from "../library/Icons";
 import AddCommandButton from "./AddCommandButton";
@@ -18,6 +17,7 @@ import { MenuItem, MenuDivider } from "../library/Menu";
 import l10n from "../../lib/helpers/l10n";
 import { EventShape } from "../../store/stateShape";
 import events from "../../lib/events";
+import makeId from "../../lib/helpers/makeId";
 
 const COMMENT_PREFIX = "//";
 
@@ -367,7 +367,7 @@ class ScriptEditorEvent extends Component {
                     {(
                       action.children[key] || [
                         {
-                          id: uuid(),
+                          id: makeId(),
                           command: EVENT_END
                         }
                       ]

--- a/src/lib/helpers/compression.ts
+++ b/src/lib/helpers/compression.ts
@@ -1,0 +1,74 @@
+import { promisify } from "util";
+import { deflate, unzip } from "zlib";
+import { SceneData } from "../../store/features/entities/entitiesTypes";
+import { ProjectData } from "../../store/features/project/projectActions";
+
+const deflateAsync = promisify(deflate);
+const unzipAsync = promisify(unzip);
+
+export type CompressedSceneData = Omit<
+  SceneData,
+  "collisions" | "tileColors"
+> & {
+  collisions: string;
+  tileColors: string;
+};
+
+export type CompressedProjectData = Omit<ProjectData, "scenes"> & {
+  scenes: CompressedSceneData[];
+};
+
+export const compress = async (data: number[]): Promise<string> => {
+  return deflateAsync(Buffer.from(data)).then((buffer) =>
+    (buffer as Buffer).toString("base64")
+  );
+};
+
+export const decompress = async (data: string): Promise<number[]> => {
+  if (!data) {
+    return [];
+  }
+  if (Array.isArray(data)) {
+    return (data as unknown) as number[];
+  }
+  return unzipAsync(Buffer.from(data, "base64"))
+    .then((buf) => Array.from(buf as Buffer))
+    .catch((error) => {
+      console.log(error);
+      return [];
+    });
+};
+
+export const compressProject = async (
+  project: ProjectData
+): Promise<CompressedProjectData> => {
+  return {
+    ...project,
+    scenes: await Promise.all(
+      project.scenes.map(async (scene) => {
+        return {
+          ...scene,
+          collisions: await compress(scene.collisions || []),
+          tileColors: await compress(scene.tileColors || []),
+        };
+      })
+    ),
+  };
+};
+
+export const decompressProject = async (
+  project: CompressedProjectData
+): Promise<ProjectData> => {
+  return {
+    ...project,
+    scenes: await Promise.all(
+      project.scenes.map(async (scene) => {
+        return {
+          ...scene,
+          collisions: await decompress(scene.collisions),
+          tileColors: await decompress(scene.tileColors),
+        };
+      })
+    ),
+  };
+};

--- a/src/lib/helpers/eventSystem.js
+++ b/src/lib/helpers/eventSystem.js
@@ -1,5 +1,5 @@
-import uuid from "uuid/v4";
 import { EVENT_CALL_CUSTOM_EVENT } from "../compiler/eventTypes";
+import makeId from "./makeId";
 
 const mapValues = (obj, fn) =>
   Object.entries(obj).reduce((memo, [key, value]) => {
@@ -278,7 +278,7 @@ const regenerateEventIds = event => {
     {},
     event,
     {
-      id: uuid(),
+      id: makeId(),
       __type: undefined,
       __customEvents: undefined
     },

--- a/src/lib/helpers/makeId.ts
+++ b/src/lib/helpers/makeId.ts
@@ -1,0 +1,14 @@
+import { nanoid } from "nanoid";
+
+// Id length set as a trade off in size/collision probability
+// Using probability calculator at
+// https://zelark.github.io/nano-id-cc/
+// this length allows making a project around the size of the
+// sample project every hour for ~3 million years before there
+// is a 1% chance of a single collision
+
+const ID_LENGTH = 16;
+
+const makeId = () => nanoid(ID_LENGTH)
+
+export default makeId;

--- a/src/lib/movement/generateRandomLookScript.ts
+++ b/src/lib/movement/generateRandomLookScript.ts
@@ -1,16 +1,16 @@
-import uuid from "uuid/v4";
+import makeId from "../helpers/makeId";
 
 const generateRandomLookScript = () => {
   return [
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_WAIT",
       args: {
         time: 1,
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_VARIABLE_MATH",
       args: {
         vectorX: "T0",
@@ -23,7 +23,7 @@ const generateRandomLookScript = () => {
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_SWITCH",
       args: {
         variable: "T0",
@@ -65,7 +65,7 @@ const generateRandomLookScript = () => {
       children: {
         true0: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_SET_DIRECTION",
             args: {
               actorId: "$self$",
@@ -76,13 +76,13 @@ const generateRandomLookScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true1: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_SET_DIRECTION",
             args: {
               actorId: "$self$",
@@ -93,13 +93,13 @@ const generateRandomLookScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true2: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_SET_DIRECTION",
             args: {
               actorId: "$self$",
@@ -110,13 +110,13 @@ const generateRandomLookScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true3: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_SET_DIRECTION",
             args: {
               actorId: "$self$",
@@ -127,99 +127,99 @@ const generateRandomLookScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true4: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true5: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true6: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true7: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true8: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true9: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true10: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true11: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true12: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true13: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true14: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true15: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         false: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_WAIT",
             args: {
               time: 0.5,
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_END",
     },
   ];

--- a/src/lib/movement/generateRandomWalkScript.ts
+++ b/src/lib/movement/generateRandomWalkScript.ts
@@ -1,16 +1,16 @@
-import uuid from "uuid/v4";
+import makeId from "../helpers/makeId";
 
 const generateRandomWalkScript = () => {
   return [
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_WAIT",
       args: {
         time: 1,
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_VARIABLE_MATH",
       args: {
         vectorX: "T0",
@@ -23,7 +23,7 @@ const generateRandomWalkScript = () => {
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_SWITCH",
       args: {
         variable: "T0",
@@ -65,7 +65,7 @@ const generateRandomWalkScript = () => {
       children: {
         true0: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_MOVE_RELATIVE",
             args: {
               actorId: "$self$",
@@ -77,13 +77,13 @@ const generateRandomWalkScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true1: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_MOVE_RELATIVE",
             args: {
               actorId: "$self$",
@@ -95,13 +95,13 @@ const generateRandomWalkScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true2: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_MOVE_RELATIVE",
             args: {
               actorId: "$self$",
@@ -113,13 +113,13 @@ const generateRandomWalkScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true3: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_ACTOR_MOVE_RELATIVE",
             args: {
               actorId: "$self$",
@@ -131,99 +131,99 @@ const generateRandomWalkScript = () => {
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true4: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true5: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true6: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true7: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true8: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true9: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true10: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true11: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true12: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true13: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true14: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         true15: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
         false: [
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_WAIT",
             args: {
               time: 0.5,
             },
           },
           {
-            id: uuid(),
+            id: makeId(),
             command: "EVENT_END",
           },
         ],
       },
     },
     {
-      id: uuid(),
+      id: makeId(),
       command: "EVENT_END",
     },
   ];

--- a/src/lib/project/loadBackgroundData.js
+++ b/src/lib/project/loadBackgroundData.js
@@ -1,8 +1,8 @@
 import glob from "glob";
 import { promisify } from "util";
-import uuid from "uuid/v4";
 import sizeOf from "image-size";
 import parseAssetPath from "../helpers/path/parseAssetPath";
+import makeId from "../helpers/makeId";
 
 const TILE_SIZE = 8;
 
@@ -14,7 +14,7 @@ const loadBackgroundData = projectRoot => async filename => {
   try {
     const size = await sizeOfAsync(filename);
     return {
-      id: uuid(),
+      id: makeId(),
       plugin,
       name: file.replace(/.png/i, ""),
       width: Math.min(Math.floor(size.width / TILE_SIZE), 255),

--- a/src/lib/project/loadMusicData.js
+++ b/src/lib/project/loadMusicData.js
@@ -1,6 +1,6 @@
 import glob from "glob";
 import { promisify } from "util";
-import uuidv4 from "uuid/v4";
+import makeId from "../helpers/makeId";
 import parseAssetPath from "../helpers/path/parseAssetPath";
 
 const globAsync = promisify(glob);
@@ -9,7 +9,7 @@ const loadMusicData = projectRoot => async filename => {
   const { file, plugin } = parseAssetPath(filename, projectRoot, "music");
 
   return {
-    id: uuidv4(),
+    id: makeId(),
     plugin,
     name: file.replace(/.mod/i, ""),
     filename: file,

--- a/src/lib/project/loadProjectData.js
+++ b/src/lib/project/loadProjectData.js
@@ -1,11 +1,11 @@
 import fs from "fs-extra";
 import path from "path";
-import uuid from "uuid/v4";
 import loadAllBackgroundData from "./loadBackgroundData";
 import loadAllSpriteData from "./loadSpriteData";
 import loadAllMusicData from "./loadMusicData";
 import migrateProject from "./migrateProject";
 import { indexByFn } from "../helpers/array";
+import makeId from "../helpers/makeId";
 
 const elemKey = (elem) => {
   return (elem.plugin ? `${elem.plugin}/` : "") + elem.filename;
@@ -91,7 +91,7 @@ const loadProject = async (projectPath) => {
     if (!entity.id) {
       return {
         ...entity,
-        id: uuid(),
+        id: makeId(),
       };
     }
     return entity;

--- a/src/lib/project/loadProjectData.js
+++ b/src/lib/project/loadProjectData.js
@@ -6,6 +6,7 @@ import loadAllMusicData from "./loadMusicData";
 import migrateProject from "./migrateProject";
 import { indexByFn } from "../helpers/array";
 import makeId from "../helpers/makeId";
+import { decompressProject } from "../helpers/compression";
 
 const elemKey = (elem) => {
   return (elem.plugin ? `${elem.plugin}/` : "") + elem.filename;
@@ -26,7 +27,9 @@ const sortByName = (a, b) => {
 };
 
 const loadProject = async (projectPath) => {
-  const json = migrateProject(await fs.readJson(projectPath));
+  const json = migrateProject(
+    await decompressProject(await fs.readJson(projectPath))
+  );
 
   const projectRoot = path.dirname(projectPath);
 

--- a/src/lib/project/loadSpriteData.js
+++ b/src/lib/project/loadSpriteData.js
@@ -1,9 +1,9 @@
 import glob from "glob";
 import { promisify } from "util";
-import uuidv4 from "uuid/v4";
 import sizeOf from "image-size";
 import parseAssetPath from "../helpers/path/parseAssetPath";
 import { spriteTypeFromNumFrames } from "../helpers/gbstudio";
+import makeId from "../helpers/makeId";
 
 const FRAME_SIZE = 16;
 
@@ -17,7 +17,7 @@ const loadSpriteData = projectRoot => async filename => {
     const numFrames = size.width / FRAME_SIZE;
 
     return {
-      id: uuidv4(),
+      id: makeId(),
       plugin,
       name: file.replace(/.png/i, ""),
       numFrames,

--- a/src/lib/project/saveAsProjectData.ts
+++ b/src/lib/project/saveAsProjectData.ts
@@ -1,8 +1,9 @@
 import Path from "path";
 import { copy, move } from "fs-extra";
 import {writeFileAndFlushAsync} from "../helpers/fs/writeFileAndFlush";
+import { CompressedProjectData } from "../helpers/compression";
 
-const saveAsProjectData = async (projectPath, newProjectPath, project) => {
+const saveAsProjectData = async (projectPath: string, newProjectPath: string, project: CompressedProjectData) => {
     await copy(Path.join(Path.dirname(projectPath), "assets"), Path.join(Path.dirname(newProjectPath), "assets"));
     await copy(projectPath, newProjectPath);
     await writeFileAndFlushAsync(newProjectPath, JSON.stringify(project, null, 4));

--- a/src/lib/project/saveProjectData.ts
+++ b/src/lib/project/saveProjectData.ts
@@ -1,6 +1,7 @@
+import { CompressedProjectData, compressProject } from "../helpers/compression";
 import { writeFileWithBackupAsync } from "../helpers/fs/writeFileWithBackup";
 
-const saveProjectData = async (projectPath, project) => {
+const saveProjectData = async (projectPath: string, project: CompressedProjectData) => {
   await writeFileWithBackupAsync(projectPath, JSON.stringify(project, null, 4));
 };
 

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -33,7 +33,6 @@ import {
 import clamp from "../../../lib/helpers/clamp";
 import { RootState } from "../../configureStore";
 import settingsActions from "../settings/settingsActions";
-import uuid from "uuid";
 import {
   replaceInvalidCustomEventVariables,
   replaceInvalidCustomEventActors,
@@ -64,6 +63,7 @@ import {
   MusicSettings,
 } from "./entitiesTypes";
 import { normalizeEntities } from "./entitiesHelpers";
+import makeId from "../../../lib/helpers/makeId";
 
 const MIN_SCENE_X = 60;
 const MIN_SCENE_Y = 30;
@@ -566,7 +566,7 @@ const addScene: CaseReducer<
     for (let actor of action.payload.defaults.actors) {
       addActorToScene(state, fixedScene, {
         ...actor,
-        id: uuid(),
+        id: makeId(),
       });
     }
   }
@@ -575,7 +575,7 @@ const addScene: CaseReducer<
     for (let trigger of action.payload.defaults.triggers) {
       addTriggerToScene(state, fixedScene, {
         ...trigger,
-        id: uuid(),
+        id: makeId(),
       });
     }
   }
@@ -1806,7 +1806,7 @@ const entitiesSlice = createSlice({
         return {
           payload: {
             ...payload,
-            sceneId: uuid(),
+            sceneId: makeId(),
           },
         };
       },
@@ -1834,7 +1834,7 @@ const entitiesSlice = createSlice({
         return {
           payload: {
             ...payload,
-            actorId: uuid(),
+            actorId: makeId(),
           },
         };
       },
@@ -1863,7 +1863,7 @@ const entitiesSlice = createSlice({
         return {
           payload: {
             ...payload,
-            triggerId: uuid(),
+            triggerId: makeId(),
           },
         };
       },
@@ -1891,7 +1891,7 @@ const entitiesSlice = createSlice({
       prepare: () => {
         return {
           payload: {
-            paletteId: uuid(),
+            paletteId: makeId(),
           },
         };
       },
@@ -1908,7 +1908,7 @@ const entitiesSlice = createSlice({
       prepare: () => {
         return {
           payload: {
-            customEventId: uuid(),
+            customEventId: makeId(),
           },
         };
       },

--- a/src/store/features/project/projectActions.ts
+++ b/src/store/features/project/projectActions.ts
@@ -10,6 +10,7 @@ import {
   Trigger,
   CustomEvent,
   EntitiesState,
+  SceneData,
 } from "../entities/entitiesTypes";
 import { RootState } from "../../configureStore";
 import loadProjectData from "../../../lib/project/loadProjectData";
@@ -22,6 +23,7 @@ import { SettingsState } from "../settings/settingsState";
 import { MetadataState } from "../metadata/metadataState";
 import parseAssetPath from "../../../lib/helpers/path/parseAssetPath";
 import { denormalizeEntities } from "../entities/entitiesHelpers";
+import { compressProject } from "../../../lib/helpers/compression";
 
 let saving: boolean = false;
 
@@ -39,11 +41,6 @@ export type ProjectData = {
   music: Music[];
   variables: Variable[];
   settings: SettingsState;
-};
-
-type SceneData = Omit<Scene, "actors" | "triggers"> & {
-  actors: Actor[];
-  triggers: Trigger[];
 };
 
 export const denormalizeProject = (project: {
@@ -218,7 +215,7 @@ const saveProject = createAsyncThunk<void, string | undefined>(
     try {
       const normalizedProject = denormalizeProject(state.project.present);
 
-      const data = {
+      const data = await compressProject({
         ...normalizedProject,
         settings: {
           ...normalizedProject.settings,
@@ -226,7 +223,7 @@ const saveProject = createAsyncThunk<void, string | undefined>(
           worldScrollX: state.editor.worldScrollX,
           worldScrollY: state.editor.worldScrollY,
         },
-      };
+      });
 
       if (newPath) {
         // Save As

--- a/yarn.lock
+++ b/yarn.lock
@@ -6509,6 +6509,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is an experimental change to reduce the file size of the GBSProj format.

* **What is the current behavior?** (You can also link to an open issue here)
Unique ids are stored as UUID v4 values and raw tile data is stored uncompressed in JSON

* **What is the new behavior (if this is a feature change)?**
- All 36 byte UUIDs (given to every actor/scene/trigger/asset/event/etc) are replaced with 16 byte [Nano IDs](https://zelark.github.io/nano-id-cc/) which should allow someone to make a project the same size as the sample project every hour for 3 million years (dedication!) before they have a 1% chance of an id collision. This cuts all ids sizes down by over 50%.

- All collision and tile color data has been compressed using [zlib](https://nodejs.org/api/zlib.html) and stored as a base64 encoded string rather than a raw byte array in the JSON data. This gives a huge saving on the storage of these values e.g. the collisions in Sample Town from the sample project go from 60775 bytes down to 355 bytes (!!) and overall halves the file size of the sample project (1.2Mb to 591Kb).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It shouldn't, the compression happens just before saving and the decompression happens immediately after loading so very little code is touched in the change. Opening a project that isn't compressed falls back gracefully so you can still open the project but it will be compressed on next save.

If anyone was editing the GBSProj collison/tile data manually (maybe as part of some custom tools) they will need to first convert the stored base64 strings to a buffer and then uncompress them with zlib to get the previous format, and reverse this process before saving. 

Nano ids will only be used for newly created entities and can be used alongside the existing UUIDs in a project with no issues.

* **Other information**:
While there doesn't seem to be any issues with this update I'm absolutely not going to include it until at least a 2.1 release. The format once migrated will not be usable by older versions so I'd rather concentrate on getting 2.0 as stable as possible before introducing a change like this.