### PR TITLE
Use A button for jump and B to run in Platform mode.

### DIFF
--- a/appData/src/gb/engine.json
+++ b/appData/src/gb/engine.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-e14",
+  "version": "2.0.0-e15",
   "fields": [
     {
       "key": "plat_min_vel",
@@ -70,7 +70,7 @@
       "defaultValue": 16384,
       "min": 0,
       "max": 32768
-    },   
+    },
     {
       "key": "plat_grav",
       "label": "FIELD_GRAVITY",
@@ -80,7 +80,7 @@
       "defaultValue": 1792,
       "min": 0,
       "max": 8192
-    },   
+    },
     {
       "key": "plat_hold_grav",
       "label": "FIELD_GRAVITY_JUMP",
@@ -90,7 +90,7 @@
       "defaultValue": 512,
       "min": 0,
       "max": 8192
-    },       
+    },
     {
       "key": "plat_max_fall_vel",
       "label": "FIELD_MAX_FALL_VEL",

--- a/appData/src/gb/src/states/Platform.c
+++ b/appData/src/gb/src/states/Platform.c
@@ -107,7 +107,7 @@ void Update_Platform() {
  
     if (INPUT_LEFT) {
       player.dir.x = -1;
-      if (INPUT_A) {
+      if (INPUT_B) {
         pl_vel_x -= plat_run_acc;
         pl_vel_x = CLAMP(pl_vel_x, -plat_run_vel, -plat_min_vel);
       } else {
@@ -119,7 +119,7 @@ void Update_Platform() {
       }
     } else if (INPUT_RIGHT) {
       player.dir.x = 1;
-      if (INPUT_A) {
+      if (INPUT_B) {
         pl_vel_x += plat_run_acc;
         pl_vel_x = CLAMP(pl_vel_x, plat_min_vel, plat_run_vel);
       } else {
@@ -148,7 +148,7 @@ void Update_Platform() {
   tile_x = pl_pos_x >> 7;
   tile_y = pl_pos_y >> 7;
 
-  if (grounded && INPUT_A_PRESSED) {
+  if (grounded && INPUT_B_PRESSED) {
     if (player.dir.x == 1) {
       hit_actor = ActorAtTile(tile_x + 2, tile_y, TRUE);
     } else {
@@ -160,7 +160,7 @@ void Update_Platform() {
   }
 
   // Jump
-  if (INPUT_B_PRESSED && grounded) {
+  if (INPUT_A_PRESSED && grounded) {
     if (!( (((pl_pos_x >> 4) & 0x7) != 7 &&
           TileAt(tile_x, tile_y - 1) & COLLISION_BOTTOM) ||  // Left Edge
           (((pl_pos_x >> 4) & 0x7) != 0 &&
@@ -172,7 +172,7 @@ void Update_Platform() {
 
   if (!on_ladder) {
     // Gravity
-    if (INPUT_B && pl_vel_y < 0) {
+    if (INPUT_A && pl_vel_y < 0) {
       pl_vel_y += plat_hold_grav;
     } else {
       pl_vel_y += plat_grav;

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -130,6 +130,12 @@ const changes: EngineChange[] = [{
     modifiedFiles: [
         "src/core/ScriptRunner_b.c",
     ]
+}, {
+    version: "2.0.0-e15",
+    description: "Use A button for jump and B to run in Platform mode",
+    modifiedFiles: [
+        "src/states/Platform.c",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change change the platform mode commands to use button A to jump and button B to run. This is in line with most commercial plaftormers on the Game Boy and provides a less surprising user experience.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, jump is assigned to button B and run to button A, which is counter intuitive to seasoned gamers.


* **What is the new behavior (if this is a feature change)?**
This change changes the platform mode commands to use button A to jump and button B to run.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, this change is breaking the experience for users making games on the v2 branch.


* **Other information**:
Some discussions took place in https://github.com/chrismaltby/gb-studio/pull/646.