### PR TITLE
Increase limit of textMenu when using Dialogue

### DIFF
--- a/src/lib/compiler/scriptBuilder.js
+++ b/src/lib/compiler/scriptBuilder.js
@@ -445,9 +445,17 @@ class ScriptBuilder {
   ) => {
     const output = this.output;
     const { strings, variables, event } = this.options;
-    const menuText = options
+    let menuText;
+    if(options.length > 4 || layout === "menu"){
+      menuText = options
       .map((option, index) => trimlines(option || "", 6, 1) || `Item ${index + 1}`)
       .join("\n");
+    }
+    else{
+      menuText = options
+      .map((option, index) => trimlines(option || "", 16, 1) || `Item ${index + 1}`)
+      .join("\n");
+    }
     const text = this.replaceVariables(menuText, variables, event);
     let stringIndex = strings.indexOf(text);
     if (stringIndex === -1) {

--- a/src/lib/events/eventMenu.js
+++ b/src/lib/events/eventMenu.js
@@ -1,8 +1,22 @@
 const trimlines = require("../helpers/trimlines");
 const l10n = require("../helpers/l10n").default;
 
-const trimMenuItem = (string) => {
-  return trimlines(string, 6, 1);
+const updateVars = (args) => {
+  const options = {};
+
+  for(let i = 0; i < 8; i++){
+    
+    if(args.items < 5 && args.layout === "dialogue")
+    {
+      options[`option${i+1}`] = trimlines(args[`option${i+1}`], 16, 1);
+    }
+    else
+    {
+      options[`option${i+1}`] = trimlines(args[`option${i+1}`], 6, 1);
+    }
+  }
+
+  return options;
 };
 
 const id = "EVENT_MENU";
@@ -20,7 +34,14 @@ const fields = [].concat(
       type: "number",
       min: 2,
       max: 8,
-      defaultValue: 2
+      defaultValue: 2,
+      postUpdate: (args) => {
+          vars = updateVars(args);
+          return {
+            ...args,
+            ...vars
+          };
+      }
     }
   ],
   Array(8)
@@ -31,7 +52,13 @@ const fields = [].concat(
         key: `option${i + 1}`,
         label: l10n("FIELD_SET_TO_VALUE_IF", { value: i + 1 }),
         type: "text",
-        updateFn: trimMenuItem,
+        postUpdate: (args) => {
+            vars = updateVars(args);
+            return {
+              ...args,
+              ...vars
+            };
+        },
         defaultValue: "",
         placeholder: l10n("FIELD_ITEM", { value: i + 1 }),
         conditions: [
@@ -44,7 +71,13 @@ const fields = [].concat(
         key: `option${i + 1}`,
         label: l10n("FIELD_SET_TO_VALUE_IF", { value: i + 1 }),
         type: "text",
-        updateFn: trimMenuItem,
+        postUpdate: (args) => {
+            vars = updateVars(args);
+            return {
+              ...args,
+              ...vars
+            };
+        },
         defaultValue: "",
         placeholder: l10n("FIELD_ITEM", { value: i + 1 }),
         conditions: [
@@ -61,7 +94,13 @@ const fields = [].concat(
         key: `option${i + 1}`,
         label: l10n("FIELD_SET_TO_VALUE_IF", { value: 0 }),
         type: "text",
-        updateFn: trimMenuItem,
+        postUpdate: (args) => {
+            vars = updateVars(args);
+            return {
+              ...args,
+              ...vars
+            };
+        },
         defaultValue: "",
         placeholder: l10n("FIELD_ITEM", { value: 0 }),
         conditions: [
@@ -96,7 +135,14 @@ const fields = [].concat(
         ["dialogue", l10n("FIELD_LAYOUT_DIALOGUE")],
         ["menu", l10n("FIELD_LAYOUT_MENU")]
       ],
-      defaultValue: "dialogue"
+      defaultValue: "dialogue",
+      postUpdate: (args) => {
+          vars = updateVars(args);
+          return {
+            ...args,
+            ...vars
+          };
+      }
     }
 );
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change to the textMenu allows up to 16 characters to be used when using the Dialogue menu style. It trims to 6 characters when using the default "menu" option or greater than 4 menu options.
![test](https://user-images.githubusercontent.com/16762845/97816235-e091f780-1c61-11eb-930d-99bc33131e91.png)

* **What is the current behavior?** (You can also link to an open issue here)
Using the Dialogue menu style causes menu options to be trimmed regardless of the space available.


* **What is the new behavior (if this is a feature change)?**
When using the Dialogue menu style, if the number of options is 4 or less, the space available is increased from 6 to 16.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I'm aware of.


* **Other information**:
~~While this change does fix the text being shown, the eventMenu.js script will need to be changed to allow for actual use. I am using custom plugin scripts to counteract it.~~