### PR TITLE
Add event "If Actor In Boundary"

### DIFF
--- a/appData/src/gb/include/ScriptRunner.h
+++ b/appData/src/gb/include/ScriptRunner.h
@@ -187,5 +187,6 @@ void Script_ActorStopUpdate_b();
 void Script_ActorSetAnimate_b();
 void Script_IfColorSupported_b();
 void Script_FadeSetSettings_b();
+void Script_IfActorInBoundary_b();
 
 #endif

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -154,6 +154,7 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_ActorSetAnimate_b, 1},     // 0x68
     {Script_IfColorSupported_b, 2},    // 0x69
     {Script_FadeSetSettings_b, 1},     // 0x6A
+    {Script_IfActorInBoundary_b, 6},   // 0x6B
 };
 
 void ScriptTimerUpdate_b() {
@@ -2293,5 +2294,13 @@ void Script_ActorSetAnimate_b() {
 void Script_IfColorSupported_b() {
   if (_cpu == CGB_TYPE) {
     active_script_ctx.script_ptr = active_script_ctx.script_start_ptr + (script_cmd_args[0] * 256) + script_cmd_args[1];
+  }
+}
+
+void Script_IfActorInBoundary_b() {
+  UBYTE tile_x = actors[active_script_ctx.script_actor].pos.x >> 3;
+  UBYTE tile_y = actors[active_script_ctx.script_actor].pos.y >> 3;
+  if (tile_x >= script_cmd_args[0] && tile_x <= script_cmd_args[1] && tile_y >= script_cmd_args[2] && tile_y <= script_cmd_args[3]) {
+    active_script_ctx.script_ptr = active_script_ctx.script_start_ptr + (script_cmd_args[4] * 256) + script_cmd_args[5];
   }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -293,6 +293,7 @@
   "EVENT_IF_INPUT": "If Joypad Input Pressed",
   "EVENT_IF_ACTOR_AT_POSITION": "If Actor At Position",
   "EVENT_IF_ACTOR_DIRECTION": "If Actor Facing Direction",
+  "EVENT_IF_ACTOR_IN_BOUNDARY": "If Actor In Boundary",
   "EVENT_SET_TRUE": "Variable: Set To 'True'",
   "EVENT_SET_FALSE": "Variable: Set To 'False'",
   "EVENT_SET_VALUE": "Variable: Set To Value",

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -96,7 +96,8 @@ import {
   ACTOR_STOP_UPDATE,
   ACTOR_SET_ANIMATE,
   IF_COLOR_SUPPORTED,
-  FADE_SET_SETTINGS
+  FADE_SET_SETTINGS,
+  IF_ACTOR_IN_BOUNDARY
 } from "../events/scriptCommands";
 import {
   getActorIndex,
@@ -1202,7 +1203,20 @@ class ScriptBuilder {
       output,
     });
 
-  }
+  };
+
+  ifActorInBoundary = (x1, y1, x2, y2, truePath = [], falsePath = []) => {
+    const output = this.output;
+    output.push(cmd(IF_ACTOR_IN_BOUNDARY));
+    output.push(x1);
+    output.push(x2);
+    output.push(y1);
+    output.push(y2);
+    compileConditional(truePath, falsePath, {
+      ...this.options,
+      output,
+    });
+  };
 
   // Helpers
 

--- a/src/lib/events/eventIfActorInBoundary.js
+++ b/src/lib/events/eventIfActorInBoundary.js
@@ -1,0 +1,122 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_IF_ACTOR_IN_BOUNDARY";
+
+const fields = [
+  {
+    label: l10n("FIELD_IF_ACTOR_IN_BOUNDARY")
+  },
+  {
+    key: "actorId",
+    type: "actor",
+    defaultValue: "player"
+  },
+  {
+    key: "x1",
+    label: "X1",
+    type: "union",
+    types: ["number", "variable", "property"],
+    defaultType: "number",
+    min: 0,
+    max: 255,
+    width: "50%",
+    defaultValue: {
+      number: 0,
+      variable: "LAST_VARIABLE",
+      property: "$self$:xpos"
+    },
+  },
+  {
+    key: "y1",
+    label: "Y1",
+    type: "union",
+    types: ["number", "variable", "property"],
+    defaultType: "number",
+    min: 0,
+    max: 255,
+    width: "50%",
+    defaultValue: {
+      number: 0,
+      variable: "LAST_VARIABLE",
+      property: "$self$:xpos"
+    },   
+  },
+  {
+    key: "x2",
+    label: "X2",
+    type: "union",
+    types: ["number", "variable", "property"],
+    defaultType: "number",
+    min: 0,
+    max: 255,
+    width: "50%",
+    defaultValue: {
+      number: 0,
+      variable: "LAST_VARIABLE",
+      property: "$self$:xpos"
+    },
+  },
+  {
+    key: "y2",
+    label: "Y2",
+    type: "union",
+    types: ["number", "variable", "property"],
+    defaultType: "number",
+    min: 0,
+    max: 255,
+    width: "50%",
+    defaultValue: {
+      number: 0,
+      variable: "LAST_VARIABLE",
+      property: "$self$:xpos"
+    },   
+  },
+  {
+    key: "true",
+    type: "events"
+  },
+  {
+    key: "__collapseElse",
+    label: l10n("FIELD_ELSE"),
+    type: "collapsable",
+    defaultValue: false,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ]
+  },
+  {
+    key: "false",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true
+      },
+      {
+        key: "__disableElse",
+        ne: true
+      }
+    ],
+    type: "events"
+  }
+];
+
+const compile = (input, helpers) => {
+  const { actorSetActive, ifActorInBoundary } = helpers;
+  const x1 = input.x1.value;
+  const y1 = input.y1.value;
+  const x2 = input.x2.value;
+  const y2 = input.y2.value;
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+  actorSetActive(input.actorId);
+  ifActorInBoundary(x1, y1, x2, y2, truePath, falsePath);
+};
+
+module.exports = {
+  id,
+  fields,
+  compile
+};

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -105,6 +105,7 @@ export const ACTOR_STOP_UPDATE = "ACTOR_STOP_UPDATE";
 export const ACTOR_SET_ANIMATE = "ACTOR_SET_ANIMATE";
 export const IF_COLOR_SUPPORTED = "IF_COLOR_SUPPORTED";
 export const FADE_SET_SETTINGS = "FADE_SET_SETTINGS";
+export const IF_ACTOR_IN_BOUNDARY = "IF_ACTOR_IN_BOUNDARY";
 
 export const scriptCommands = [
   END,
@@ -214,6 +215,7 @@ export const scriptCommands = [
   ACTOR_SET_ANIMATE,
   IF_COLOR_SUPPORTED,
   FADE_SET_SETTINGS,
+  IF_ACTOR_IN_BOUNDARY,
 ];
 
 export const commandIndex = key => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the event "If Actor In Boundary". This event checks whether the specified actor is in the boundary. The boundary is rectangular, from top left (X1, Y1) to bottom right (X2, Y2).
![If Actor In Boundary](https://user-images.githubusercontent.com/14967142/95667402-8bb40300-0b33-11eb-8617-8e299d3a64e0.gif)


* **What is the current behavior?** (You can also link to an open issue here)
You cannot check whether an actor is in a boundary without using several events (slower) and quite a few variables. You can also attempt to fake this functionality using triggers, but that has its own drawbacks.


* **What is the new behavior (if this is a feature change)?**
You can now easily check if an actor is in a specified boundary.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I'm aware of.


* **Other information**:
As with my previous pull request, not sure if I'm adding events correctly, but it works. It would be nice to add some visual indication in the GUI on the Game World page for where the boundary is, much like what can be seen with triggers or events like "Actor: Move To". 