### PR TITLE
Reduce projectile collision width to fix #506 & #573

### DIFF
--- a/appData/src/gb/engine_version
+++ b/appData/src/gb/engine_version
@@ -1,2 +1,2 @@
 # Don't remove this file, it is used to determine if your ejected engine is out of date.
-2.0.0-e10
+2.0.0-e11

--- a/appData/src/gb/src/core/Projectiles_b.c
+++ b/appData/src/gb/src/core/Projectiles_b.c
@@ -118,8 +118,8 @@ void UpdateProjectiles_b() {
           continue;
         }
 
-        if ((projectiles[i].pos.x + 16 >= actors[a].pos.x) &&
-            (projectiles[i].pos.x <= actors[a].pos.x + 16) &&
+        if ((projectiles[i].pos.x + 12 >= actors[a].pos.x) &&
+            (projectiles[i].pos.x <= actors[a].pos.x + 12) &&
             (projectiles[i].pos.y + 8 >= actors[a].pos.y) &&
             (projectiles[i].pos.y <= actors[a].pos.y + 8)) {
           hit = a;

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -87,7 +87,13 @@ const changes: EngineChange[] = [{
     version: "2.0.0-e10",
     description: "Fix bug where an attached script overrides default behavior even when not persisted between scenes",
     modifiedFiles: [
-        "src/core/Input.c ",
+        "src/core/Input.c",
+    ]
+}, {
+    version: "2.0.0-e11",
+    description: "Improve collision detection between actors and projectiles",
+    modifiedFiles: [
+        "src/core/Projectiles_b.c",
     ]
 }];
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tiny Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#506 actors moving up or down have a width of 5 tiles if on grid, instead of 3, due to a value of +-16 each side including equal to. 
#573 Is user error where a player fired projectile can collide with the player.


* **What is the new behavior (if this is a feature change)?**
Reducing to 15 will fix this on grid to 3 tiles horizontally, but is extremely tight in adventure mode.
Reduced a further 3 px each side to 12, assuming projectile with a 2px border each side & Actor having 1px leeway each side, this feels pretty good.


* **Does this PR introduce a breaking change?**
Attacks with a sword will not do crazy sweeping damage horizontally, some testing may be required if this needs to be pushed to 13+- to better attack enemies at the tip of a sword.


* **Other information**:
Should probably increase vertical too, as 8+- is barely 3 tiles? Some note of missed shots in shootemup.
@pautomas  asked if this could ever be expanded/performant enough to take bounding per actor, however this would need both actor/projectile bounding to be correct...
In this context, exposing projectile bounding may be wise where a sword/arrow/bullet could be slimmer in certain directions, than a ball or swipe. Changes to that only affects per pixel modes like adventure or platformer. 