### PR TITLE
Remove xcode tools dependency for Mac by using bash script rather than Makefile

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -598,6 +598,10 @@
   "GAMETYPE_PLATFORMER": "Platformer",
   "GAMETYPE_ADVENTURE": "Adventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click"
+  "GAMETYPE_POINT_N_CLICK": "Point and Click",
 
+  "// 20": "Compiler -----------------------------------------------------",
+
+  "COMPILER_COMPILING": "Compiling",
+  "COMPILER_LINKING": "Linking"
 }

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -2,7 +2,7 @@ import childProcess from "child_process";
 import fs from "fs-extra";
 import { buildToolsRoot } from "../../consts";
 import copy from "../helpers/fsCopy";
-import buildMakeBat from "./buildMakeBat";
+import buildMakeScript from "./buildMakeScript";
 import { hexDec } from "../helpers/8bit";
 import getTmp from "../helpers/getTmp";
 import { isMBC1 } from "./helpers";
@@ -122,16 +122,19 @@ const makeBuild = async ({
 
   await fetchCachedObjData(buildRoot, env);
 
-  const makeBat = await buildMakeBat(buildRoot, {
+  const makeScriptFile = process.platform === "win32" ? "make.bat" : "make.sh"
+  
+  const makeScript = await buildMakeScript(buildRoot, {
     CART_TYPE: env.CART_TYPE,
     CART_SIZE: env.CART_SIZE,
     customColorsEnabled: settings.customColorsEnabled,
     gbcFastCPUEnabled: settings.gbcFastCPUEnabled,
-    profile
+    profile,
+    platform: process.platform
   });
-  await fs.writeFile(`${buildRoot}/make.bat`, makeBat);
+  await fs.writeFile(`${buildRoot}/${makeScriptFile}`, makeScript);
 
-  const command = process.platform === "win32" ? "make.bat" : "make";
+  const command = process.platform === "win32" ? makeScriptFile : `/bin/sh ${makeScriptFile}`;
   const args = ["rom"];
 
   const options = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Replaces the Makefile with a generated Bash script when building the app for Mac/Linux to remove dependencies needed to build a game.

* **What is the current behavior?** (You can also link to an open issue here)
On a Mac building without the full Xcode app or the Xcode Command Line Tools installed throws errors preventing a build from completing, there are also cases where some users have Xcode installed but their specific environment prevents it from working. There is currently a section in the documentation giving a fix https://www.gbstudio.dev/docs/build/#troubleshooting but many people do not find this and ideally GB Studio should not require any third party applications to be installed manually.

* **What is the new behavior (if this is a feature change)?**
The only actual dependency on Xcode was that it installed GNU Make which is used on the Mac/Linux builds to run the build scripts. On Windows to prevent requiring a similar dependency we instead auto generate a make.bat file which was already handling things like the incremental builds by checking for the existence of compiled object files. This PR updates the script that was previously generating the make.bat file to also allow generating a make.sh Bash script which is now used in the Mac/Linux builds.

With this change a fresh Mac OS install can run GB Studio and build games without a single other application being installed.
 
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I've kept the Makefile as it's still useful for anyone who exports their project source