### PR TITLE
Switch dialogue event text input to use monospace font making it easier to align text in game

### DIFF
--- a/src/components/script/ScriptEditor.css
+++ b/src/components/script/ScriptEditor.css
@@ -680,6 +680,7 @@
   width: 100%;
   box-sizing: border-box;
   height: auto;
+  font-family: 'Courier New', Courier, monospace;
 }
 
 .ScriptEditorEvent__FormRow {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements enhancement request from #602 

* **What is the current behavior?** (You can also link to an open issue here)
"Display Dialogue" event textarea input uses variable width fonts making it difficult to align how text will appear ingame from the editor

* **What is the new behavior (if this is a feature change)?**
"Display Dialogue" event textarea has been switched to use a monospace font to closer align with ingame appearance.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
