### PR TITLE
Fix movement in Adventure mode

### DIFF
--- a/appData/src/gb/engine_version
+++ b/appData/src/gb/engine_version
@@ -1,2 +1,2 @@
 # Don't remove this file, it is used to determine if your ejected engine is out of date.
-2.0.0-e8
+2.0.0-e9

--- a/appData/src/gb/include/Input.h
+++ b/appData/src/gb/include/Input.h
@@ -14,34 +14,34 @@
 #define ALLOW_DEFAULT_INPUT_B (ui_block || !GET_BIT(input_override_default,5))
 
 /* TRUE if left is being held on dpad */
-#define INPUT_LEFT ALLOW_DEFAULT_INPUT_LEFT && (joy & J_LEFT)
+#define INPUT_LEFT (ALLOW_DEFAULT_INPUT_LEFT && (joy & J_LEFT))
 
 /* TRUE if right is being held on dpad */
-#define INPUT_RIGHT ALLOW_DEFAULT_INPUT_RIGHT && (joy & J_RIGHT)
+#define INPUT_RIGHT (ALLOW_DEFAULT_INPUT_RIGHT && (joy & J_RIGHT))
 
 /* TRUE if up is being held on dpad */
-#define INPUT_UP ALLOW_DEFAULT_INPUT_UP && (joy & J_UP)
+#define INPUT_UP (ALLOW_DEFAULT_INPUT_UP && (joy & J_UP))
 
 /* TRUE if down is being held on dpad */
-#define INPUT_DOWN ALLOW_DEFAULT_INPUT_DOWN && (joy & J_DOWN)
+#define INPUT_DOWN (ALLOW_DEFAULT_INPUT_DOWN && (joy & J_DOWN))
 
 /* TRUE if left is being held on dpad */
-#define INPUT_RECENT_LEFT ALLOW_DEFAULT_INPUT_LEFT && ((recent_joy & J_LEFT) || (!recent_joy && (joy & J_LEFT)))
+#define INPUT_RECENT_LEFT (ALLOW_DEFAULT_INPUT_LEFT && ((recent_joy & J_LEFT) || (!recent_joy && (joy & J_LEFT))))
 
 /* TRUE if right is being held on dpad */
-#define INPUT_RECENT_RIGHT ALLOW_DEFAULT_INPUT_RIGHT && ((recent_joy & J_RIGHT) || (!recent_joy && (joy & J_RIGHT)))
+#define INPUT_RECENT_RIGHT (ALLOW_DEFAULT_INPUT_RIGHT && ((recent_joy & J_RIGHT) || (!recent_joy && (joy & J_RIGHT))))
 
 /* TRUE if up is being held on dpad */
-#define INPUT_RECENT_UP ALLOW_DEFAULT_INPUT_UP && ((recent_joy & J_UP) || (!recent_joy && (joy & J_UP)))
+#define INPUT_RECENT_UP (ALLOW_DEFAULT_INPUT_UP && ((recent_joy & J_UP) || (!recent_joy && (joy & J_UP))))
 
 /* TRUE if down is being held on dpad */
-#define INPUT_RECENT_DOWN ALLOW_DEFAULT_INPUT_DOWN && ((recent_joy & J_DOWN) || (!recent_joy && (joy & J_DOWN)))
+#define INPUT_RECENT_DOWN (ALLOW_DEFAULT_INPUT_DOWN && ((recent_joy & J_DOWN) || (!recent_joy && (joy & J_DOWN))))
 
 /* TRUE if A button is being held */
-#define INPUT_A ALLOW_DEFAULT_INPUT_A && (joy & J_A)
+#define INPUT_A (ALLOW_DEFAULT_INPUT_A && (joy & J_A))
 
 /* TRUE if B button is being held */
-#define INPUT_B ALLOW_DEFAULT_INPUT_B && (joy & J_B)
+#define INPUT_B (ALLOW_DEFAULT_INPUT_B && (joy & J_B))
 
 /* TRUE if Start button is being held */
 #define INPUT_START (joy & J_START)
@@ -50,22 +50,22 @@
 #define INPUT_SELECT (joy & J_SELECT)
 
 /* TRUE on first frame that left is pressed on dpad  */
-#define INPUT_LEFT_PRESSED ALLOW_DEFAULT_INPUT_LEFT && ((joy & J_LEFT) && !(last_joy & J_LEFT))
+#define INPUT_LEFT_PRESSED (ALLOW_DEFAULT_INPUT_LEFT && ((joy & J_LEFT) && !(last_joy & J_LEFT)))
 
 /* TRUE on first frame that right is pressed on dpad  */
-#define INPUT_RIGHT_PRESSED ALLOW_DEFAULT_INPUT_RIGHT && ((joy & J_RIGHT) && !(last_joy & J_RIGHT))
+#define INPUT_RIGHT_PRESSED (ALLOW_DEFAULT_INPUT_RIGHT && ((joy & J_RIGHT) && !(last_joy & J_RIGHT)))
 
 /* TRUE on first frame that up is pressed on dpad  */
-#define INPUT_UP_PRESSED ALLOW_DEFAULT_INPUT_UP && ((joy & J_UP) && !(last_joy & J_UP))
+#define INPUT_UP_PRESSED (ALLOW_DEFAULT_INPUT_UP && ((joy & J_UP) && !(last_joy & J_UP)))
 
 /* TRUE on first frame that down is pressed on dpad  */
-#define INPUT_DOWN_PRESSED ALLOW_DEFAULT_INPUT_DOWN && ((joy & J_DOWN) && !(last_joy & J_DOWN))
+#define INPUT_DOWN_PRESSED (ALLOW_DEFAULT_INPUT_DOWN && ((joy & J_DOWN) && !(last_joy & J_DOWN)))
 
 /* TRUE on first frame that A button is pressed */
-#define INPUT_A_PRESSED ALLOW_DEFAULT_INPUT_A && ((joy & J_A) && !(last_joy & J_A))
+#define INPUT_A_PRESSED (ALLOW_DEFAULT_INPUT_A && ((joy & J_A) && !(last_joy & J_A)))
 
 /* TRUE on first frame that B button is pressed */
-#define INPUT_B_PRESSED ALLOW_DEFAULT_INPUT_B && ((joy & J_B) && !(last_joy & J_B))
+#define INPUT_B_PRESSED (ALLOW_DEFAULT_INPUT_B && ((joy & J_B) && !(last_joy & J_B)))
 
 /* TRUE on first frame that Start button is pressed */
 #define INPUT_START_PRESSED ((joy & J_START) && !(last_joy & J_START))

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -77,6 +77,12 @@ const changes: EngineChange[] = [{
         "src/core/Palette.c",
         "src/core/ScriptRunner_b.c",
     ]
+}, {
+    version: "2.0.0-e9",
+    description: "Fix movement in Adventure mode",
+    modifiedFiles: [
+        "include/Input.h",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
Fox for #611 - Adventure scene type movement is broken

Regression introduced in 410e6bec5d5b6f279d60fe41109410d5b4ef5bab

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Player only moves in diagonal in Adventure mode as reported in #611 

* **What is the new behavior (if this is a feature change)?**

Player can move in any of the 8 directions in Adventure mode

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
