### PR TITLE
Don't add sprites to the sprite scene list if not used

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -1156,7 +1156,7 @@ export const precompileScenes = (
         const spriteIndex = usedSprites.findIndex(
           (sprite) => sprite.id === spriteId
         );
-        if (memo.indexOf(spriteIndex) === -1) {
+        if (spriteIndex !== -1 && memo.indexOf(spriteIndex) === -1) {
           memo.push(spriteIndex);
         }
         return memo;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Reported [on Discord](https://discord.com/channels/554713715442712616/585023243732123676/769298433202061364) a project was failing on compile with the following error:

![image](https://user-images.githubusercontent.com/54246642/97062365-87a3ce80-1592-11eb-8edf-ec286c28b7bd.png)

After a bit of debugging, the error was due to a spritesheet field being set to `None` in a commented event in a completely different script from the same scene.

Even if the spritesheet didn't exist, it was added to the scene sprite list with index `-1`. Then, when compiling a call to `Actor: Set Sprite Sheet`, the call to `getSpriteOffset` looks in the global sprite list for a sprite with index `-1`, which is `undefined` and then tries to access `size` on that sprite, causing a crash.

* **What is the new behavior (if this is a feature change)?**

If a sprite found in a scene script can't be found in the `usedSprites` list simply skip it and don't add it to the scene sprite list.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

There's should probably be some extra guard in `getSpriteOffset` to make sure the  case for `undefined` sprites is covered there too. However I'm not sure we can provide a good error message that points the user to how to fix the issue as we don't have enough information about why the sprite might be `undefined`.