### PR TITLE
Add movement presets to OnUpdate if empty

### DIFF
--- a/src/components/editors/ActorEditor.js
+++ b/src/components/editors/ActorEditor.js
@@ -9,7 +9,7 @@ import ScriptEditor from "../script/ScriptEditor";
 import DirectionPicker from "../forms/DirectionPicker";
 import { FormField, ToggleableFormField } from "../library/Forms";
 import castEventValue from "../../lib/helpers/castEventValue";
-import { DropdownButton } from "../library/Button";
+import Button, { DropdownButton } from "../library/Button";
 import { MenuItem, MenuDivider } from "../library/Menu";
 import l10n from "../../lib/helpers/l10n";
 import MovementSpeedSelect from "../forms/MovementSpeedSelect";
@@ -32,6 +32,8 @@ import { actorSelectors, sceneSelectors, spriteSheetSelectors } from "../../stor
 import editorActions from "../../store/features/editor/editorActions";
 import clipboardActions from "../../store/features/clipboard/clipboardActions";
 import entitiesActions from "../../store/features/entities/entitiesActions";
+import generateRandomWalkScript from "../../lib/movement/generateRandomWalkScript";
+import generateRandomLookScript from "../../lib/movement/generateRandomLookScript";
 
 const defaultTabs = {
   interact: l10n("SIDEBAR_ON_INTERACT"),
@@ -469,7 +471,7 @@ class ActorEditor extends Component {
             <li
               onClick={() => {
                 const { selectScene } = this.props;
-                selectScene({sceneId: scene.id});
+                selectScene({ sceneId: scene.id });
               }}
             >
               <div className="EditorSidebar__Icon">
@@ -527,6 +529,31 @@ class ActorEditor extends Component {
                   onChange={scripts[scriptMode][scriptModeSecondary].onChange}
                   entityId={actor.id}
                 />
+              )}
+
+            {scriptMode === "update" &&
+              (!scripts.update.value || scripts.update.value.length <= 1) && (
+                <div className="ScriptEditor__Presets">
+                  <div className="ScriptEditor__PresetsLabel">
+                    {l10n("FIELD_OR_CHOOSE_PRESET")}
+                  </div>
+                  <div className="ScriptEditor__PresetsButtons">
+                    <Button
+                      onClick={() => {
+                        this.onEditUpdateScript(generateRandomWalkScript());
+                      }}
+                    >
+                      {l10n("FIELD_MOVEMENT_RANDOM_WALK")}
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        this.onEditUpdateScript(generateRandomLookScript());
+                      }}
+                    >
+                      {l10n("FIELD_MOVEMENT_RANDOM_ROTATION")}
+                    </Button>
+                  </div>
+                </div>
               )}
           </div>
         </SidebarColumn>

--- a/src/components/script/ScriptEditor.css
+++ b/src/components/script/ScriptEditor.css
@@ -714,3 +714,27 @@
   > .ScriptEditorEvent__Command.EventComment {
   background: var(--comment-event-color-alt);
 }
+
+.ScriptEditor__Presets {
+  padding: 10px;
+  padding-bottom: 30px;
+}
+
+.ScriptEditor__PresetsLabel {
+  font-size: 11px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.ScriptEditor__PresetsButtons {
+  display: flex;
+}
+
+.ScriptEditor__PresetsButtons > * {
+  width: 100%;
+  margin-right: 5px;
+}
+
+.ScriptEditor__PresetsButtons > *:last-child {
+  margin-right: 0;
+}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,6 +264,7 @@
   "FIELD_FRAMES_COUNT": "This scene has used {frameCount} of {maxFrames} available",
   "FIELD_TRIGGERS_COUNT": "This scene has used {triggerCount} of {maxTriggers} available",
   "FIELD_WARNING": "Warning",
+  "FIELD_OR_CHOOSE_PRESET": "or choose from presets",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add feature to quickly choose movement script preset similar to 1.2.0 movement types

* **What is the current behavior?** (You can also link to an open issue here)
Since 2.0.0 the simple but not very flexible movement type dropdown has been replaced with the ability to create custom movement with the "OnUpdate" script. When migrating an old project the movement is converted for you but if you want to create a new actor with the old movement types you now need to understand how to script it manually or copy and paste and existing actor.

* **What is the new behavior (if this is a feature change)?**
Adds a few preset buttons to generate quick movement scripts matching the previous movement types when editing an Actors "OnUpdate" script.

<img width="287" alt="Screenshot 2020-10-01 at 20 55 51" src="https://user-images.githubusercontent.com/16776042/94857377-515aaf80-0429-11eb-8790-17f4f0b75d3f.png">

These buttons only appear if the script is currently empty.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

These two events probably only make sense on top down scenes, it might be good to have these buttons be context sensitive on the current scene type so that Platformer and Shoot Em' Up scenes contain different presets.
