### PR TITLE
Feature/paste actors vars

### DIFF
--- a/src/components/world/SceneCursor.js
+++ b/src/components/world/SceneCursor.js
@@ -8,7 +8,7 @@ import editorActions from "../../store/features/editor/editorActions";
 import settingsActions from "../../store/features/settings/settingsActions";
 import entitiesActions from "../../store/features/entities/entitiesActions";
 
-import { SceneShape } from "../../store/stateShape";
+import { SceneShape, VariableShape } from "../../store/stateShape";
 import { TOOL_COLORS, TOOL_COLLISIONS, TOOL_ERASER, TOOL_TRIGGERS, TOOL_ACTORS, BRUSH_FILL, BRUSH_16PX, TOOL_SELECT, COLLISION_ALL, TILE_PROPS } from "../../consts";
 
 class SceneCursor extends Component {
@@ -78,6 +78,7 @@ class SceneCursor extends Component {
       scene,
       actorDefaults,
       triggerDefaults,
+      clipboardVariables,
       selectScene,
       showCollisions,
       showLayers,
@@ -97,10 +98,10 @@ class SceneCursor extends Component {
     }
 
     if (tool === "actors") {
-      addActor({sceneId, x, y, defaults: actorDefaults});
+      addActor({sceneId, x, y, defaults: actorDefaults, variables: clipboardVariables});
       setTool({ tool: "select" });
     } else if (tool === "triggers") {
-      addTrigger({sceneId, x, y, width: 1, height: 1, defaults: triggerDefaults});
+      addTrigger({sceneId, x, y, width: 1, height: 1, defaults: triggerDefaults, variables: clipboardVariables});
       this.startX = x;
       this.startY = y;
       this.setState({ resize: true });
@@ -371,6 +372,7 @@ SceneCursor.propTypes = {
   entityId: PropTypes.string,
   actorDefaults: PropTypes.shape(),
   triggerDefaults: PropTypes.shape(),
+  clipboardVariables: PropTypes.arrayOf(VariableShape).isRequired,
   sceneId: PropTypes.string.isRequired,
   scene: SceneShape.isRequired,
   showCollisions: PropTypes.bool.isRequired,
@@ -401,7 +403,7 @@ SceneCursor.defaultProps = {
 function mapStateToProps(state, props) {
   const { tool } = state.editor;
   const { x, y } = state.editor.hover;
-  const { entityId, selectedPalette, selectedTileType, selectedBrush, showLayers, actorDefaults, triggerDefaults } = state.editor;
+  const { entityId, selectedPalette, selectedTileType, selectedBrush, showLayers, actorDefaults, triggerDefaults, clipboardVariables } = state.editor;
   const showCollisions = state.project.present.settings.showCollisions;
   const scenesLookup = sceneSelectors.selectEntities(state);
   const scene = scenesLookup[props.sceneId];
@@ -414,6 +416,7 @@ function mapStateToProps(state, props) {
     selectedBrush,
     actorDefaults,
     triggerDefaults,
+    clipboardVariables,
     entityId,
     showCollisions,
     scene,

--- a/src/components/world/World.js
+++ b/src/components/world/World.js
@@ -7,7 +7,7 @@ import Scene from "./Scene";
 import WorldHelp from "./WorldHelp";
 import Connections from "./Connections";
 import { MIDDLE_MOUSE, TOOL_COLORS, TOOL_COLLISIONS, TOOL_ERASER } from "../../consts";
-import { SceneShape } from "../../store/stateShape";
+import { SceneShape, VariableShape } from "../../store/stateShape";
 import { sceneSelectors, getMaxSceneRight, getMaxSceneBottom } from "../../store/features/entities/entitiesState";
 import editorActions from "../../store/features/editor/editorActions";
 import clipboardActions from "../../store/features/clipboard/clipboardActions";
@@ -233,9 +233,9 @@ class World extends Component {
   }
 
   onAddScene = e => {
-    const { addScene, setTool, sceneDefaults } = this.props;
+    const { addScene, setTool, sceneDefaults, clipboardVariables } = this.props;
     const { hoverX, hoverY } = this.state;
-    addScene({x: hoverX, y: hoverY, defaults: sceneDefaults});
+    addScene({x: hoverX, y: hoverY, defaults: sceneDefaults, variables: clipboardVariables});
     setTool({tool:"select"});
     this.setState({ hover: false });
   };
@@ -316,6 +316,7 @@ World.propTypes = {
   zoomRatio: PropTypes.number.isRequired,
   focus: PropTypes.bool.isRequired,
   sceneDefaults: PropTypes.shape({}),
+  clipboardVariables: PropTypes.arrayOf(VariableShape).isRequired,
   sidebarWidth: PropTypes.number.isRequired,
   showConnections: PropTypes.bool.isRequired,
   tool: PropTypes.string.isRequired,
@@ -349,7 +350,8 @@ function mapStateToProps(state) {
     worldScrollX: scrollX,
     worldScrollY: scrollY,
     showLayers,
-    sceneDefaults
+    sceneDefaults,
+    clipboardVariables
   } = state.editor;
   
   const { worldSidebarWidth: sidebarWidth } = state.editor;
@@ -384,6 +386,7 @@ function mapStateToProps(state) {
     scrollY,
     tool,
     sceneDefaults,
+    clipboardVariables,
     zoomRatio: (state.editor.zoom || 100) / 100,
     showConnections: (!!showConnections) && (showLayers || (tool !== TOOL_COLORS && tool !== TOOL_COLLISIONS && tool !== TOOL_ERASER)),
     sidebarWidth,

--- a/src/consts.js
+++ b/src/consts.js
@@ -3,11 +3,14 @@ import path from "path";
 const isDist = __dirname.indexOf(".webpack") > -1;
 const isCli = __dirname.indexOf("out/cli") > -1;
 
-const rootDir = isDist
-  ? __dirname.substr(0, __dirname.lastIndexOf(".webpack"))
-  : isCli
-  ? __dirname.substr(0, __dirname.lastIndexOf("out/cli"))
-  : __dirname.substr(0, __dirname.lastIndexOf("node_modules"));
+let rootDir = __dirname.substr(0, __dirname.lastIndexOf("node_modules"));
+if (isDist) {
+  rootDir = __dirname.substr(0, __dirname.lastIndexOf(".webpack")); 
+} else if (isCli) {
+  rootDir = __dirname.substr(0, __dirname.lastIndexOf("out/cli")); 
+} else if (process.env.NODE_ENV === "test") {
+  rootDir = path.normalize(`${__dirname}/../`);
+}
 
 const engineRoot = path.normalize(`${rootDir}/appData/src`);
 const buildToolsRoot = path.normalize(`${rootDir}/buildTools`);

--- a/src/lib/helpers/eventSystem.js
+++ b/src/lib/helpers/eventSystem.js
@@ -1,5 +1,6 @@
 import uuid from "uuid/v4";
 import { EVENT_CALL_CUSTOM_EVENT } from "../compiler/eventTypes";
+import events from "../../lib/events";
 
 const mapValues = (obj, fn) =>
   Object.entries(obj).reduce((memo, [key, value]) => {
@@ -290,6 +291,32 @@ const regenerateEventIds = event => {
   );
 };
 
+const replaceEventActorIds = (replacementIds, event) => {
+  const events = require("../events").default;
+  const eventSchema = events[event.command];
+
+  if (!eventSchema) {
+    return event;
+  }
+
+  const patchArgs = {};
+  eventSchema.fields.forEach((field) => {
+    if (field.type === "actor") {
+      if (replacementIds[event.args[field.key]]) {
+        patchArgs[field.key] = replacementIds[event.args[field.key]];
+      }
+    }
+  });
+
+  return {
+    ...event,
+    args: {
+      ...event.args,
+      ...patchArgs
+    }
+  }
+}
+
 const filterEvents = (data, fn) => {
   return data.reduce((memo, o) => {
     if (fn(o)) {
@@ -402,6 +429,7 @@ export {
   prependEvent,
   appendEvent,
   regenerateEventIds,
+  replaceEventActorIds,
   removeEventIds,
   filterEvents,
   findEvent,

--- a/src/store/features/clipboard/clipboardActions.ts
+++ b/src/store/features/clipboard/clipboardActions.ts
@@ -10,6 +10,7 @@ import {
   Scene,
   ScriptEvent,
   SceneData,
+  Variable,
 } from "../entities/entitiesTypes";
 import { RootState } from "../../configureStore";
 import editorActions from "../editor/editorActions";
@@ -62,6 +63,10 @@ const pasteClipboardEntity = (clipboardData: any) => (
     dispatch(pasteCustomEvents());
     dispatch(editorActions.setTriggerDefaults(clipboardTrigger));
   }
+  if (clipboardData.__variables) {
+    const clipboardVariables = clipboardData.__variables as Variable[];
+    dispatch(editorActions.setClipboardVariables(clipboardVariables));
+  }
 };
 
 const pasteClipboardEntityInPlace = (clipboardData: any) => (
@@ -79,6 +84,7 @@ const pasteClipboardEntityInPlace = (clipboardData: any) => (
         x: clipboardScene.x,
         y: clipboardScene.y,
         defaults: clipboardScene,
+        variables: clipboardData.__variables
       })
     );
   } else if (sceneId && clipboardData.__type === "actor") {
@@ -90,6 +96,7 @@ const pasteClipboardEntityInPlace = (clipboardData: any) => (
         x: clipboardActor.x,
         y: clipboardActor.y,
         defaults: clipboardActor,
+        variables: clipboardData.__variables
       })
     );
   } else if (sceneId && clipboardData.__type === "trigger") {
@@ -103,6 +110,7 @@ const pasteClipboardEntityInPlace = (clipboardData: any) => (
         width: clipboardTrigger.width,
         height: clipboardTrigger.height,
         defaults: clipboardTrigger,
+        variables: clipboardData.__variables
       })
     );
   }

--- a/src/store/features/clipboard/clipboardMiddleware.ts
+++ b/src/store/features/clipboard/clipboardMiddleware.ts
@@ -11,6 +11,7 @@ import {
   customEventSelectors,
   actorSelectors,
   triggerSelectors,
+  variableSelectors,
 } from "../entities/entitiesState";
 import {
   CustomEvent,
@@ -30,6 +31,10 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
     const usedCustomEvents = usedCustomEventIds
       .map((id) => customEventsLookup[id])
       .filter((i) => i);
+    const allVariables = variableSelectors.selectAll(state);
+    const usedVariables = allVariables.filter((variable) => {
+      return variable.id.startsWith(action.payload.id);
+    });
     clipboard.writeText(
       JSON.stringify(
         {
@@ -37,6 +42,8 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
           __type: "actor",
           __customEvents:
             usedCustomEvents.length > 0 ? usedCustomEvents : undefined,
+          __variables:
+            usedVariables.length > 0 ? usedVariables : undefined
         },
         null,
         4
@@ -51,6 +58,10 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
     const usedCustomEvents = usedCustomEventIds
       .map((id) => customEventsLookup[id])
       .filter((i) => i);
+    const allVariables = variableSelectors.selectAll(state);
+    const usedVariables = allVariables.filter((variable) => {
+      return variable.id.startsWith(action.payload.id);
+    });      
     clipboard.writeText(
       JSON.stringify(
         {
@@ -58,6 +69,8 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
           __type: "trigger",
           __customEvents:
             usedCustomEvents.length > 0 ? usedCustomEvents : undefined,
+          __variables:
+            usedVariables.length > 0 ? usedVariables : undefined            
         },
         null,
         4
@@ -79,6 +92,13 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
     const usedCustomEvents = usedCustomEventIds
       .map((id) => customEventsLookup[id])
       .filter((i) => i);
+    const allVariables = variableSelectors.selectAll(state);
+
+    const entityIds = [action.payload.id, ...action.payload.actors, ...action.payload.triggers];
+    console.log({entityIds})
+    const usedVariables = allVariables.filter((variable) => {
+      return entityIds.find((id) => variable.id.startsWith(id))
+    });   
 
     clipboard.writeText(
       JSON.stringify(
@@ -87,6 +107,8 @@ const clipboardMiddleware: Middleware<{}, RootState> = (store) => (next) => (
           __type: "scene",
           __customEvents:
             usedCustomEvents.length > 0 ? usedCustomEvents : undefined,
+          __variables:
+            usedVariables.length > 0 ? usedVariables : undefined
         },
         null,
         4

--- a/src/store/features/editor/editorState.ts
+++ b/src/store/features/editor/editorState.ts
@@ -12,6 +12,7 @@ import {
   Actor,
   Trigger,
   SceneData,
+  Variable,
 } from "../entities/entitiesTypes";
 import navigationActions from "../navigation/navigationActions";
 import projectActions from "../project/projectActions";
@@ -43,6 +44,7 @@ export interface EditorState {
   actorDefaults?: Partial<Actor>;
   triggerDefaults?: Partial<Trigger>;
   sceneDefaults?: Partial<SceneData>;
+  clipboardVariables: Variable[];
   type: EditorSelectionType;
   worldFocus: boolean;
   scene: string;
@@ -121,6 +123,7 @@ export const initialState: EditorState = {
   profile: false,
   worldSidebarWidth: 300,
   filesSidebarWidth: 300,
+  clipboardVariables: []
 };
 
 const editorSlice = createSlice({
@@ -427,6 +430,10 @@ const editorSlice = createSlice({
       state.sceneDefaults = action.payload;
       state.tool = "scene";
     },
+
+    setClipboardVariables: (state, action: PayloadAction<Variable[]>) => {
+      state.clipboardVariables = action.payload;
+    },    
   },
   extraReducers: (builder) =>
     builder

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -592,7 +592,7 @@ const addScene: CaseReducer<
   }
 
   // Add any variables from clipboard
-  if (action.payload.defaults?.id && action.payload.variables) {
+  if (action.payload.variables) {
     const newVariables = action.payload.variables.map((variable) => {
       let newId = variable.id;
       for (var id in idReplacements) {

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -29,6 +29,7 @@ import {
   isVariableField,
   isPropertyField,
   walkEvents,
+  replaceEventActorIds,
 } from "../../../lib/helpers/eventSystem";
 import clamp from "../../../lib/helpers/clamp";
 import { RootState } from "../../configureStore";
@@ -544,6 +545,7 @@ const addScene: CaseReducer<
     x: number;
     y: number;
     defaults?: Partial<SceneData>;
+    variables?: Variable[];
   }>
 > = (state, action) => {
   const scenesTotal = localSceneSelectors.selectTotal(state);
@@ -573,7 +575,42 @@ const addScene: CaseReducer<
     }
   );
 
-  const fixedScene = mapSceneEvents(newScene, regenerateEventIds);
+  // Generate new ids
+  const idReplacements:Dictionary<string> = {};
+  if (action.payload.defaults?.id) {
+    idReplacements[action.payload.defaults.id] = action.payload.sceneId;
+  }
+  if (action.payload.defaults?.actors) {
+    for (let actor of action.payload.defaults.actors) {
+      idReplacements[actor.id] = uuid();
+    }
+  }
+  if (action.payload.defaults?.triggers) {
+    for (let trigger of action.payload.defaults.triggers) {
+      idReplacements[trigger.id] = uuid();
+    }
+  }
+
+  // Add any variables from clipboard
+  if (action.payload.defaults?.id && action.payload.variables) {
+    const newVariables = action.payload.variables.map((variable) => {
+      let newId = variable.id;
+      for (var id in idReplacements) {
+        if (variable.id.startsWith(id)) {
+          newId = variable.id.replace(id, idReplacements[id] || newId);
+          break;
+        }
+      }
+      return {
+        ...variable,
+        id: newId
+      }
+    });
+
+    variablesAdapter.upsertMany(state.variables, newVariables);
+  }
+
+  const fixedScene = mapSceneEvents(newScene, (event) => replaceEventActorIds(idReplacements, regenerateEventIds(event)));
 
   scenesAdapter.addOne(state.scenes, fixedScene);
 
@@ -581,8 +618,8 @@ const addScene: CaseReducer<
     for (let actor of action.payload.defaults.actors) {
       addActorToScene(state, fixedScene, {
         ...actor,
-        id: uuid(),
-      });
+        id: idReplacements[actor.id] || uuid(),
+      }, idReplacements);
     }
   }
 
@@ -590,8 +627,8 @@ const addScene: CaseReducer<
     for (let trigger of action.payload.defaults.triggers) {
       addTriggerToScene(state, fixedScene, {
         ...trigger,
-        id: uuid(),
-      });
+        id: idReplacements[trigger.id] || uuid()
+      }, idReplacements);
     }
   }
 };
@@ -765,6 +802,7 @@ const addActor: CaseReducer<
     x: number;
     y: number;
     defaults?: Partial<Actor>;
+    variables?: Variable[];
   }>
 > = (state, action) => {
   const scene = localSceneSelectors.selectById(state, action.payload.sceneId);
@@ -775,6 +813,17 @@ const addActor: CaseReducer<
   const spriteSheetId = first(localSpriteSheetSelectors.selectAll(state))?.id;
   if (!spriteSheetId) {
     return;
+  }
+
+  // Add any variables from clipboard
+  if (action.payload.defaults?.id && action.payload.variables) {
+    const newVariables = action.payload.variables.map((variable) => {
+      return {
+        ...variable,
+        id: variable.id.replace(action.payload.defaults?.id || "", action.payload.actorId)
+      }
+    });
+    variablesAdapter.upsertMany(state.variables, newVariables);
   }
 
   const newActor = Object.assign(
@@ -802,11 +851,11 @@ const addActor: CaseReducer<
     }
   );
 
-  addActorToScene(state, scene, newActor);
+  addActorToScene(state, scene, newActor, {});
 };
 
-const addActorToScene = (state: EntitiesState, scene: Scene, actor: Actor) => {
-  const fixedActor = mapActorEvents(actor, regenerateEventIds);
+const addActorToScene = (state: EntitiesState, scene: Scene, actor: Actor, idReplacements: Dictionary<string>) => {
+  const fixedActor = mapActorEvents(actor, (event) => replaceEventActorIds(idReplacements, regenerateEventIds(event)));
 
   // Add to scene
   scene.actors = ([] as string[]).concat(scene.actors, fixedActor.id);
@@ -1057,6 +1106,7 @@ const addTrigger: CaseReducer<
     width: number;
     height: number;
     defaults?: Partial<Trigger>;
+    variables?: Variable[];
   }>
 > = (state, action) => {
   const scene = localSceneSelectors.selectById(state, action.payload.sceneId);
@@ -1066,6 +1116,17 @@ const addTrigger: CaseReducer<
 
   const width = Math.min(action.payload.width, scene.width);
   const height = Math.min(action.payload.height, scene.height);
+
+  // Add any variables from clipboard
+  if (action.payload.defaults?.id && action.payload.variables) {
+    const newVariables = action.payload.variables.map((variable) => {
+      return {
+        ...variable,
+        id: variable.id.replace(action.payload.defaults?.id || "", action.payload.triggerId)
+      }
+    });
+    variablesAdapter.upsertMany(state.variables, newVariables);
+  }
 
   const newTrigger: Trigger = Object.assign(
     {
@@ -1084,19 +1145,20 @@ const addTrigger: CaseReducer<
   );
 
   // Add to scene
-  addTriggerToScene(state, scene, newTrigger);
+  addTriggerToScene(state, scene, newTrigger, {});
 };
 
 const addTriggerToScene = (
   state: EntitiesState,
   scene: Scene,
-  trigger: Trigger
+  trigger: Trigger,
+  idReplacements: Dictionary<string>
 ) => {
-  const fixedActor = mapTriggerEvents(trigger, regenerateEventIds);
+  const fixedTrigger = mapTriggerEvents(trigger, (event) => replaceEventActorIds(idReplacements, regenerateEventIds(event)));
 
   // Add to scene
-  scene.triggers = ([] as string[]).concat(scene.triggers, fixedActor.id);
-  triggersAdapter.addOne(state.triggers, fixedActor);
+  scene.triggers = ([] as string[]).concat(scene.triggers, fixedTrigger.id);
+  triggersAdapter.addOne(state.triggers, fixedTrigger);
 };
 
 const editTrigger: CaseReducer<
@@ -1817,6 +1879,7 @@ const entitiesSlice = createSlice({
         x: number;
         y: number;
         defaults?: Partial<SceneData>;
+        variables?: Variable[];
       }) => {
         return {
           payload: {
@@ -1845,6 +1908,7 @@ const entitiesSlice = createSlice({
         x: number;
         y: number;
         defaults?: Partial<Actor>;
+        variables?: Variable[];
       }) => {
         return {
           payload: {
@@ -1874,6 +1938,7 @@ const entitiesSlice = createSlice({
         width: number;
         height: number;
         defaults?: Partial<Trigger>;
+        variables?: Variable[];
       }) => {
         return {
           payload: {

--- a/test/store/features/clipboard/clipboardMiddleware.test.ts
+++ b/test/store/features/clipboard/clipboardMiddleware.test.ts
@@ -12,33 +12,106 @@ jest.mock("electron");
 const mockedClipboard = mocked(clipboard, true);
 
 test("Should be able to copy actor to clipboard", async () => {
+  mockedClipboard.writeText.mockClear();
 
   const store = ({
     getState: () => ({
-        project: {
-            present: {
-                entities: {
-                    customEvents: {
-                        entities: {},
-                        ids: []
-                    }
-                }
-            }
-        }
+      project: {
+        present: {
+          entities: {
+            customEvents: {
+              entities: {},
+              ids: [],
+            },
+            variables: {
+              entities: {},
+              ids: [],
+            },
+          },
+        },
+      },
     }),
     dispatch: jest.fn(),
   } as unknown) as MiddlewareAPI<Dispatch<AnyAction>, RootState>;
 
   const next = jest.fn();
   const action = actions.copyActor({
-      ...dummyActor
-  })
+    ...dummyActor,
+  });
 
   middleware(store)(next)(action);
 
   expect(next).toHaveBeenCalledWith(action);
-  expect(mockedClipboard.writeText).toHaveBeenCalledWith(JSON.stringify({
-      actor: dummyActor,
-      __type: "actor"
-  }, null, 4));
+  expect(mockedClipboard.writeText).toHaveBeenCalledWith(
+    JSON.stringify(
+      {
+        actor: dummyActor,
+        __type: "actor",
+      },
+      null,
+      4
+    )
+  );
+});
+
+test("Should be include referenced variables when copying actor", async () => {
+  mockedClipboard.writeText.mockClear();
+
+  const store = ({
+    getState: () => ({
+      project: {
+        present: {
+          entities: {
+            customEvents: {
+              entities: {},
+              ids: [],
+            },
+            variables: {
+              entities: {
+                actor1_L0: {
+                  id: "actor1_L0",
+                  name: "Actor Local",
+                },
+                actor2_L0: {
+                  id: "actor2_L0",
+                  name: "Actor Local",
+                },
+              },
+              ids: ["actor1_L0", "actor2_L0"],
+            },
+          },
+        },
+      },
+    }),
+    dispatch: jest.fn(),
+  } as unknown) as MiddlewareAPI<Dispatch<AnyAction>, RootState>;
+
+  const next = jest.fn();
+  const action = actions.copyActor({
+    ...dummyActor,
+    id: "actor1",
+  });
+
+  middleware(store)(next)(action);
+
+  expect(next).toHaveBeenCalledWith(action);
+  expect(mockedClipboard.writeText).toHaveBeenCalledWith(
+    JSON.stringify(
+      {
+        actor: {
+          ...dummyActor,
+          id: "actor1",
+        },
+        __type: "actor",
+        __variables: [
+          {
+            id: "actor1_L0",
+            name: "Actor Local",
+          },
+        ],
+      },
+      null,
+      4
+    )
+  );
 });

--- a/test/store/features/clipboard/clipboardMiddleware.test.ts
+++ b/test/store/features/clipboard/clipboardMiddleware.test.ts
@@ -54,7 +54,7 @@ test("Should be able to copy actor to clipboard", async () => {
   );
 });
 
-test("Should be include referenced variables when copying actor", async () => {
+test("Should include referenced variables when copying actor", async () => {
   mockedClipboard.writeText.mockClear();
 
   const store = ({

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -439,6 +439,53 @@ test("Should be able to add a scene", () => {
   expect(newState.scenes.entities[newState.scenes.ids[0]]?.y).toBe(220);
 });
 
+test("Should be able to add a scene with defaults and variables", () => {
+  jest.mock('../../../../src/consts')
+
+  const state: EntitiesState = {
+    ...initialState,
+  };
+
+  const action = actions.addScene({
+    x: 110,
+    y: 220,
+    defaults: {
+      name: "Clipboard Scene Name",
+      actors: [{
+        ...dummyActor,
+        id: "actor1",
+        name: "Clipboard Actor",
+        x: 5,
+        y: 3
+      }],
+      triggers: [{
+        ...dummyTrigger,
+        id: "trigger1",
+        script: [{
+          id: "event1",
+          command: "EVENT_ACTOR_MOVE_TO",
+          args: {
+            actorId: "actor1"
+          }
+        }]
+      }]
+    },
+    variables: [{
+      id: "trigger1__L0",
+      name: "Clipboard Trigger Name"
+    }]
+  });
+
+  const newState = reducer(state, action);
+
+  expect(newState.scenes.ids.length).toBe(1);
+  expect(newState.actors.ids.length).toBe(1);
+  expect(newState.triggers.ids.length).toBe(1);
+  expect(newState.variables.ids.length).toBe(1);
+  expect(newState.variables.entities[`${newState.triggers.ids[0]}__L0`]?.name).toBe("Clipboard Trigger Name");
+  expect(newState.triggers.entities[newState.triggers.ids[0]]?.script[0]?.args?.actorId).toBe(newState.actors.ids[0]);
+});
+
 test("Should be able to move a scene", () => {
   const state: EntitiesState = {
     ...initialState,

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -450,6 +450,7 @@ test("Should be able to add a scene with defaults and variables", () => {
     x: 110,
     y: 220,
     defaults: {
+      id: "scene1",
       name: "Clipboard Scene Name",
       actors: [{
         ...dummyActor,
@@ -472,7 +473,10 @@ test("Should be able to add a scene with defaults and variables", () => {
     },
     variables: [{
       id: "trigger1__L0",
-      name: "Clipboard Trigger Name"
+      name: "Clipboard Trigger Var Name"
+    },{
+      id: "scene1__L0",
+      name: "Clipboard Scene Var Name"
     }]
   });
 
@@ -481,8 +485,9 @@ test("Should be able to add a scene with defaults and variables", () => {
   expect(newState.scenes.ids.length).toBe(1);
   expect(newState.actors.ids.length).toBe(1);
   expect(newState.triggers.ids.length).toBe(1);
-  expect(newState.variables.ids.length).toBe(1);
-  expect(newState.variables.entities[`${newState.triggers.ids[0]}__L0`]?.name).toBe("Clipboard Trigger Name");
+  expect(newState.variables.ids.length).toBe(2);
+  expect(newState.variables.entities[`${newState.triggers.ids[0]}__L0`]?.name).toBe("Clipboard Trigger Var Name");
+  expect(newState.variables.entities[`${newState.scenes.ids[0]}__L0`]?.name).toBe("Clipboard Scene Var Name");
   expect(newState.triggers.entities[newState.triggers.ids[0]]?.script[0]?.args?.actorId).toBe(newState.actors.ids[0]);
 });
 
@@ -1164,6 +1169,50 @@ test("Should be able to add a trigger to a scene", () => {
   expect(newState.triggers.entities[newTriggerId]?.y).toBe(3);
   expect(newState.triggers.entities[newTriggerId]?.width).toBe(4);
   expect(newState.triggers.entities[newTriggerId]?.height).toBe(2);
+});
+
+test("Should be able to add a trigger to a scene with defaults and variables", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          width: 10,
+          height: 5,
+          actors: [],
+          triggers: [],
+        },
+      },
+      ids: ["scene1"],
+    },
+  };
+
+  const action = actions.addTrigger({
+    sceneId: "scene1",
+    x: 1,
+    y: 3,
+    width: 4,
+    height: 2,
+    defaults: {
+      id: "trigger1",
+      name: "Clipboard Trigger"
+    },
+    variables: [{
+      id: "trigger1__L0",
+      name: "Clipboard Variable Name"
+    }]
+  });
+
+  const newState = reducer(state, action);
+
+  const newTriggerId = action.payload.triggerId;
+
+  expect(newState.triggers.ids.length).toBe(1);
+  expect(newState.variables.ids.length).toBe(1);
+  expect(newState.triggers.entities[newTriggerId]?.id).not.toBe("trigger1");
+  expect(newState.variables.entities[`${newTriggerId}__L0`]?.name).toBe("Clipboard Variable Name");
 });
 
 test("Should be able to move a trigger with a scene", () => {

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -937,6 +937,54 @@ test("Should be able to add an actor to a scene", () => {
   expect(newState.actors.entities[newActorId]?.spriteSheetId).toBe("sprite1");
 });
 
+test("Should be able to add an actor to a scene with default values and variables", () => {
+  const state: EntitiesState = {
+    ...initialState,
+    scenes: {
+      entities: {
+        scene1: {
+          ...dummyScene,
+          id: "scene1",
+          width: 10,
+          height: 5,
+          actors: [],
+          triggers: [],
+        },
+      },
+      ids: ["scene1"],
+    },
+    spriteSheets: {
+      entities: {
+        sprite1: {
+          ...dummySpriteSheet,
+          id: "sprite1",
+          filename: "sprite1.png",
+        },
+      },
+      ids: ["sprite1"],
+    },
+  };
+
+  const action = actions.addActor({
+    sceneId: "scene1",
+    x: 2,
+    y: 4,
+    defaults: {
+      id: "clipboard_id",
+      name: "Clipboard Actor Name",
+    },
+    variables: [{ id: "clipboard_id__L0", name: "Clipboard Variable Name" }],
+  });
+
+  const newState = reducer(state, action);
+
+  const newActorId = action.payload.actorId;
+
+  expect(newState.scenes.entities["scene1"]?.actors).toEqual([newActorId]);
+  expect(newState.actors.entities[newActorId]?.name).toBe("Clipboard Actor Name");
+  expect(newState.variables.entities[`${newActorId}__L0`]?.name).toBe("Clipboard Variable Name");
+});
+
 test("Should be able to move an actor with a scene", () => {
   const state: EntitiesState = {
     ...initialState,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements an enhancement request from #578 improving clipboard functionality to retain variable names and actor links.

* **What is the current behavior?** (You can also link to an open issue here)
As noted in #578 when copy/pasting a scene/actor/trigger all custom variable names are reset to the defaults on the new entity. Also when copy/pasting a full scene all events that reference actors from that scene don't update correctly so reset to pointing to Player or Self depending on the script type causing a lot of manual effort to be needed after pasting.

* **What is the new behavior (if this is a feature change)?**
When copying any custom local variables used by the selected entities are also copied to the clipboard, when pasting this data is used to generate new variables for the new entities to keep the previous variable names.

Also when pasting a full scene all of the scripts within the new scene are updated to fix all actor references to the new ids.

With both of these changes copy/pasting should work as expected even when moving data between projects.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not that I know of just yet, though I'm writing some tests before merging to cover as many cases as seem necessary to confirm.
