### PR TITLE
Fix "none" value for palette select inputs in palette events

### DIFF
--- a/appData/src/gb/engine_version
+++ b/appData/src/gb/engine_version
@@ -1,2 +1,2 @@
 # Don't remove this file, it is used to determine if your ejected engine is out of date.
-2.0.0-e7
+2.0.0-e8

--- a/appData/src/gb/include/Palette.h
+++ b/appData/src/gb/include/Palette.h
@@ -30,5 +30,6 @@ extern UWORD SprPaletteBuffer[32];
 extern UWORD BkgPaletteBuffer[32];
 
 extern UBYTE palette_dirty;
+extern UBYTE palette_update_mask;
 
 #endif

--- a/appData/src/gb/src/core/DataManager.c
+++ b/appData/src/gb/src/core/DataManager.c
@@ -88,8 +88,28 @@ void LoadPalette(UINT16 index) {
   POP_BANK;
 
   PUSH_BANK(bank);
-  memcpy(BkgPalette, data_ptr, 48);
-  POP_BANK;
+  if (palette_update_mask == 0x3F) {
+    memcpy(BkgPalette, data_ptr, 48);
+  } else {
+    if (palette_update_mask & 0x1) {
+      memcpy(BkgPalette, data_ptr, 8);
+    }
+    if (palette_update_mask & 0x2) {
+      memcpy(BkgPalette + 4, data_ptr + 8, 8);
+    }
+    if (palette_update_mask & 0x4) {
+      memcpy(BkgPalette + 8, data_ptr + 16, 8);
+    }
+    if (palette_update_mask & 0x8) {
+      memcpy(BkgPalette + 12, data_ptr + 24, 8);
+    }    
+    if (palette_update_mask & 0x10) {
+      memcpy(BkgPalette + 16, data_ptr + 32, 8);
+    }    
+    if (palette_update_mask & 0x20) {
+      memcpy(BkgPalette + 20, data_ptr + 40, 8);
+    }            
+  }  POP_BANK;
 }
 
 void LoadUIPalette(UINT16 index) {

--- a/appData/src/gb/src/core/Palette.c
+++ b/appData/src/gb/src/core/Palette.c
@@ -1,6 +1,7 @@
 #include "Palette.h"
 
 UBYTE palette_dirty = FALSE;
+UBYTE palette_update_mask = 0x3F;
 
 UWORD SprPalette[32];
 UWORD BkgPalette[32];

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -18,6 +18,7 @@
 #include "Camera.h"
 #include "data_ptrs.h"
 #include "Projectiles.h"
+#include "Palette.h"
 #include "states/Platform.h"
 #include <rand.h>
 
@@ -144,7 +145,7 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_IfActorRelActor_b, 4},     // 0x61
     {Script_PlayerBounce_b, 1},        // 0x62
     {Script_WeaponAttack_b, 2},        // 0x63
-    {Script_PalSetBackground_b, 2},    // 0x64
+    {Script_PalSetBackground_b, 3},    // 0x64
     {Script_PalSetSprite_b, 2},        // 0x65
     {Script_PalSetUI_b, 2},            // 0x66
     {Script_ActorStopUpdate_b, 0},     // 0x67
@@ -2251,7 +2252,8 @@ void Script_WeaponAttack_b() {
 }
 
 void Script_PalSetBackground_b() {
-  LoadPalette((script_cmd_args[0] * 256) + script_cmd_args[1]);
+  palette_update_mask = script_cmd_args[0];
+  LoadPalette((script_cmd_args[1] * 256) + script_cmd_args[2]);
   ApplyPaletteChange();
 }
 

--- a/src/components/script/ScriptEventFormInput.js
+++ b/src/components/script/ScriptEventFormInput.js
@@ -173,6 +173,8 @@ class ScriptEventFormInput extends Component {
             optionalDefaultPaletteId={
               defaultBackgroundPaletteIds[field.paletteIndex] || ""
             }
+            canKeep
+            keepLabel={l10n("FIELD_DONT_MODIFY")}
           />
         );
       }

--- a/src/components/script/ScriptEventFormInput.js
+++ b/src/components/script/ScriptEventFormInput.js
@@ -27,6 +27,7 @@ import { ConnectIcon, CheckIcon, BlankIcon } from "../library/Icons";
 import PropertySelect from "../forms/PropertySelect";
 import CollisionMaskPicker from "../forms/CollisionMaskPicker";
 import { EventValueShape, EventDefaultValueShape } from "../../store/stateShape";
+import l10n from "../../lib/helpers/l10n";
 
 const argValue = (arg) => {
   if(arg && arg.value !== undefined) {
@@ -84,7 +85,7 @@ class ScriptEventFormInput extends Component {
   }  
 
   render() {
-    const { type, id, value, defaultValue, args, field, entityId, allowRename, scope } = this.props;
+    const { type, id, value, defaultValue, args, field, entityId, allowRename, scope, defaultBackgroundPaletteIds, defaultUIPaletteId } = this.props;
 
     if (type === "textarea") {
       return (
@@ -160,8 +161,43 @@ class ScriptEventFormInput extends Component {
       );
     }
     if (type === "palette") {
+      if (field.paletteType === "background") {
+        return (
+          <PaletteSelect
+            id={id}
+            value={value}
+            onChange={this.onChange}
+            prefix={`${field.paletteIndex + 1}: `}
+            optional
+            optionalLabel={l10n("FIELD_GLOBAL_DEFAULT")}
+            optionalDefaultPaletteId={
+              defaultBackgroundPaletteIds[field.paletteIndex] || ""
+            }
+          />
+        );
+      }
+      if (field.paletteType === "ui") {
+        return (
+          <PaletteSelect
+            id={id}
+            value={value}
+            onChange={this.onChange}
+            optional
+            optionalLabel={l10n("FIELD_GLOBAL_DEFAULT")}
+            optionalDefaultPaletteId={
+              defaultUIPaletteId || ""
+            }
+          />
+        );
+      }      
       return (
-        <PaletteSelect id={id} value={value} onChange={this.onChange} optional />
+        <PaletteSelect
+          id={id}
+          value={value}
+          onChange={this.onChange}
+          optional
+          optionalLabel={l10n("FIELD_GLOBAL_DEFAULT")}
+        />
       );
     }
     if (type === "sprite") {
@@ -318,7 +354,9 @@ ScriptEventFormInput.propTypes = {
   defaultValue: EventDefaultValueShape,
   allowRename: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
-  scope: PropTypes.string.isRequired
+  scope: PropTypes.string.isRequired,
+  defaultBackgroundPaletteIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  defaultUIPaletteId: PropTypes.string.isRequired
 };
 
 ScriptEventFormInput.defaultProps = {
@@ -328,15 +366,21 @@ ScriptEventFormInput.defaultProps = {
   defaultValue: undefined,
   args: {},
   type: "",
-  allowRename: true
+  allowRename: true,
 };
 
 function mapStateToProps(state) {
   const scope = state.editor.type === "customEvent"
     ? "customEvent"
     : "global";
+  const settings = state.project.present.settings;
+  const defaultBackgroundPaletteIds =
+    settings.defaultBackgroundPaletteIds || [];
+  const defaultUIPaletteId = settings.defaultUIPaletteId || "";
   return {
-    scope
+    scope,
+    defaultBackgroundPaletteIds,
+    defaultUIPaletteId
   };
 }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -266,6 +266,7 @@
   "FIELD_WARNING": "Warning",
   "FIELD_TMP_DIRECTORY": "Temp Directory",
   "FIELD_TMP_DIRECTORY_INFO": "The location where temporary files are stored during the build of your game.\nIf you are unable to build your game due to permissions errors you can change this to a folder that you have access to.",
+  "FIELD_DONT_MODIFY": "Don't modify",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/lib/compiler/helpers.js
+++ b/src/lib/compiler/helpers.js
@@ -273,3 +273,12 @@ export const fadeStyleDec = (style) => {
   }
   return 0;
 }
+
+export const paletteMaskDec = (mask) => {
+  return mask.reduce((memo, value, index) => {
+    if (!value) {
+      return memo;
+    }
+    return memo + Math.pow(2, index);
+  }, 0);
+}

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -116,6 +116,7 @@ import {
   moveSpeedDec,
   animSpeedDec,
   collisionMaskDec,
+  paletteMaskDec,
   combineMultipleChoiceText,
   collisionGroupDec,
   actorRelativeDec,
@@ -353,11 +354,12 @@ class ScriptBuilder {
 
   // Palette
 
-  paletteSetBackground = (eventId) => {
+  paletteSetBackground = (eventId, mask) => {
     const output = this.output;
     const { eventPaletteIndexes } = this.options;
     const paletteIndex = eventPaletteIndexes[eventId] || 0;
     output.push(cmd(PALETTE_SET_BACKGROUND));
+    output.push(paletteMaskDec(mask));
     output.push(hi(paletteIndex));
     output.push(lo(paletteIndex));
   }

--- a/src/lib/events/eventPaletteSetBackground.js
+++ b/src/lib/events/eventPaletteSetBackground.js
@@ -5,31 +5,43 @@ const fields = [
     key: "palette0",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 0
   },
   {
     key: "palette1",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 1 
   },
   {
     key: "palette2",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 2  
   },
   {
     key: "palette3",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 3    
   },
   {
     key: "palette4",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 4      
   },
   {
     key: "palette5",
     type: "palette",
     defaultValue: "",
+    paletteType: "background",
+    paletteIndex: 5       
   },
 ];
 

--- a/src/lib/events/eventPaletteSetBackground.js
+++ b/src/lib/events/eventPaletteSetBackground.js
@@ -6,48 +6,55 @@ const fields = [
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 0
+    paletteIndex: 0,
+    canKeep: true
   },
   {
     key: "palette1",
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 1 
+    paletteIndex: 1,
+    canKeep: true
   },
   {
     key: "palette2",
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 2  
+    paletteIndex: 2,
+    canKeep: true
   },
   {
     key: "palette3",
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 3    
+    paletteIndex: 3,
+    canKeep: true
   },
   {
     key: "palette4",
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 4      
+    paletteIndex: 4,
+    canKeep: true    
   },
   {
     key: "palette5",
     type: "palette",
     defaultValue: "",
     paletteType: "background",
-    paletteIndex: 5       
+    paletteIndex: 5,
+    canKeep: true
   },
 ];
 
 const compile = (input, helpers) => {
   const { paletteSetBackground, event } = helpers;
-  paletteSetBackground(event.id);
+  const mask = [0,1,2,3,4,5].map((i) => input[`palette${i}`] !== "keep")
+  paletteSetBackground(event.id, mask);
 };
 
 module.exports = {

--- a/src/lib/events/eventPaletteSetUI.js
+++ b/src/lib/events/eventPaletteSetUI.js
@@ -5,6 +5,7 @@ const fields = [
     key: "palette",
     type: "palette",
     defaultValue: "",
+    paletteType: "ui"
   }
 ];
 

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -68,6 +68,15 @@ const changes: EngineChange[] = [{
         "src/core/Scroll.c",
         "src/core/Scroll_b.c",
     ]
+}, {
+    version: "2.0.0-e8",
+    description: "Add support for preserving some background palettes while palette swapping",
+    modifiedFiles: [
+        "include/Palette.h",
+        "src/core/DataManager.c",
+        "src/core/Palette.c",
+        "src/core/ScriptRunner_b.c",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements a request from #591 making the palette select inputs on palette events clearer

* **What is the current behavior?** (You can also link to an open issue here)
As seen in #591 palette events have a default label of "None" with the swatch preview showing the default DMG colors when actually choosing this value would use the scene default colors defined on the Settings page.

* **What is the new behavior (if this is a feature change)?**
The palette update events have been updated to closer match how they work in the Scene editor sidebar. The default label now says "Global Default", the palette number is prefixed before each label, and the swatch preview shows the global palette that would be used.

<img width="260" alt="Screenshot 2020-10-07 at 21 33 52" src="https://user-images.githubusercontent.com/16776042/95385516-07207500-08e6-11eb-938d-f6ee8d6de2eb.png">

<img width="260" alt="Screenshot 2020-10-07 at 21 34 08" src="https://user-images.githubusercontent.com/16776042/95385526-0982cf00-08e6-11eb-88f0-bb9f6b8bd5f3.png">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
