### PR TITLE
Feature/custom external apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "json-loader": "^0.5.7",
     "lodash": "^4.17.14",
     "normalizr": "^3.4.0",
+    "open": "^7.3.0",
     "prop-types": "^15.7.2",
     "raw-loader": "^4.0.0",
     "react": "^16.12.0",

--- a/src/components/app/Preferences.tsx
+++ b/src/components/app/Preferences.tsx
@@ -1,79 +1,118 @@
 import React, { useEffect, useState } from "react";
 import Path from "path";
 import settings from "electron-settings";
-import { ipcRenderer, remote } from "electron";
-import { DotsIcon } from "../library/Icons";
 import l10n from "../../lib/helpers/l10n";
-import Button from "../library/Button";
 import getTmp from "../../lib/helpers/getTmp";
+import ThemeProvider from "../ui/theme/ThemeProvider";
+import GlobalStyle from "../ui/globalStyle";
+import { PreferencesWrapper } from "../ui/preferences/Preferences";
+import { FormField, FormRow } from "../ui/form/FormLayout";
+import { TextField } from "../ui/form/TextField";
+import { Button } from "../ui/buttons/Button";
+import { DotsIcon } from "../ui/icons/Icons";
+import { FixedSpacer } from "../ui/spacing/Spacing";
+import { AppSelect } from "../ui/form/AppSelect";
 
 const { dialog } = require("electron").remote;
 
 const Preferences = () => {
   const pathError = "";
-  const [path, setPath] = useState<string>("");
+  const [tmpPath, setTmpPath] = useState<string>("");
+  const [imageEditorPath, setImageEditorPath] = useState<string>("");
+  const [musicEditorPath, setMusicEditorPath] = useState<string>("");
 
   useEffect(() => {
-    setPath(getTmp(false));
+    setTmpPath(getTmp(false));
+    setImageEditorPath(String(settings.get("imageEditorPath") || ""));
+    setMusicEditorPath(String(settings.get("musicEditorPath") || ""));
   }, []);
 
-  const onChangePath = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeTmpPath = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newPath = e.currentTarget.value;
-    setPath(newPath);
+    setTmpPath(newPath);
     settings.set("tmpDir", newPath);
   };
 
-  const onSelectFolder = async (
-    e: React.MouseEvent<HTMLInputElement, MouseEvent>
-  ) => {
+  const onChangeImageEditorPath = (path: string) => {
+    setImageEditorPath(path);
+    settings.set("imageEditorPath", path);
+  };
+
+  const onChangeMusicEditorPath = (path: string) => {
+    setMusicEditorPath(path);
+    settings.set("musicEditorPath", path);
+  };
+
+  const onSelectTmpFolder = async () => {
     const path = await dialog.showOpenDialog({
       properties: ["openDirectory"],
     });
     if (path.filePaths[0]) {
-      const newPath = Path.normalize(`${path.filePaths}/`);
-      setPath(newPath);
+      const newPath = Path.normalize(`${path.filePaths[0]}/`);
+      setTmpPath(newPath);
       settings.set("tmpDir", newPath);
     }
   };
 
-  const onRestoreDefault = () => {
+  const onRestoreDefaultTmpPath = () => {
     settings.delete("tmpDir");
-    setPath(getTmp(false));
+    setTmpPath(getTmp(false));
   };
 
   return (
-    <div className="Preferences">
-      <div className="Preferences__FormGroup">
-        <label
-          htmlFor="projectPath"
-          className={pathError ? "Preferences__Label--Error" : ""}
-        >
-          {pathError || l10n("FIELD_TMP_DIRECTORY")}
-          <input id="projectPath" value={path} onChange={onChangePath} />
-          <div className="Preferences__InputButton">
-            <DotsIcon />
-            <input
-              className="Preferences__InputButton"
-              onClick={onSelectFolder}
+    <ThemeProvider>
+      <GlobalStyle />
+
+      <PreferencesWrapper>
+        <FormRow>
+          <TextField
+            name="path"
+            label={l10n("FIELD_TMP_DIRECTORY")}
+            errorLabel={pathError}
+            value={tmpPath}
+            onChange={onChangeTmpPath}
+            additionalRight={
+              <Button onClick={onSelectTmpFolder} type="button">
+                <DotsIcon />
+              </Button>
+            }
+            info={l10n("FIELD_TMP_DIRECTORY_INFO")}
+          />
+        </FormRow>
+        <FormRow>
+          <Button onClick={onRestoreDefaultTmpPath}>
+            {l10n("FIELD_RESTORE_DEFAULT")}
+          </Button>
+        </FormRow>
+
+        <FixedSpacer height={40} />
+
+        <FormRow>
+          <FormField
+            name="musicEditorPath"
+            label={l10n("FIELD_DEFAULT_IMAGE_EDITOR")}
+          >
+            <AppSelect
+              value={imageEditorPath}
+              onChange={onChangeImageEditorPath}
             />
-          </div>
-        </label>
-        <div className="Preferences__Info">
-          {l10n("FIELD_TMP_DIRECTORY_INFO")}
-        </div>
-      </div>
-      <div className="Preferences__FlexSpacer"></div>
-      <div>
-        <Button
-          transparent={false}
-          small={false}
-          large={false}
-          onClick={onRestoreDefault}
-        >
-          {l10n("FIELD_RESTORE_DEFAULT")}
-        </Button>
-      </div>
-    </div>
+          </FormField>
+        </FormRow>
+        <FixedSpacer height={10} />
+
+        <FormRow>
+          <FormField
+            name="musicEditorPath"
+            label={l10n("FIELD_DEFAULT_MUSIC_EDITOR")}
+          >
+            <AppSelect
+              value={musicEditorPath}
+              onChange={onChangeMusicEditorPath}
+            />
+          </FormField>
+        </FormRow>
+      </PreferencesWrapper>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/app/Preferences.tsx
+++ b/src/components/app/Preferences.tsx
@@ -10,7 +10,7 @@ import { FormField, FormRow } from "../ui/form/FormLayout";
 import { TextField } from "../ui/form/TextField";
 import { Button } from "../ui/buttons/Button";
 import { DotsIcon } from "../ui/icons/Icons";
-import { FixedSpacer } from "../ui/spacing/Spacing";
+import { FixedSpacer, FlexGrow } from "../ui/spacing/Spacing";
 import { AppSelect } from "../ui/form/AppSelect";
 
 const { dialog } = require("electron").remote;
@@ -85,7 +85,7 @@ const Preferences = () => {
           </Button>
         </FormRow>
 
-        <FixedSpacer height={40} />
+        <FlexGrow />
 
         <FormRow>
           <FormField

--- a/src/components/assets/ImageViewer.js
+++ b/src/components/assets/ImageViewer.js
@@ -31,8 +31,11 @@ class ImageViewer extends Component {
   };
 
   onOpen = () => {
-    const { projectRoot, file, folder, openFolder } = this.props;
-    openFolder(`${projectRoot}/assets/${folder}/${file.filename}`);
+    const { projectRoot, file, folder, openFile } = this.props;
+    openFile({
+      filename: `${projectRoot}/assets/${folder}/${file.filename}`,
+      type: "image"
+    });
   };
 
   render() {
@@ -86,7 +89,7 @@ ImageViewer.propTypes = {
   sidebarWidth: PropTypes.number.isRequired,
   zoomIn: PropTypes.func.isRequired,
   zoomOut: PropTypes.func.isRequired,
-  openFolder: PropTypes.func.isRequired,
+  openFile: PropTypes.func.isRequired,
 };
 
 ImageViewer.defaultProps = {
@@ -108,7 +111,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 const mapDispatchToProps = {
-  openFolder: electronActions.openFolder,
+  openFile: electronActions.openFile,
   zoomIn: editorActions.zoomIn,
   zoomOut: editorActions.zoomOut
 };

--- a/src/components/assets/MusicViewer.js
+++ b/src/components/assets/MusicViewer.js
@@ -19,8 +19,11 @@ class MusicViewer extends Component {
   }
 
   onOpen = () => {
-    const { projectRoot, file, openFolder } = this.props;
-    openFolder(`${projectRoot}/assets/music/${file.filename}`);
+    const { projectRoot, file, openFile } = this.props;
+    openFile({
+      filename: `${projectRoot}/assets/music/${file.filename}`,
+      type: "music"
+    });
   };
 
   onPlay = () => {
@@ -114,7 +117,7 @@ MusicViewer.propTypes = {
   playing: PropTypes.bool.isRequired,
   play: PropTypes.func.isRequired,
   pause: PropTypes.func.isRequired,
-  openFolder: PropTypes.func.isRequired,
+  openFile: PropTypes.func.isRequired,
   editMusicSettings: PropTypes.func.isRequired,
 };
 
@@ -134,7 +137,7 @@ function mapStateToProps(state) {
 const mapDispatchToProps = {
   play: musicActions.playMusic,
   pause: musicActions.pauseMusic,
-  openFolder: electronActions.openFolder,
+  openFile: electronActions.openFile,
   editMusicSettings: entitiesActions.editMusicSettings,
 };
 

--- a/src/components/ui/form/AppSelect.tsx
+++ b/src/components/ui/form/AppSelect.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from "react";
+import Path from "path";
+import l10n from "../../../lib/helpers/l10n";
+import { Select, Option } from "./Select";
+import { remote } from "electron";
+
+const { dialog } = remote;
+
+interface AppSelectProps {
+  value?: string;
+  onChange?: (newValue: string) => void;
+}
+
+export const AppSelect: FC<AppSelectProps> = ({ value, onChange }) => {
+  const options = ([] as Option[]).concat(
+    [
+      {
+        value: "choose",
+        label: l10n("FIELD_CHOOSE_APPLICATION"),
+      },
+      {
+        value: "",
+        label: l10n("FIELD_SYSTEM_DEFAULT"),
+      },
+    ],
+    value
+      ? {
+          value,
+          label: Path.basename(value),
+        }
+      : []
+  );
+
+  const currentValue =
+    options.find((option) => option.value === value) || options[0];
+
+  const onSelectOption = async (newValue: Option) => {
+    if (newValue.value === "choose") {
+      const path = await dialog.showOpenDialog({
+        properties: ["openFile"],
+      });
+      if (path.filePaths[0]) {
+        const newPath = Path.normalize(path.filePaths[0]);
+        onChange?.(newPath);
+      }
+    } else {
+      onChange?.(newValue.value);
+    }
+  };
+
+  return (
+    <Select options={options} value={currentValue} onChange={onSelectOption} />
+  );
+};

--- a/src/components/ui/form/FormLayout.tsx
+++ b/src/components/ui/form/FormLayout.tsx
@@ -72,21 +72,31 @@ const FormFieldWrapper = styled.div<FormFieldWrapperProps>`
       : ""}
 `;
 
+const FormFieldInfo = styled.div`
+  opacity: 0.5;
+  display: block;
+  font-size: 11px;
+  margin-top: 5px;
+`;
+
 export interface FormFieldProps {
   readonly name: string;
   readonly label?: string;
+  readonly info?: string;
   readonly variant?: "normal" | "error";
 }
 
 export const FormField: FC<FormFieldProps> = ({
   name,
   label,
+  info,
   variant,
   children,
 }) => (
   <FormFieldWrapper variant={variant}>
     {label && <Label htmlFor={name}>{label}</Label>}
     {children}
+    {info && <FormFieldInfo>{info}</FormFieldInfo>}
   </FormFieldWrapper>
 );
 

--- a/src/components/ui/form/TextField.tsx
+++ b/src/components/ui/form/TextField.tsx
@@ -6,6 +6,8 @@ import { Input } from "./Input";
 export interface TextFieldProps {
   readonly name: string;
   readonly label?: string;
+  readonly info?: string;
+  readonly placeholder?: string;
   readonly errorLabel?: string;
   readonly value?: string;
   readonly size?: "small" | "medium" | "large";
@@ -24,7 +26,7 @@ const AdditionalRight = styled.div`
   right: 3px;
   display: flex;
 
-  & > * {
+  && > * {
     height: 100%;
     margin-left: 5px;
   }
@@ -33,19 +35,27 @@ const AdditionalRight = styled.div`
 export const TextField: FC<TextFieldProps> = ({
   name,
   label,
+  info,
+  placeholder,
   errorLabel,
   size,
   value,
   onChange,
   additionalRight,
 }) => (
-  <FormField name={name} label={errorLabel || label} variant={errorLabel ? "error" : undefined}>
+  <FormField
+    name={name}
+    label={errorLabel || label}
+    info={info}
+    variant={errorLabel ? "error" : undefined}
+  >
     {additionalRight ? (
       <AdditionalWrapper>
         <Input
           id={name}
           name={name}
           value={value}
+          placeholder={placeholder}
           displaySize={size}
           onChange={onChange}
           style={{ paddingRight: 60 }}

--- a/src/components/ui/preferences/Preferences.tsx
+++ b/src/components/ui/preferences/Preferences.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const PreferencesWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+`;

--- a/src/components/ui/spacing/Spacing.tsx
+++ b/src/components/ui/spacing/Spacing.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 export interface FixedSpacerProps {
-  width: number;
+  width?: number;
+  height?: number;
 }
 
 export const FlexGrow = styled.div`
@@ -9,6 +10,7 @@ export const FlexGrow = styled.div`
 `;
 
 export const FixedSpacer = styled.div<FixedSpacerProps>`
-  width: ${props => props.width}px;
+  width: ${(props) => (props.width ? props.width : 1)}px;
+  height: ${(props) => (props.height ? props.height : 1)}px;
   flex-shrink: 0;
 `;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -301,6 +301,10 @@
   "FIELD_MORE_SETTINGS": "More Settings",
   "FIELD_LOCK_SCRIPT_EDITOR": "Lock Script Editor",
   "FIELD_UNLOCK_SCRIPT_EDITOR": "Unlock Script Editor",
+  "FIELD_DEFAULT_IMAGE_EDITOR": "Default Image Editor",
+  "FIELD_DEFAULT_MUSIC_EDITOR": "Default Music Editor",
+  "FIELD_SYSTEM_DEFAULT": "System Default",
+  "FIELD_CHOOSE_APPLICATION": "Choose Application",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ const createPreferences = async (forceTab?: SplashTab) => {
   // Create the browser window.
   preferencesWindow = new BrowserWindow({
     width: 600,
-    height: 280,
+    height: 330,
     resizable: false,
     maximizable: false,
     fullscreenable: false,

--- a/src/store/features/electron/electronActions.ts
+++ b/src/store/features/electron/electronActions.ts
@@ -2,8 +2,13 @@ import { createAction } from "@reduxjs/toolkit";
 
 const openHelp = createAction<string>("electron/openHelp");
 const openFolder = createAction<string>("electron/openFolder");
+const openFile = createAction<{
+  filename: string;
+  type?: "image" | "music";
+}>("electron/openFile");
 
 export default {
   openHelp,
   openFolder,
+  openFile,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7405,6 +7405,14 @@ open@^7.0.1:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+open@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.3.0.tgz#45461fdee46444f3645b6e14eb3ca94b82e1be69"
+  integrity sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements enhancement request from #644 allowing custom image/music editors to be opened from GB Studio asset viewer when "Edit" button is clicked.

* **What is the current behavior?** (You can also link to an open issue here)
Edit button opens PNG and Mod files using the default application for the extension in your operating system, in many cases this may not be the application you want to use to edit the file, e.g. Preview.app is often the default for PNG files on Mac. 

* **What is the new behavior (if this is a feature change)?**
Adds two new fields the preferences window allowing the default behaviour to be overridden and a custom application to be used instead.
 
<img width="670" alt="Screenshot 2020-11-22 at 19 55 51" src="https://user-images.githubusercontent.com/16776042/99915638-bbdaee00-2cfc-11eb-8f58-19d41da557af.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No