### PR TITLE
Detect itch.io parent, add class and attempt to fix layout style issues

### DIFF
--- a/appData/js-emulator/css/style.css
+++ b/appData/js-emulator/css/style.css
@@ -315,3 +315,12 @@ body {
   }
 }
 
+/* itch.io fix for game size 640 x 576 */
+@media only screen and (min-width: 640px) {
+  .detected-itch #game canvas {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+    max-width: 600px;
+  }
+}

--- a/appData/js-emulator/index.html
+++ b/appData/js-emulator/index.html
@@ -40,5 +40,6 @@
     <script src="js/other/resize.js"></script>    
     <script src="js/GameBoyCore.js"></script>
     <script src="js/GameBoyIO.js"></script>
+    <script src="js/other/itchDetection.js"></script>
   </body>
 </html>

--- a/appData/js-emulator/js/other/itchDetection.js
+++ b/appData/js-emulator/js/other/itchDetection.js
@@ -1,0 +1,3 @@
+if (document.referrer && document.referrer.indexOf(".itch.io/") !== -1) {
+  document.body.classList.add("detected-itch");
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug fix for itch.io hosted games


* **What is the current behaviour?**
Rendering is borked on itch.io, if you set your game as `640x576` or larger, because the existing styles force it to 480px wide so it stretches vertically.
Moreover, itch.io sets the iFrame to 640px wide, but an ancestor element obnoxiously enforces a max width of 600px under a breakpoint with the rule:
```css
@media (max-width: 1000px)
.responsive .inner_column {
    max-width: 600px;
}
```
.. which cuts off the right 40px when it's `width: 100%`

Fair enough if you don't want to merge, because it's partly a problem with itch.io, but here's my workaround attempt anyway as I know lots of games end up on that platform and this behaviour was quite unexpected. 


* **What is the new behavior (if this is a feature change)?**
Allows for a 600px wide game on itch.io (the page's max-width for smaller browsers) - which you can [check out here](https://entozoon.itch.io/rumboy) .


* **Does this PR introduce a breaking change?**
Nope, it's pretty safe.


* **Other information**:
* I absolutely love gb-studio. Incredible piece of kit, and have enjoyed using it massively.
