### PR TITLE
Feature/weapon offset

### DIFF
--- a/appData/src/gb/engine_version
+++ b/appData/src/gb/engine_version
@@ -1,2 +1,2 @@
 # Don't remove this file, it is used to determine if your ejected engine is out of date.
-2.0.0-e11
+2.0.0-e12

--- a/appData/src/gb/include/Projectiles.h
+++ b/appData/src/gb/include/Projectiles.h
@@ -16,6 +16,7 @@ typedef struct _PROJECTILE {
   Vector2D dir;
   UBYTE moving;
   UBYTE pin_actor;
+  UBYTE pin_offset;
   UBYTE sprite;
   UBYTE palette_index;
   SPRITE_TYPE sprite_type;
@@ -53,10 +54,11 @@ void UpdateProjectiles_b();
  * @param sprite Index of in vram of sprite to use
  * @param palette Palette index for sprite color
  * @param actor Index of actor that will attack
+ * @param offset Offset in front of player to place attack sprite
  * @param col_group Collision group that attack belongs to
  * @param col_mask Collision mask to collide with
  */
-void WeaponAttack(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE col_group, UBYTE col_mask);
+void WeaponAttack(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE offset, UBYTE col_group, UBYTE col_mask);
 
 /**
  * Launch projectile from location

--- a/appData/src/gb/src/core/Projectiles.c
+++ b/appData/src/gb/src/core/Projectiles.c
@@ -3,7 +3,7 @@
 #include "BankManager.h"
 
 void ProjectilesInit_b();
-void WeaponAttack_b(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE col_group, UBYTE col_mask);
+void WeaponAttack_b(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE offset, UBYTE col_group, UBYTE col_mask);
 void ProjectileLaunch_b(UBYTE sprite,
                         UBYTE palette,
                         WORD x,
@@ -23,9 +23,9 @@ void ProjectilesInit() {
   POP_BANK;
 }
 
-void WeaponAttack(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE col_group, UBYTE col_mask) {
+void WeaponAttack(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE offset, UBYTE col_group, UBYTE col_mask) {
   PUSH_BANK(PROJECTILE_BANK);
-  WeaponAttack_b(sprite, palette, actor, col_group, col_mask);
+  WeaponAttack_b(sprite, palette, actor, offset, col_group, col_mask);
   POP_BANK;
 }
 

--- a/appData/src/gb/src/core/Projectiles_b.c
+++ b/appData/src/gb/src/core/Projectiles_b.c
@@ -13,7 +13,6 @@
 #define SCREENWIDTH_PLUS_64 224   // 160 + 64
 #define SCREENHEIGHT_PLUS_64 208  // 144 + 64
 #define NO_ACTOR_PINNED 255
-#define ATTACK_OFFSET 10
 
 Projectile projectiles[MAX_PROJECTILES];
 UBYTE current_projectile = 0;
@@ -26,17 +25,18 @@ void ProjectilesInit_b() {
   }
 }
 
-void WeaponAttack_b(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE col_group, UBYTE col_mask) {
+void WeaponAttack_b(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE offset, UBYTE col_group, UBYTE col_mask) {
   if (projectiles[current_projectile].life_time == 0) {
     projectiles[current_projectile].moving = FALSE;
     projectiles[current_projectile].dir.x = actors[actor].dir.x;
     projectiles[current_projectile].dir.y = actors[actor].dir.y;
     projectiles[current_projectile].pin_actor = actor;
+    projectiles[current_projectile].pin_offset = offset;
 
     if (actors[projectiles[current_projectile].pin_actor].dir.y == 0) {
       projectiles[current_projectile].pos.x =
           actors[projectiles[current_projectile].pin_actor].pos.x +
-          (ATTACK_OFFSET * actors[projectiles[current_projectile].pin_actor].dir.x);
+          (offset * actors[projectiles[current_projectile].pin_actor].dir.x);
       projectiles[current_projectile].pos.y =
           actors[projectiles[current_projectile].pin_actor].pos.y;
     } else {
@@ -44,7 +44,7 @@ void WeaponAttack_b(UBYTE sprite, UBYTE palette, UBYTE actor, UBYTE col_group, U
           actors[projectiles[current_projectile].pin_actor].pos.x;
       projectiles[current_projectile].pos.y =
           actors[projectiles[current_projectile].pin_actor].pos.y +
-          (ATTACK_OFFSET * actors[projectiles[current_projectile].pin_actor].dir.y);
+          (offset * actors[projectiles[current_projectile].pin_actor].dir.y);
     }
 
     projectiles[current_projectile].move_speed = 0;
@@ -173,11 +173,11 @@ void UpdateProjectiles_b() {
         } else if (projectiles[i].dir.y == 0 && projectiles[i].dir.x != 0) {
           fo = 2 + MUL_2(projectiles[i].sprite_type == SPRITE_ACTOR_ANIMATED);
         }
-        // Facing left so flip sprite
-        if (IS_NEG(projectiles[i].dir.x)) {
-          flip = TRUE;
-        }
       }
+      // Facing left so flip sprite
+      if (IS_NEG(projectiles[i].dir.x)) {
+        flip = TRUE;
+      }      
       frame = MUL_4(projectiles[i].sprite + projectiles[i].frame + fo);
 
       // Update GB Sprite tile and props
@@ -243,12 +243,12 @@ void UpdateProjectiles_b() {
         } else {
           if (actors[projectiles[i].pin_actor].dir.y == 0) {
             projectiles[i].pos.x = actors[projectiles[i].pin_actor].pos.x +
-                                   (ATTACK_OFFSET * actors[projectiles[i].pin_actor].dir.x);
+                                   (projectiles[i].pin_offset * actors[projectiles[i].pin_actor].dir.x);
             projectiles[i].pos.y = actors[projectiles[i].pin_actor].pos.y;
           } else {
             projectiles[i].pos.x = actors[projectiles[i].pin_actor].pos.x;
             projectiles[i].pos.y = actors[projectiles[i].pin_actor].pos.y +
-                                   (ATTACK_OFFSET * actors[projectiles[i].pin_actor].dir.y);
+                                   (projectiles[i].pin_offset * actors[projectiles[i].pin_actor].dir.y);
           }
         }
       }

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -146,7 +146,7 @@ const SCRIPT_CMD script_cmds[] = {
     {Script_ActorSetSprite_b, 2},      // 0x60
     {Script_IfActorRelActor_b, 4},     // 0x61
     {Script_PlayerBounce_b, 1},        // 0x62
-    {Script_WeaponAttack_b, 2},        // 0x63
+    {Script_WeaponAttack_b, 3},        // 0x63
     {Script_PalSetBackground_b, 3},    // 0x64
     {Script_PalSetSprite_b, 2},        // 0x65
     {Script_PalSetUI_b, 2},            // 0x66
@@ -2259,8 +2259,9 @@ void Script_WeaponAttack_b() {
   WeaponAttack(script_cmd_args[0],  // Sprite
                palette,             // Palette index
                active_script_ctx.script_actor,
-               script_cmd_args[1] & 0xF,  // Collision group
-               script_cmd_args[1] >> 4);  // Collision mask
+               script_cmd_args[1],
+               script_cmd_args[2] & 0xF,  // Collision group
+               script_cmd_args[2] >> 4);  // Collision mask
 }
 
 void Script_PalSetBackground_b() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -270,6 +270,7 @@
   "FIELD_TMP_DIRECTORY": "Temp Directory",
   "FIELD_TMP_DIRECTORY_INFO": "The location where temporary files are stored during the build of your game.\nIf you are unable to build your game due to permissions errors you can change this to a folder that you have access to.",
   "FIELD_DONT_MODIFY": "Don't modify",
+  "FIELD_OFFSET": "Offset",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -328,13 +328,14 @@ class ScriptBuilder {
 
   // Weapons
 
-  weaponAttack = (spriteSheetId, collisionGroup, collisionMask) => {
+  weaponAttack = (spriteSheetId, offset = 10, collisionGroup, collisionMask) => {
     const output = this.output;
     const { sprites, scene } = this.options;
     const spriteSceneIndex = getSpriteSceneIndex(spriteSheetId, sprites, scene);
     
     output.push(cmd(WEAPON_ATTACK));
     output.push(spriteSceneIndex);
+    output.push(offset);
     output.push(((collisionMaskDec(collisionMask)) << 4) + collisionGroupDec(collisionGroup));
   }
 

--- a/src/lib/events/eventWeaponAttack.js
+++ b/src/lib/events/eventWeaponAttack.js
@@ -14,7 +14,17 @@ const fields = [
     type: "actor",
     label: l10n("FIELD_SOURCE"),
     defaultValue: "$self$",
+    width: "50%",
   },  
+  {
+    key: "offset",
+    type: "number",
+    label: l10n("FIELD_OFFSET"),
+    defaultValue: 10,
+    min: 0,
+    max: 64,
+    width: "50%",
+  },    
   {
     key: "collisionGroup",
     label: l10n("FIELD_COLLISION_GROUP"),
@@ -35,8 +45,9 @@ const fields = [
 
 const compile = (input, helpers) => {
   const { weaponAttack, actorSetActive } = helpers;
+  const offset = input.offset === "" || input.offset === undefined || input.offset === null ? 10 : input.offset;
   actorSetActive(input.actorId);
-  weaponAttack(input.spriteSheetId, input.collisionGroup, input.collisionMask);
+  weaponAttack(input.spriteSheetId, offset, input.collisionGroup, input.collisionMask);
 };
 
 module.exports = {

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -95,6 +95,15 @@ const changes: EngineChange[] = [{
     modifiedFiles: [
         "src/core/Projectiles_b.c",
     ]
+}, {
+    version: "2.0.0-e12",
+    description: "Add support for offsetting weapon attack, and flip attack while facing left if using static sprite",
+    modifiedFiles: [
+        "include/Projectiles.h",
+        "src/core/Projectiles.c",
+        "src/core/Projectiles_b.c",
+        "src/core/ScriptRunner_b.c",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature, adds the ability to set a how many pixels to offset the weapon sprite in front of the source actor.

* **What is the current behavior?** (You can also link to an open issue here)
There is a hard coded value ATTACK_OFFSET set to 10 pixels used to calculate where to position the attack sprite by adding to the source actors position depending on the direction it is facing. Changing this value requires ejecting the game engine.

* **What is the new behavior (if this is a feature change)?**
Adds an additional offset field to the Weapon Attack event allowing this to be changed dynamically.
<img width="339" alt="Screenshot 2020-11-01 at 13 33 45" src="https://user-images.githubusercontent.com/16776042/97804318-df070600-1c46-11eb-9370-8d83816d1d09.png">

This PR also changes the behaviour of weapon/projectile sprites which aren't using actor sprites so that they flip horizontally when facing left allowing you to use sprites that flip matching the source actor without needing to provide an unnecessary up and down variation for platform scenes

Previous behaviour
<img width="590" alt="Screenshot 2020-11-01 at 13 42 59" src="https://user-images.githubusercontent.com/16776042/97804482-2f329800-1c48-11eb-8880-0ba5ad00a666.png">

New behaviour
<img width="546" alt="Screenshot 2020-11-01 at 13 42 50" src="https://user-images.githubusercontent.com/16776042/97804485-35c10f80-1c48-11eb-807c-02fa5e692ca1.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

If you were depending on the sprites not flipping when facing left then maybe though this seems unlikely

Will require ejecting the engine again if you have done this previously.
