### PR TITLE
Add preferences window for setting tmp directory

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -74,6 +74,16 @@ module.exports = {
                 "vendor-lodash",
               ],
             },
+            {
+              html: "./src/preferences.html",
+              js: "./src/PreferencesRoot.js",
+              name: "preferences_window",
+              additionalChunks: [
+                "vendor-react",
+                "vendor-hotloader",
+                "vendor-lodash",
+              ],
+            },            
           ],
         },
       },

--- a/src/PreferencesRoot.js
+++ b/src/PreferencesRoot.js
@@ -1,0 +1,21 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { AppContainer } from "react-hot-loader";
+import Preferences from "./components/app/Preferences";
+import "./lib/helpers/handleTheme";
+import "./styles/App.css";
+
+const render = () => {
+  ReactDOM.render(
+    <AppContainer>
+      <Preferences />
+    </AppContainer>,
+    document.getElementById("App")
+  );
+};
+
+render();
+
+if (module.hot) {
+  module.hot.accept(render);
+}

--- a/src/components/app/Preferences.tsx
+++ b/src/components/app/Preferences.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from "react";
+import Path from "path";
+import settings from "electron-settings";
+import { ipcRenderer, remote } from "electron";
+import { DotsIcon } from "../library/Icons";
+import l10n from "../../lib/helpers/l10n";
+import Button from "../library/Button";
+import getTmp from "../../lib/helpers/getTmp";
+
+const { dialog } = require("electron").remote;
+
+const Preferences = () => {
+  const pathError = "";
+  const [path, setPath] = useState<string>("");
+
+  useEffect(() => {
+    setPath(getTmp(false));
+  }, []);
+
+  const onChangePath = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newPath = e.currentTarget.value;
+    setPath(newPath);
+    settings.set("tmpDir", newPath);
+  };
+
+  const onSelectFolder = async (
+    e: React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    const path = await dialog.showOpenDialog({
+      properties: ["openDirectory"],
+    });
+    if (path.filePaths[0]) {
+      const newPath = Path.normalize(`${path.filePaths}/`);
+      setPath(newPath);
+      settings.set("tmpDir", newPath);
+    }
+  };
+
+  const onRestoreDefault = () => {
+    settings.delete("tmpDir");
+    setPath(getTmp(false));
+  };
+
+  return (
+    <div className="Preferences">
+      <div className="Preferences__FormGroup">
+        <label
+          htmlFor="projectPath"
+          className={pathError ? "Preferences__Label--Error" : ""}
+        >
+          {pathError || l10n("FIELD_TMP_DIRECTORY")}
+          <input id="projectPath" value={path} onChange={onChangePath} />
+          <div className="Preferences__InputButton">
+            <DotsIcon />
+            <input
+              className="Preferences__InputButton"
+              onClick={onSelectFolder}
+            />
+          </div>
+        </label>
+        <div className="Preferences__Info">
+          {l10n("FIELD_TMP_DIRECTORY_INFO")}
+        </div>
+      </div>
+      <div className="Preferences__FlexSpacer"></div>
+      <div>
+        <Button
+          transparent={false}
+          small={false}
+          large={false}
+          onClick={onRestoreDefault}
+        >
+          {l10n("FIELD_RESTORE_DEFAULT")}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Preferences;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,6 +264,8 @@
   "FIELD_FRAMES_COUNT": "This scene has used {frameCount} of {maxFrames} available",
   "FIELD_TRIGGERS_COUNT": "This scene has used {triggerCount} of {maxTriggers} available",
   "FIELD_WARNING": "Warning",
+  "FIELD_TMP_DIRECTORY": "Temp Directory",
+  "FIELD_TMP_DIRECTORY_INFO": "The location where temporary files are stored during the build of your game.\nIf you are unable to build your game due to permissions errors you can change this to a folder that you have access to.",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",
@@ -467,6 +469,7 @@
   "MENU_EJECT_ENGINE": "Eject Engine",
   "MENU_EJECT_PROJECT_BUILD": "Export Project Source",
   "MENU_PASTE_IN_PLACE": "Paste in Place",
+  "MENU_PREFERENCES": "Preferences...",
 
   "// 11": "Warnings -----------------------------------------------------",
 

--- a/src/lib/helpers/getTmp.js
+++ b/src/lib/helpers/getTmp.js
@@ -1,9 +1,12 @@
 import fs from "fs-extra";
 import os from "os";
+import settings from "electron-settings";
 
-export default () => {
+export default (create = true) => {
   let tmpPath = os.tmpdir();
-  if (
+  if (settings.get("tmpDir")) {
+    tmpPath = settings.get("tmpDir");
+  } else if (
     tmpPath.indexOf(" ") === -1 &&
     tmpPath.indexOf(".itch") === -1 &&
     (process.platform !== "win32" || tmpPath.length < 35)
@@ -12,6 +15,8 @@ export default () => {
   } else if (process.platform === "win32") {
     tmpPath = "C:\\tmp";
   } else tmpPath = "/tmp";
-  fs.ensureDirSync(tmpPath);
+  if (create) {
+    fs.ensureDirSync(tmpPath);
+  }
   return tmpPath;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,9 @@ declare var MAIN_WINDOW_WEBPACK_ENTRY: any;
 declare var SPLASH_WINDOW_PRELOAD_WEBPACK_ENTRY: any;
 declare var SPLASH_WINDOW_WEBPACK_ENTRY: any;
 
+declare var PREFERENCES_WINDOW_PRELOAD_WEBPACK_ENTRY: any;
+declare var PREFERENCES_WINDOW_WEBPACK_ENTRY: any;
+
 type SplashTab = "info" | "new" | "recent";
 
 // Stop app launching during squirrel install
@@ -29,6 +32,7 @@ app.allowRendererProcessReuse = false;
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow: any = null;
 let splashWindow: any = null;
+let preferencesWindow: any = null
 let playWindow: any = null;
 let hasCheckedForUpdate = false;
 
@@ -86,6 +90,38 @@ const createSplash = async (forceTab?: SplashTab) => {
     splashWindow = null;
   });
 };
+
+const createPreferences = async (forceTab?: SplashTab) => {
+  // Create the browser window.
+  preferencesWindow = new BrowserWindow({
+    width: 600,
+    height: 280,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    show: false,
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: true,
+      devTools: isDevMode,
+      preload: PREFERENCES_WINDOW_PRELOAD_WEBPACK_ENTRY
+    }
+  });
+
+  preferencesWindow.setMenu(null);
+  preferencesWindow.loadURL(PREFERENCES_WINDOW_WEBPACK_ENTRY);
+
+  preferencesWindow.webContents.on("did-finish-load", () => {
+    setTimeout(() => {
+      preferencesWindow.show();
+    }, 40);
+  });
+
+  preferencesWindow.on("closed", () => {
+    preferencesWindow = null;
+  });
+};
+
 
 const createWindow = async (projectPath: string) => {
   const mainWindowState = windowStateKeeper({
@@ -428,6 +464,14 @@ menu.on("pasteInPlace", () => {
 menu.on("checkUpdates", () => {
   checkForUpdate(true);
 });
+
+menu.on("preferences", () => {
+  if (!preferencesWindow) {
+    createPreferences();
+  } else {
+    preferencesWindow.show();
+  }
+})
 
 menu.on("updateSetting", (setting: string, value: any) => {
   settings.set(setting, value);

--- a/src/menu.js
+++ b/src/menu.js
@@ -95,7 +95,7 @@ const buildMenu = async (plugins = []) => {
           }
         },
         { role: "delete" },
-        { role: "selectall" }
+        { role: "selectall" },
       ]
     },
     {
@@ -396,11 +396,18 @@ const buildMenu = async (plugins = []) => {
             openAbout();
           }
         },
-        { type: "separator" },
         {
           label: l10n("MENU_CHECK_FOR_UPDATES"),
           click: () => {
             notifyListeners("checkUpdates");
+          }
+        },        
+        { type: "separator" },
+        {
+          label: l10n("MENU_PREFERENCES"),
+          accelerator: "CommandOrControl+,",
+          click: () => {
+            notifyListeners("preferences");
           }
         },
         { type: "separator" },
@@ -447,6 +454,18 @@ const buildMenu = async (plugins = []) => {
         }
       }
     );
+
+    // Edit Preferences for Windows / Linux
+    template[1].submenu.push(
+      { type: "separator" },
+      {
+        label: l10n("MENU_PREFERENCES"),
+        accelerator: "CommandOrControl+,",
+        click: () => {
+          notifyListeners("preferences");
+        }
+      }
+    );
   }
 
   menu = Menu.buildFromTemplate(template);
@@ -472,7 +491,8 @@ const listeners = {
   build: [],
   ejectEngine: [],
   ejectProject: [],
-  pasteInPlace: []
+  pasteInPlace: [],
+  preferences: []
 };
 
 const notifyListeners = (event, ...data) => {

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <style id="theme"></style>
+    <title>GB Studio</title>
+  </head>
+  <body>
+    <div id="App"></div>
+    <div id="MenuPortal"></div>
+  </body>
+</html>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,4 +1,5 @@
 @import url("./Splash.css");
+@import url("./Preferences.css");
 @import url("./RTL.css");
 @import url("./../components/forms/DirectionPicker.css");
 @import url("./../components/forms/CustomPalettePicker.css");

--- a/src/styles/Preferences.css
+++ b/src/styles/Preferences.css
@@ -1,0 +1,96 @@
+.Preferences {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.Preferences__Info {
+  white-space: pre-wrap;
+}
+
+.Preferences__FlexSpacer {
+  flex-grow: 1;
+}
+
+.Preferences__FormGroup {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 20px;
+}
+
+.Preferences__FormGroup label {
+  color: #999;
+  padding-bottom: 5px;
+  user-select: none;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.Preferences__FormGroup label input,
+.Preferences__FormGroup label select {
+  margin-top: 5px;
+  flex-shrink: 0;
+}
+
+.Preferences__FormGroup label.Preferences__Label--Error {
+  color: #e91e63;
+}
+
+.Preferences__FormGroup input,
+.Preferences__FormGroup select {
+  height: 28px;
+  font-size: 16px;
+  padding: 5px 10px;
+  padding-right: 42px;
+  border-radius: 4px;
+  background-color: var(--input-bg-color);
+  border: 1px solid var(--input-border-color);
+  color: var(--input-text-color);
+}
+
+.Preferences__FormGroup select {
+  height: 40px;
+}
+
+.Preferences__FormGroup input:focus,
+.Preferences__FormGroup select:focus {
+  outline: none;
+  border-color: transparent;
+  box-shadow: 0 0 0px 2px var(--highlight-color);
+}
+
+.Preferences__InputButton {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  bottom: 9px;
+  right: 4px;
+  border-radius: 2px;
+  height: 32px;
+  width: 40px;
+  user-select: none;
+  cursor: default;
+}
+
+input.Preferences__InputButton {
+  opacity: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.Preferences__InputButton:hover {
+  background-color: #e8e7e8;
+}
+
+.Preferences__InputButton:active {
+  background-color: #cdcdcd;
+}
+
+.Preferences__InputButton svg {
+  fill: var(--main-text-color);
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature, adds the ability to change tmp directory location

* **What is the current behavior?** (You can also link to an open issue here)
The tmp directory is set automatically using Node's `os.tmpdir()` function with a few overrides to handle long folder paths and detecting if the user used the itch.io app to install (both of which have caused issues in the past). As noted by @RichardULZ in the comments of #592 some users due to their environments do not have the permission to create files and run the compiler from within this folder.

* **What is the new behavior (if this is a feature change)?**
The default tmp directory logic is the same but a Preferences window has been added, accessible from the menu, allowing you to specify a manual override. This should allow anyone to set a folder that they do have access to if they have issues while building.

<img width="712" alt="Screenshot 2020-10-06 at 19 47 18" src="https://user-images.githubusercontent.com/16776042/95246694-c0128100-080c-11eb-9131-5d37f5cdef5e.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
I just need to test this appears correctly on the Windows menu, on a Mac this will appear on the application menu as is standard, on Windows/Linux the "Preferences" menu item should appear at the bottom of the Edit menu.