### PR TITLE
Set smaller min width for main window

### DIFF
--- a/src/components/library/Toolbar.css
+++ b/src/components/library/Toolbar.css
@@ -39,7 +39,6 @@
 }
 
 .Toolbar__FixedSpacer {
-  width: 20px;
   flex-shrink: 0;
 }
 
@@ -106,7 +105,6 @@
 
 .Toolbar__DropdownButton .Toolbar__DropdownButton__Triangle {
   width: 10px;
-  margin-left: 5px;
   flex-grow: 0;
 }
 
@@ -160,7 +158,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 0px 10px;
+  padding: 0px 5px;
 }
 
 .Toolbar__Search {
@@ -171,4 +169,27 @@
   border-radius: 20px;
   font-size: 13px;
   padding: 0px 10px;
+  min-width: 86px;
+}
+
+/* Screen width <= 720px */
+@media (max-width:720px) {
+  .Toolbar__DropdownButton .Toolbar__DropdownButton__Triangle {
+    margin-left: -2px;
+  }
+
+  .Toolbar__FixedSpacer {
+    width: 5px;
+  }
+}
+
+/* Screen width >= 720px */
+@media (min-width:720px) {
+  .Toolbar__DropdownButton .Toolbar__DropdownButton__Triangle {
+    margin-left: 5px;
+  }
+  
+  .Toolbar__FixedSpacer {
+    width: 20px;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,9 +97,9 @@ const createWindow = async (projectPath: string) => {
   mainWindow = new BrowserWindow({
     x: mainWindowState.x,
     y: mainWindowState.y,
-    width: Math.max(600, mainWindowState.width),
+    width: Math.max(640, mainWindowState.width),
     height: Math.max(600, mainWindowState.height),
-    minWidth: 600,
+    minWidth: 640,
     minHeight: 600,
     titleBarStyle: "hiddenInset",
     fullscreenable: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,9 +97,9 @@ const createWindow = async (projectPath: string) => {
   mainWindow = new BrowserWindow({
     x: mainWindowState.x,
     y: mainWindowState.y,
-    width: Math.max(800, mainWindowState.width),
+    width: Math.max(600, mainWindowState.width),
     height: Math.max(600, mainWindowState.height),
-    minWidth: 800,
+    minWidth: 600,
     minHeight: 600,
     titleBarStyle: "hiddenInset",
     fullscreenable: true,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Sets a smaller min width on the main window, allowing GB Studio to run maximised on devices with lower resolution screens (such as phones) or allow GB Studio to be tiled on medium resolution screens (such as low-end laptops).


* **What is the current behavior?** (You can also link to an open issue here)
Only medium resolution screens can run GB Studio maximised, and only high resolution screens can tile GB Studio.


* **What is the new behavior (if this is a feature change)?**
Min width of the main window has been adjusted to compensate for lower resolutions, allowing more devices to run GB Studio maximised or tiled.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I'm aware of.


* **Other information**:
![Screenshot from 2020-10-01 10-33-35](https://user-images.githubusercontent.com/14967142/94823205-981cbb00-03d1-11eb-9912-3dc7429ccb79.png)