### PR TITLE
Highlight palette under hovered tile. Alt click to switch to that palette

### DIFF
--- a/src/components/library/PaletteBlock.tsx
+++ b/src/components/library/PaletteBlock.tsx
@@ -6,10 +6,12 @@ type PaletteBlockProps = {
   colors: string[];
   size?: number;
   type?: "tile" | "sprite";
+  highlight?: boolean;
 };
 
 type WrapperProps = {
   type?: "tile" | "sprite";
+  highlight?: boolean;
 };
 
 const Wrapper = styled.div<WrapperProps>`
@@ -17,10 +19,16 @@ const Wrapper = styled.div<WrapperProps>`
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 0px 0px;
-  border: 1px solid ${(props) => props.theme.colors.input.background};
+  border: 1px solid
+    ${(props) =>
+      props.highlight
+        ? props.theme.colors.highlight
+        : props.theme.colors.input.background};
   border-radius: 3px;
   overflow: hidden;
   flex-shrink: 0;
+  transition: border 0.2s ease-in-out;
+  transition-delay: ${(props) => (props.highlight ? "0.5s" : "0")};
   ${(props) => (props.type === "sprite" ? spriteStyles : "")}
 `;
 
@@ -35,9 +43,11 @@ const PaletteBlock: React.FC<PaletteBlockProps> = ({
   colors,
   size = 24,
   type = "tile",
+  highlight,
 }) => (
   <Wrapper
     type={type}
+    highlight={highlight}
     style={{
       width: size,
       height: size,

--- a/src/components/world/BrushToolbar.js
+++ b/src/components/world/BrushToolbar.js
@@ -199,6 +199,7 @@ class BrushToolbar extends Component {
   render() {
     const {
       selectedPalette,
+      highlightPalette,
       selectedTileType,
       selectedBrush,
       visible,
@@ -260,7 +261,10 @@ class BrushToolbar extends Component {
                   number: paletteIndex + 1,
                 })} (${paletteIndex + 1}) - ${palettes[paletteIndex].name}`}
               >
-                <PaletteBlock colors={palettes[paletteIndex].colors} />
+                <PaletteBlock
+                  colors={palettes[paletteIndex].colors}
+                  highlight={paletteIndex === highlightPalette}
+                />
               </div>
             ))}
           {showPalettes && <div className="BrushToolbar__Divider" />}
@@ -364,6 +368,7 @@ BrushToolbar.propTypes = {
   showPalettes: PropTypes.bool.isRequired,
   showTileTypes: PropTypes.bool.isRequired,
   selectedPalette: PropTypes.number.isRequired,
+  highlightPalette: PropTypes.number.isRequired,
   selectedTileType: PropTypes.number.isRequired,
   sceneId: PropTypes.string,
   setSelectedPalette: PropTypes.func.isRequired,
@@ -395,6 +400,16 @@ function mapStateToProps(state) {
   const scenesLookup = sceneSelectors.selectEntities(state);
 
   const { scene: sceneId } = state.editor;
+
+  let highlightPalette = -1;
+  const scene = sceneSelectors.selectById(state, state.editor.hover.sceneId);
+
+  if (scene) {
+    const { x, y } = state.editor.hover;
+    highlightPalette = Array.isArray(scene.tileColors)
+      ? scene.tileColors[x + y * scene.width]
+      : 0;
+  }
 
   const defaultBackgroundPaletteIds =
     settings.defaultBackgroundPaletteIds || [];
@@ -435,6 +450,7 @@ function mapStateToProps(state) {
     defaultBackgroundPaletteIds,
     scenePaletteIds,
     sceneBackgroundPaletteIds,
+    highlightPalette,
   };
 }
 

--- a/src/components/world/SceneCursor.js
+++ b/src/components/world/SceneCursor.js
@@ -86,7 +86,9 @@ class SceneCursor extends Component {
       removeActorAt,
       removeTriggerAt,
       sceneFiltered,
-      editSearchTerm
+      editSearchTerm,
+      hoverPalette,
+      setSelectedPalette,
     } = this.props;
 
     this.lockX = undefined;
@@ -151,6 +153,11 @@ class SceneCursor extends Component {
         window.addEventListener("mouseup", this.onCollisionsStop);
       }
     } else if (tool === "colors") {
+      if (e.altKey) {
+        setSelectedPalette({paletteIndex: hoverPalette});
+        return;
+      }
+
       if(selectedBrush === BRUSH_FILL) {
         paintColor({ brush: selectedBrush, sceneId, x, y, paletteIndex: selectedPalette });
       } else {
@@ -373,6 +380,7 @@ SceneCursor.propTypes = {
   triggerDefaults: PropTypes.shape(),
   clipboardVariables: PropTypes.arrayOf(VariableShape).isRequired,
   sceneId: PropTypes.string.isRequired,
+  hoverPalette: PropTypes.number.isRequired,
   scene: SceneShape.isRequired,
   showCollisions: PropTypes.bool.isRequired,
   showLayers: PropTypes.bool.isRequired,
@@ -406,6 +414,15 @@ function mapStateToProps(state, props) {
   const showCollisions = state.project.present.settings.showCollisions;
   const scenesLookup = sceneSelectors.selectEntities(state);
   const scene = scenesLookup[props.sceneId];
+
+  let hoverPalette = -1;
+  const hoverScene = sceneSelectors.selectById(state, state.editor.hover.sceneId);
+  if (hoverScene) {
+    hoverPalette = Array.isArray(scene.tileColors)
+      ? scene.tileColors[x + y * scene.width]
+      : 0;
+  }
+
   return {
     x: x || 0,
     y: y || 0,
@@ -419,7 +436,8 @@ function mapStateToProps(state, props) {
     entityId,
     showCollisions,
     scene,
-    showLayers
+    showLayers,
+    hoverPalette
   };
 }
 
@@ -436,7 +454,8 @@ const mapDispatchToProps = {
   setTool: editorActions.setTool,
   editPlayerStartAt: settingsActions.editPlayerStartAt,
   editDestinationPosition: entitiesActions.editDestinationPosition,
-  editSearchTerm: editorActions.editSearchTerm
+  editSearchTerm: editorActions.editSearchTerm,
+  setSelectedPalette: editorActions.setSelectedPalette,
 };
 
 export default connect(

--- a/src/components/world/World.js
+++ b/src/components/world/World.js
@@ -23,6 +23,7 @@ class World extends Component {
     };
     this.worldDragging = false;
     this.scrollRef = React.createRef();
+    this.worldRef = React.createRef();
     this.scrollContentsRef = React.createRef();
     this.dragDistance = { x:0, y:0 };
   }
@@ -146,7 +147,9 @@ class World extends Component {
     const { selectWorld } = this.props;
     if(this.worldDragging) {
       if(Math.abs(this.dragDistance.x) < 20 && Math.abs(this.dragDistance.y) < 20) {
-        selectWorld();
+        if (e.target === this.worldRef.current) {
+          selectWorld();
+        }
       }
     }
     this.worldDragging = false;
@@ -204,7 +207,6 @@ class World extends Component {
 
   startWorldDragIfAltOrMiddleClick = e => {
     if (e.altKey || e.nativeEvent.which === MIDDLE_MOUSE) {
-      event.preventDefault();
       this.worldDragging = true;
       e.stopPropagation();
     }
@@ -267,6 +269,7 @@ class World extends Component {
       >
         <div ref={this.scrollContentsRef} className="World__Content">
           <div
+            ref={this.worldRef}
             className="World__Grid"
             style={{ width: scrollWidth, height: scrollHeight }}
             onMouseDown={this.startWorldDrag}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements an enhancement request from #656 allowing the currently hovered tile's palette to be highlighted in the palette toolbar.

* **What is the current behavior?** (You can also link to an open issue here)
It's not possible to determine the palette used for a specific tile except by looking at the colour, if tiles use similar palettes or palettes with overlapping colours it may not be possible to tell which palette the tile is using at all.

* **What is the new behaviour (if this is a feature change)?**

When in the colorize mode if you hover over a tile for a short period of time the tile's current palette will be highlighted

<img width="405" alt="Screenshot 2020-11-18 at 20 44 00" src="https://user-images.githubusercontent.com/16776042/99585847-cafd2b80-29de-11eb-8434-9deae2532c3e.png">

In this screenshot the hovered tile is using the second palette (shown by the outline) and the third palette is the selected palette (shown by the background colour).

If you Alt+Click on a tile while painting it will switch the currently selected palette to match the tile you just clicked on.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

This should probably work the same for drawing collision tiles too