### PR TITLE
Allow renaming project assets while preserving id

### DIFF
--- a/src/lib/helpers/clone.ts
+++ b/src/lib/helpers/clone.ts
@@ -1,0 +1,3 @@
+export const clone = <T>(input:T): T => {
+    return JSON.parse(JSON.stringify(input));
+}

--- a/src/lib/project/loadBackgroundData.js
+++ b/src/lib/project/loadBackgroundData.js
@@ -2,6 +2,7 @@ import glob from "glob";
 import { promisify } from "util";
 import uuid from "uuid/v4";
 import sizeOf from "image-size";
+import { stat } from "fs-extra";
 import parseAssetPath from "../helpers/path/parseAssetPath";
 
 const TILE_SIZE = 8;
@@ -13,6 +14,8 @@ const loadBackgroundData = projectRoot => async filename => {
   const { file, plugin } = parseAssetPath(filename, projectRoot, "backgrounds");
   try {
     const size = await sizeOfAsync(filename);
+    const fileStat = await stat(filename, { bigint: true });
+    const inode = fileStat.ino.toString();
     return {
       id: uuid(),
       plugin,
@@ -22,6 +25,7 @@ const loadBackgroundData = projectRoot => async filename => {
       imageWidth: size.width,
       imageHeight: size.height,
       filename: file,
+      inode,
       _v: Date.now()
     };
   } catch (e) {

--- a/src/lib/project/loadMusicData.js
+++ b/src/lib/project/loadMusicData.js
@@ -1,19 +1,22 @@
 import glob from "glob";
 import { promisify } from "util";
 import uuidv4 from "uuid/v4";
+import { stat } from "fs-extra";
 import parseAssetPath from "../helpers/path/parseAssetPath";
 
 const globAsync = promisify(glob);
 
 const loadMusicData = projectRoot => async filename => {
   const { file, plugin } = parseAssetPath(filename, projectRoot, "music");
-
+  const fileStat = await stat(filename, { bigint: true });
+  const inode = fileStat.ino.toString();
   return {
     id: uuidv4(),
     plugin,
     name: file.replace(/.mod/i, ""),
     filename: file,
     settings: {},
+    inode,
     _v: Date.now()
   };
 };

--- a/src/lib/project/loadProjectData.js
+++ b/src/lib/project/loadProjectData.js
@@ -5,13 +5,14 @@ import loadAllBackgroundData from "./loadBackgroundData";
 import loadAllSpriteData from "./loadSpriteData";
 import loadAllMusicData from "./loadMusicData";
 import migrateProject from "./migrateProject";
-import { indexByFn } from "../helpers/array";
+import { indexByFn, indexBy } from "../helpers/array";
 
 const elemKey = (elem) => {
   return (elem.plugin ? `${elem.plugin}/` : "") + elem.filename;
 };
 
 const indexByFilename = indexByFn(elemKey);
+const indexByInode = indexBy("inode");
 
 const sortByName = (a, b) => {
   const aName = a.name.toUpperCase();
@@ -38,10 +39,11 @@ const loadProject = async (projectPath) => {
 
   // Merge stored backgrounds data with file system data
   const oldBackgroundByFilename = indexByFilename(json.backgrounds || []);
+  const oldBackgroundByInode = indexByInode(json.backgrounds || []);
 
   const fixedBackgroundIds = backgrounds
     .map((background) => {
-      const oldBackground = oldBackgroundByFilename[elemKey(background)];
+      const oldBackground = oldBackgroundByFilename[elemKey(background)] || oldBackgroundByInode[background.inode];
       if (oldBackground) {
         return {
           ...background,
@@ -54,10 +56,11 @@ const loadProject = async (projectPath) => {
 
   // Merge stored sprite data with file system data
   const oldSpriteByFilename = indexByFilename(json.spriteSheets || []);
+  const oldSpriteByInode = indexByInode(json.spriteSheets || []);
 
   const fixedSpriteIds = sprites
     .map((sprite) => {
-      const oldSprite = oldSpriteByFilename[elemKey(sprite)];
+      const oldSprite = oldSpriteByFilename[elemKey(sprite)] || oldSpriteByInode[sprite.inode];
       if (oldSprite) {
         return {
           ...sprite,
@@ -70,10 +73,11 @@ const loadProject = async (projectPath) => {
 
   // Merge stored music data with file system data
   const oldMusicByFilename = indexByFilename(json.music || []);
+  const oldMusicByInode = indexByInode(json.music || []);
 
   const fixedMusicIds = music
     .map((track) => {
-      const oldTrack = oldMusicByFilename[elemKey(track)];
+      const oldTrack = oldMusicByFilename[elemKey(track)] || oldMusicByInode[track.inode];
       if (oldTrack) {
         return {
           ...track,

--- a/src/lib/project/loadSpriteData.js
+++ b/src/lib/project/loadSpriteData.js
@@ -2,6 +2,7 @@ import glob from "glob";
 import { promisify } from "util";
 import uuidv4 from "uuid/v4";
 import sizeOf from "image-size";
+import { stat } from "fs-extra";
 import parseAssetPath from "../helpers/path/parseAssetPath";
 import { spriteTypeFromNumFrames } from "../helpers/gbstudio";
 
@@ -14,8 +15,9 @@ const loadSpriteData = projectRoot => async filename => {
   const { file, plugin } = parseAssetPath(filename, projectRoot, "sprites");
   try {
     const size = await sizeOfAsync(filename);
+    const fileStat = await stat(filename, { bigint: true });
+    const inode = fileStat.ino.toString();
     const numFrames = size.width / FRAME_SIZE;
-
     return {
       id: uuidv4(),
       plugin,
@@ -23,6 +25,7 @@ const loadSpriteData = projectRoot => async filename => {
       numFrames,
       type: spriteTypeFromNumFrames(numFrames),
       filename: file,
+      inode,
       _v: Date.now()
     };
   } catch (e) {

--- a/src/lib/project/watchProject.js
+++ b/src/lib/project/watchProject.js
@@ -77,7 +77,7 @@ const watchProject = async (
       ignored: /^.*\.(?!(mod|MOD)$)[^.]+$/,
       ignoreInitial: true,
       persistent: true,
-      musicAwaitWriteFinish
+      awaitWriteFinish: musicAwaitWriteFinish
     })
     .on("add", onAddMusic)
     .on("change", onChangedMusic)

--- a/src/store/features/entities/entitiesTypes.ts
+++ b/src/store/features/entities/entitiesTypes.ts
@@ -48,6 +48,7 @@ export type Background = {
   imageWidth: number;
   imageHeight: number;
   plugin?: string;
+  inode: string;
   _v: number;
 };
 
@@ -61,6 +62,7 @@ export type Music = {
   filename: string;
   plugin?: string;
   settings: MusicSettings;
+  inode: string;
   _v: number;
 };
 
@@ -103,6 +105,7 @@ export type SpriteSheet = {
   type: SpriteType;
   numFrames: number;
   plugin?: string;
+  inode: string;
   _v: number;
 };
 

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -81,6 +81,7 @@ export const dummyBackground: Background = {
   height: 1,
   imageWidth: 1,
   imageHeight: 1,
+  inode: "0",
   _v: 0,
 };
 
@@ -90,6 +91,7 @@ export const dummySpriteSheet: SpriteSheet = {
   filename: "",
   numFrames: 1,
   type: "static",
+  inode: "1",  
   _v: 0,
 };
 
@@ -97,6 +99,7 @@ export const dummyMusic: Music = {
   id: "",
   name: "",
   filename: "",
+  inode: "2",  
   _v: 0,
   settings: {}
 };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Attempt to fix issues seen in #574 where renaming assets causes ids to be regenerated and any scenes/events referring to those ids would be broken.

* **What is the current behavior?** (You can also link to an open issue here)
Asset file watching is handled in https://github.com/chrismaltby/gb-studio/blob/v2beta/src/lib/project/watchProject.js using the module [chokidar](https://github.com/paulmillr/chokidar) which handles the complexities of cross platform file watching. In chokidar when a watched file is renamed it fires an unlink (delete) file event followed by an add file event with no way to determine that this was a single rename action (and it looks unlikely that this functionality will change https://github.com/paulmillr/chokidar/issues/303). This caused a rename to first delete the asset, then it will be readded, at which point it gets a new id and all previous references are broken.

* **What is the new behavior (if this is a feature change)?**
Using fs.stat I am fetching the inode value for each asset which appears to stay the same after a rename, when a file is deleted I store the asset data in a lookup table by inode and when a new file is added I check if the inode matches a recently deleted one and if it does I reuse the previous id and any additional previous data that might be useful to keep (such as the music speed conversion flag). With this change renaming an asset has a small flash of the asset being deleted before it reappears again a second a later with the scene collisions and actors positions unchanged.

As the inode values also get written to disk in the GBSProj file it's also now possible to rename an asset while GB Studio is closed and it will fix the links when you next load the project.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Maybe, I've only tested this on Mac so far. I'm interested in seeing if this works correctly on Windows. I believe Windows uses 64-bit inode values so I'm using the bigint arg when calling stat `await stat(filename, { bigint: true });` and storing the value as a string (since JSON doesn't support 64-bit values), without testing I can't be sure this is working. I'll do plenty before merging this.

Linux should be okay but also needs a lot of testing.
