### PR TITLE
Allow the same script to be attached to multiple buttons in "Joypad Input: Attach Script To Button"

### DIFF
--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -2009,13 +2009,13 @@ void Script_SetInputScript_b() {
   }
 
   index = 0;
-  while (!(input & 1) && input != 0) {
-    index += 1;
+  for (index = 0; index != 8; ++index) {
+    if (input & 1) {
+      input_script_ptrs[index].bank = script_cmd_args[2];
+      input_script_ptrs[index].offset = (script_cmd_args[3] * 256) + script_cmd_args[4];
+    }
     input = input >> 1;
   }
-
-  input_script_ptrs[index].bank = script_cmd_args[2];
-  input_script_ptrs[index].offset = (script_cmd_args[3] * 256) + script_cmd_args[4];
 }
 
 /*

--- a/src/lib/events/eventInputScriptSet.js
+++ b/src/lib/events/eventInputScriptSet.js
@@ -6,7 +6,7 @@ const fields = [
   {
     key: "input",
     type: "input",
-    defaultValue: "b"
+    defaultValue: ["b"]
   },
   {
     key: "persist",

--- a/test/migrate/migrate200releases.test.js
+++ b/test/migrate/migrate200releases.test.js
@@ -48,7 +48,7 @@ test("should migrate EVENT_PLAYER_SET_SPRITE events from 2.0.0 r1 to 2.0.0 r2", 
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
     _version: "2.0.0",
-    _release: "2",
+    _release: "3",
     scenes: [
       {
         actors: [],
@@ -74,10 +74,10 @@ test("should migrate EVENT_PLAYER_SET_SPRITE events from 2.0.0 r1 to 2.0.0 r2", 
   });
 });
 
-test("should not migrate EVENT_PLAYER_SET_SPRITE events if already on 2.0.0 r2", () => {
+test("should not migrate EVENT_PLAYER_SET_SPRITE events if already on 2.0.0 r2+", () => {
   const oldProject = {
     _version: "2.0.0",
-    _release: "2",
+    _release: "3",
     scenes: [
       {
         actors: [],
@@ -103,4 +103,110 @@ test("should not migrate EVENT_PLAYER_SET_SPRITE events if already on 2.0.0 r2",
   };
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual(oldProject);
+});
+
+test("should migrate EVENT_SET_INPUT_SCRIPT events from 2.0.0 r2 to 2.0.0 r3", () => {
+  const oldProject = {
+    _version: "2.0.0",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_SET_INPUT_SCRIPT",
+            args: {
+              input: "a",
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  };
+  const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
+  expect(newProject).toEqual({
+    _version: "2.0.0",
+    _release: "3",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_SET_INPUT_SCRIPT",
+            args: {
+              input: ["a"]
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  });
+});
+
+test("should not migrate 2.0.0 r2 EVENT_SET_INPUT_SCRIPT events if they already were arrays (not sure if possible)", () => {
+  const oldProject = {
+    _version: "2.0.0",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_SET_INPUT_SCRIPT",
+            args: {
+              input: ["a", "b"],
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  };
+  const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
+  expect(newProject).toEqual({
+    _version: "2.0.0",
+    _release: "3",
+    scenes: [
+      {
+        actors: [],
+        triggers: [],
+        collisions: [],
+        script: [
+          {
+            id: "abc",
+            command: "EVENT_SET_INPUT_SCRIPT",
+            args: {
+              input: ["a", "b"]
+            },
+          },
+        ],
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [],
+    customEvents: [],
+  });
 });

--- a/test/migrate/migrateProject.test.js
+++ b/test/migrate/migrateProject.test.js
@@ -36,7 +36,7 @@ test("should migrate conditional events from 1.0.0 to 2.0.0", () => {
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
     _version: "2.0.0",
-    _release: "2",
+    _release: "3",
     scenes: [
       {
         width: 32,
@@ -116,7 +116,7 @@ test("should migrate conditional events from 1.2.0 to 2.0.0", () => {
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
     _version: "2.0.0",
-    _release: "2",
+    _release: "3",
     scenes: [
       {
         width: 32,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allow the same script to be attached to multiple buttons in "Joypad Input: Attach Script To Button".
Inspired by @pau-tomas's pull request #593, I decided to implement the ability to attach the same script to multiple buttons. This could be useful in simpler games where there is only one action assigned to both A and B, or where you'd like to temporarily disable player movement by attaching empty scripts to all the D-Pad buttons, for instance.

* **What is the current behavior?** (You can also link to an open issue here)
You cannot attach the same script to multiple buttons without calling "Joypad Input: Attach Script To Button" multiple times.

* **What is the new behavior (if this is a feature change)?**
You now can do the above.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Currently, for existing projects, any "Joypad Input: Attach Script To Button" events would have to be deleted and readded manually. I am looking into implementing a migration script and as such, I am marking this pull request as a draft until the migration script works, but as this pull request stands, this is an issue.

* **Other information**:
Just need to add a migration script, as mentioned above.