### PR TITLE
Fix instant camera move with Fade to black

### DIFF
--- a/appData/src/gb/src/core/Scroll.c
+++ b/appData/src/gb/src/core/Scroll.c
@@ -6,6 +6,7 @@
 #include "DataManager.h"
 #include "GameTime.h"
 #include "FadeManager.h"
+#include "Palette.h"
 #include "data_ptrs.h"
 
 INT16 scroll_x = 0;
@@ -231,11 +232,18 @@ void RenderScreen() {
     DISPLAY_OFF
   } else if (!fade_timer == 0)
   {
-    // Set palette black if not already, then restore.
-    temp = fade_timer;
-    fade_timer = 0;
-    ApplyPaletteChange();
-    fade_timer = temp;
+    // Immediately set all palettes black while screen renders.
+    #ifdef CGB
+    if (_cpu == CGB_TYPE) {
+      for (UBYTE c = 0; c != 32; ++c) {
+        BkgPaletteBuffer[c] = RGB_BLACK;
+      }
+      set_bkg_palette(0, 8, BkgPaletteBuffer);
+      set_sprite_palette(0, 8, BkgPaletteBuffer);
+    } else
+    #endif
+      OBP0_REG = 0xFF;
+      BGP_REG = 0xFF;
   }
 
   // Clear pending rows/ columns


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix on the Engine props branch (as this already modifies fade to black)

* **What is the current behavior?** (You can also link to an open issue here) 
#568
A bug from old Fade to black vsync change, where instant camera moves could show 1 frame of garbage.

* **What is the new behavior (if this is a feature change)?**
Force black palette for everything before the re render occurs in scroll.c, bypassing the palette switch.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not likely.

* **Other information**:
#625 for engine props/fields pr