### PR TITLE
Bugfixes for Attach Script to Button 

### DIFF
--- a/appData/src/gb/engine_version
+++ b/appData/src/gb/engine_version
@@ -1,2 +1,2 @@
 # Don't remove this file, it is used to determine if your ejected engine is out of date.
-2.0.0-e9
+2.0.0-e10

--- a/appData/src/gb/src/core/Input.c
+++ b/appData/src/gb/src/core/Input.c
@@ -41,6 +41,7 @@ void RemoveInputScripts() {
   for (i = 0; i != 8; ++i) {
     if (!GET_BIT(input_script_persist, i)) {
       input_script_ptrs[i].bank = 0;
+      UNSET_BIT(input_override_default, i);
     }
   }
 }

--- a/src/components/forms/InputPicker.js
+++ b/src/components/forms/InputPicker.js
@@ -90,7 +90,7 @@ const renderButton = (id, value, onChange) => input => (
       }
       onChange={() => {
         if (Array.isArray(value)) {
-          if (value.indexOf(input.key) > -1) {
+          if (value.indexOf(input.key) > -1 && value.length > 1) {
             onChange(value.filter(i => i !== input.key));
           } else {
             onChange([].concat(value, input.key));

--- a/src/components/forms/InputPicker.js
+++ b/src/components/forms/InputPicker.js
@@ -90,8 +90,10 @@ const renderButton = (id, value, onChange) => input => (
       }
       onChange={() => {
         if (Array.isArray(value)) {
-          if (value.indexOf(input.key) > -1 && value.length > 1) {
-            onChange(value.filter(i => i !== input.key));
+          if (value.indexOf(input.key) > -1) {
+            if (value.length > 1) {
+              onChange(value.filter(i => i !== input.key));
+            }
           } else {
             onChange([].concat(value, input.key));
           }

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -83,6 +83,12 @@ const changes: EngineChange[] = [{
     modifiedFiles: [
         "include/Input.h",
     ]
+}, {
+    version: "2.0.0-e10",
+    description: "Fix bug where an attached script overrides default behavior even when not persisted between scenes",
+    modifiedFiles: [
+        "src/core/Input.c ",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Two small fixes for regressions introduced by the recent changes on Attach Script to Button

* **What is the current behavior?** (You can also link to an open issue here)

1) When `Attach Script to Button` doesn't persist across scenes, the override default behavior does. Making default behaviors unavailable in following scenes after attaching a script.
2) `Attach Script to Button` allows for no button to be selected which results on the script being attached to all buttons. Same happens with `Remove Attached Script`, but in that case the script is detached from all the buttons.

* **What is the new behavior (if this is a feature change)?**

1) Override flag bit is unset when the script is remove on scene change.
2) When only one button is selected, clicking that button doesn't deselect it.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

For 2 if somebody is using the behavior to attach/remove form all buttons, it'll still work. Until they select one button, then they won't be able to deselect it again and they'll have to select all the buttons in order for the event to behave as before.

* **Other information**:

N/A