### PR TITLE
Fix edge cases in trimlines

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -32,7 +32,6 @@ import {
 } from "./eventTypes";
 import { projectTemplatesRoot, MAX_ACTORS, MAX_TRIGGERS, DMG_PALETTE, SPRITE_TYPE_STATIC, TMP_VAR_1, TMP_VAR_2 } from "../../consts";
 import {
-  combineMultipleChoiceText,
   dirDec,
   dirToXDec,
   dirToYDec,
@@ -709,11 +708,6 @@ export const precompileStrings = (scenes) => {
           }
         }
       } else if (strings.indexOf(text) === -1) {
-        strings.push(text);
-      }
-    } else if (cmd.command === EVENT_CHOICE) {
-      const text = combineMultipleChoiceText(cmd.args);
-      if (strings.indexOf(text) === -1) {
         strings.push(text);
       }
     }

--- a/src/lib/compiler/helpers.js
+++ b/src/lib/compiler/helpers.js
@@ -143,12 +143,6 @@ export const actorFramesPerDir = (spriteType, numFrames) => {
   return numFrames;
 };
 
-export const combineMultipleChoiceText = (args) => {
-  const trueText = args.trueText || "Choice A";
-  const falseText = args.falseText || "Choice B";
-  return `${trueText}\n${falseText}`;
-};
-
 export const isMBC1 = (cartType) => cartType === "03" || cartType === "02";
 
 export const replaceInvalidCustomEventVariables = (variable) => {

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -117,7 +117,6 @@ import {
   animSpeedDec,
   collisionMaskDec,
   paletteMaskDec,
-  combineMultipleChoiceText,
   collisionGroupDec,
   actorRelativeDec,
   moveTypeDec,
@@ -128,6 +127,7 @@ import {
   fadeStyleDec,
 } from "./helpers";
 import { hi, lo } from "../helpers/8bit";
+import trimlines from "../helpers/trimlines";
 import { SPRITE_TYPE_ACTOR } from "../../consts";
 
 class ScriptBuilder {
@@ -387,7 +387,11 @@ class ScriptBuilder {
   textDialogue = (inputText = " ", avatarId) => {
     const output = this.output;
     const { strings, avatars, variables, event } = this.options;
-    const text = this.replaceVariables(inputText, variables, event);
+    let text = this.replaceVariables(inputText, variables, event);
+
+    const maxPerLine = avatarId ? 16 : 18;
+    text = trimlines(text, maxPerLine);
+
     let stringIndex = strings.indexOf(text);
     if (stringIndex === -1) {
       strings.push(text);
@@ -411,7 +415,11 @@ class ScriptBuilder {
   textChoice = (setVariable, args) => {
     const output = this.output;
     const { strings, variables, event } = this.options;
-    const choiceText = combineMultipleChoiceText(args);
+
+    const trueText = trimlines(args.trueText || "", 17, 1)  || "Choice A";
+    const falseText = trimlines(args.falseText || "", 17, 1) || "Choice B";
+    const choiceText = `${trueText}\n${falseText}`;
+
     const text = this.replaceVariables(choiceText, variables, event);
     let stringIndex = strings.indexOf(text);
     if (stringIndex === -1) {
@@ -437,7 +445,7 @@ class ScriptBuilder {
     const output = this.output;
     const { strings, variables, event } = this.options;
     const menuText = options
-      .map((option, index) => option || `Item ${index + 1}`)
+      .map((option, index) => trimlines(option || "", 6, 1) || `Item ${index + 1}`)
       .join("\n");
     const text = this.replaceVariables(menuText, variables, event);
     let stringIndex = strings.indexOf(text);

--- a/src/lib/helpers/trimlines.js
+++ b/src/lib/helpers/trimlines.js
@@ -7,89 +7,80 @@ const varRegex = new RegExp("\\$[VLT]?[0-9]+\\$", "g");
 const varCharRegex = new RegExp("#[VLT]?[0-9]+#", "g");
 const commandRegex = new RegExp("\\!S[0-5]\\!", "g");
 
-const startsWithVarRegex = new RegExp("^\\$[VLT]?[0-9]+\\$");
-const startsWithVarCharRegex = new RegExp("^#[VLT]?[0-9]+#");
-const startsWithCommandRegex = new RegExp("^\\!S[0-5]\\!");
-
 export const lineLength = (line) => {
   return line
     .replace(varRegex, "255")
     .replace(varCharRegex, "C")
-    .replace(commandRegex, "")
-    .length
-}
-
-const trimlines = (string, maxCharsPerLine = CHARS_PER_LINE, maxLines = LINE_MAX) => {
-  let lengthCount = 0;
-
-  return string
-    .split("\n")
-    .map((line, lineIndex) => {
-
-      let cropLength = 0;
-      let textLength = 0;
-
-      // Determine crop length by checking for escape codes
-      for (let i=0; i<line.length; i++) {
-        const remaining = line.substring(i);
-
-        if (remaining.match(startsWithCommandRegex)) {
-          i += 3;
-          cropLength += 4;
-        } else if (remaining.match(startsWithVarRegex)) {
-          if (textLength + 3 < maxCharsPerLine) {
-            textLength += 3;
-            cropLength += remaining.match(startsWithVarRegex)[0].length;            
-          }
-        } else if (remaining.match(startsWithVarCharRegex)) {
-          if (textLength + 1 < maxCharsPerLine) {
-            textLength += 1;
-            cropLength += remaining.match(startsWithVarCharRegex)[0].length;            
-          }
-        } else if (textLength < maxCharsPerLine) {
-          textLength++;
-          cropLength++;
-        } else {
-          break;
-        }
-      }
-
-      if (lineIndex === maxLines - 1) {
-        return line.substring(0, cropLength);
-      }
-
-      if (lineLength(line) <= maxCharsPerLine) {
-        return line;
-      }
-      const lastBreakSymbol = line
-        .substring(0, cropLength + 1)
-        .lastIndexOf(" ");
-      if (lastBreakSymbol > -1) {
-        return `${line.substring(0, lastBreakSymbol)}\n${line.substring(
-          lastBreakSymbol + 1,
-          lastBreakSymbol + cropLength + 1
-        )}`;
-      }
-
-      return line.substring(0, cropLength);
-    })
-    .join("\n")
-    .split("\n")
-    .map(line => {
-      // Trim text over max limit
-      lengthCount += line.length;
-      if (lengthCount > CHARS_MAX_TOTAL) {
-        const amountOver = lengthCount - CHARS_MAX_TOTAL;
-        return line.substring(0, line.length - amountOver);
-      }
-      return line;
-    })
-    .slice(0, maxLines)
-    .join("\n");
-
+    .replace(commandRegex, "").length;
 };
 
-export const textNumLines = string =>
+const cropLine = (line, maxLength) => {
+  const len = lineLength(line);
+  if (len <= maxLength) {
+    return line;
+  }
+  const lenDiff = len - maxLength;
+  const cropped = line.substring(0, line.length - lenDiff);
+  return cropLine(cropped, maxLength);
+};
+
+const trimlines = (
+  string,
+  maxCharsPerLine = CHARS_PER_LINE,
+  maxLines = LINE_MAX
+) => {
+  let lengthCount = 0;
+
+  return (
+    string
+      .split("\n")
+      .map((line, lineIndex) => {
+
+        // Include whole line if under limits
+        if (lineLength(line) <= maxCharsPerLine) {
+          return line;
+        }
+
+        let cropped = line;
+        // If not last line
+        if (lineIndex < maxLines - 1) {
+          // Crop to last space if possible
+          if (cropped.indexOf(" ") > -1) {
+            while (cropped.indexOf(" " > -1)) {
+              const lastBreakSymbol = cropped.lastIndexOf(" ");
+              cropped = cropped.substring(0, lastBreakSymbol);
+              if (lineLength(cropped) <= maxCharsPerLine) {
+                return `${cropped}\n${trimlines(
+                  line.substring(cropped.length + 1, line.length),
+                  maxCharsPerLine,
+                  maxLines
+                )}`;
+              }
+            }
+          }
+        }
+
+        // Fallback to just cropping the line to fit mid word
+        return cropLine(line, maxCharsPerLine);
+      })
+      .join("\n")
+      .split("\n")
+      .map((line) => {
+        lengthCount += lineLength(line);
+        if (lengthCount > CHARS_MAX_TOTAL) {
+          const amountOver = lengthCount - CHARS_MAX_TOTAL;
+          return line.substring(0, line.length - amountOver);
+        }
+        return line;
+      })
+      .slice(0, maxLines)
+      .join("\n")
+      // Crop to max 80 characters used in C string buffer
+      .substring(0, 80)
+  );
+};
+
+export const textNumLines = (string) =>
   Math.max(LINE_MIN, (string || "").split("\n").length);
 
 export default trimlines;

--- a/test/helpers/trimlines.test.js
+++ b/test/helpers/trimlines.test.js
@@ -5,6 +5,7 @@ test("shouldn't modify strings under line limit", () => {
 });
 
 test("should trim strings over line limit", () => {
+  expect(trimlines("0123456789012345678")).toBe("012345678901234567", 18);
   expect(trimlines("01234567890123456789")).toBe("012345678901234567", 18);
 });
 
@@ -16,6 +17,12 @@ test("should trim full string to 52 characters", () => {
   expect(
     trimlines("012345678901234567\n012345678901234567\n012345678901234567")
   ).toBe("012345678901234567\n012345678901234567\n0123456789012345", 18);
+});
+
+test("should keep cropped word on last line", () => {
+  expect(
+    trimlines("012345678901234567\n012345678901234567\n012345678901 234567")
+  ).toBe("012345678901234567\n012345678901234567\n012345678901 234", 18);
 });
 
 test("should allow 52 characters to be distributed any way across the three lines", () => {
@@ -75,6 +82,30 @@ test("should treat variable characters as length=1 in character limits", () => {
   expect(
     trimlines("Hell#L0#\nWorld", 5)
   ).toBe("Hell#L0#\nWorld");   
+});
+
+test("should treat variables as length=3 in total limits", () => {
+  expect(
+    trimlines("$L0$Hello\nWorld", 5, 1)
+  ).toBe("$L0$He");  
+  expect(
+    trimlines("He$L0$\nWorld", 5, 1)
+  ).toBe("He$L0$");    
+  expect(
+    trimlines("Hello$L0$\nWorld", 5, 1)
+  ).toBe("Hello");   
+});
+
+test("should treat variable characters as length=1 in total limits", () => {
+  expect(
+    trimlines("HelloWorld", 5, 1)
+  ).toBe("Hello");
+  expect(
+    trimlines("#L0#HelloWorld", 5, 1)
+  ).toBe("#L0#Hell"); 
+  expect(
+    trimlines("01234567890123456#L0#\n01234567890123456#L0#\n012345678901234#L0#67")
+  ).toBe("01234567890123456#L0#\n01234567890123456#L0#\n012345678901234#L0#", 18);
 });
 
 test("should allow trimming text to a single line using third arg", () => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for edge cases in `trimlines` function used for string trimming to fit character limits.
 
* **What is the current behavior?** (You can also link to an open issue here)
Since an issue in beta3 prevented input from being trimmed automatically projects could have text that overflows into the background tiles, while the latest dev builds mostly fix this issue if anyone made a broken text event in beta3 it wouldn't be fixed in beta4 until they manually edited the event. There are also a handful of edge cases I've found where variables ($L0$), characters codes (#L0#) and speed codes (!S3!) contribute more characters to totals than they should so cause unnecessary cropping.

* **What is the new behavior (if this is a feature change)?**
1. Additional calls to `trimlines()` have been added to `scriptBuilder.js` to make sure that any invalid data created in beta3 (or by manually editing the gbsproj file) is trimmed to the correct length before building the game.
2. `trimlines()` has been updated to correctly treat variables as 3 characters, character codes as one character and speed code to have no length and to crop strings accordingly.
3. An additional cropping to a maximum of 80 characters has been added as is this is the size of the C string buffer used in the game engine

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It shouldn't do, all the existing string trimming tests pass with no changes, a number of additional tests have been added for the extra edge cases.
