### PR TITLE
Update Timer script even if On Update scripts are running

### DIFF
--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -157,8 +157,8 @@ const SCRIPT_CMD script_cmds[] = {
 };
 
 void ScriptTimerUpdate_b() {
-  // Don't update timer while script is running
-  if (active_script_ctx.script_ptr != 0) {
+  // Don't update timer while a non-background script is running
+  if (script_ctxs[0].script_ptr != 0) {
     return;
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Timer scripts aren't executed if there's On Update scripts (that don't contain a Wait event) in the scene.

* **What is the new behavior (if this is a feature change)?**

Timer scripts run even when On Update scripts are present.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

🤷 I'm not sure of the side effects of the change. But the assumption is that `script_ctxs[0]` is used only for non-background scripts so `On Update` ones are never assigned there.

* **Other information**:

N/A