### PR TITLE
Fixing beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add live preview of how dialogue will appear in game when hovering over "Display Dialogue" events using ascii.png, frame.png and avatar sprites
 - Add character count to dialogue event text input (52 characters max, or 48 if using an avatar)
 - Add autocomplete and syntax highlighting for variables and speed codes in dialogue
-
 - Add Engine Property Fields for platfomer physics, 2d grid size, and fade style in settings
 - Add Event: Engine: Field Update for changing platformer physics mid game
 - Add 16bit variables for engine property fields only
 - Create Engine.json with ejected engines, to add your own custom engine properties
-
 - Add Navigation side bar to left of the editor, Accessible with Tab key and full keyboard navigation
 - Navigation sidebar lists: All scenes, actors/triggers within each scene, Custom Events, Global Variables
 - Navigation Clicking a variable opens a variable editor, to rename the variable, and list all uses of that variable in your project
 - Alt click a variable field in any event (if currently a global variable) to open the variable editor
 - Drag navigator sidebar completely to the left to hide it, to reenable it use the menu item "View / Show Navigator"
-
 - Add GBDK 2020 v4.0.1
 
 ### Changed
@@ -34,10 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom Events are now listed in navigator sidebar only
 - Updated to GBDK2020 v4.0.1 for massive performance increase, new ejected engine mandatory
 - Engine bank push pop functions replaced with __banked for performance increase
+- Multichoice no longer uses B for option 2, new users mistook A and B buttons as both chose an option, with little indication of result, menu is unaffected.
 
 ### Fixed
 
 - Fix issue where sidebar tabs could become hidden if translation wasn't able to fit in space available
+- Fix Actor speed event while moving caused the player to walk forever, now clamps to 4 pixels
+- Fix Emote sprites no longer stuck on screen after scene change
+- Fix Textbox flash of nothing between instant transitions
+- Fix Bg palette event "Don't modify" no longer breaks per scene palettes
 
 ## [2.0.0-beta4]
 

--- a/appData/src/gb/engine.json
+++ b/appData/src/gb/engine.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-e17",
+  "version": "2.0.0-e18",
   "fields": [
     {
       "key": "plat_min_vel",

--- a/appData/src/gb/include/Math.h
+++ b/appData/src/gb/include/Math.h
@@ -8,7 +8,6 @@
 INT16 DespRight(INT16 a, INT16 b);
 UBYTE Lt16(UINT16 a, UINT16 b);
 UBYTE Gt16(UINT16 a, UINT16 b);
-void SeedRand();
 
 #define IS_NEG(a) ((UBYTE)(a)&0x80)
 

--- a/appData/src/gb/src/core/Actor_b.c
+++ b/appData/src/gb/src/core/Actor_b.c
@@ -93,9 +93,9 @@ UBYTE ActorInFrontOfPlayer_b(UBYTE grid_size, UBYTE inc_noclip) __banked {
     }      
   } else {
     if (player.dir.y == -1) {
-      hit_actor = ActorAt3x1Tile(tile_x - 1, tile_y - 1, inc_noclip);
+      hit_actor = ActorAt3x1Tile(tile_x, tile_y - 1, inc_noclip);
     } else if (player.dir.y == 1) {
-      hit_actor = ActorAt3x1Tile(tile_x - 1, tile_y + 2, inc_noclip);
+      hit_actor = ActorAt3x1Tile(tile_x, tile_y + 2, inc_noclip);
     } else {
       if (player.dir.x == -1) {
         hit_actor = ActorAt1x2Tile(tile_x - 2, tile_y, inc_noclip);
@@ -120,9 +120,9 @@ UBYTE ActorInFrontOfActor_b(UBYTE i) __banked {
   tile_y = actors[i].pos.y >> 3;
 
   if (actors[i].dir.y == -1) {
-    hit_actor = ActorAt3x1Tile(tile_x - 1, tile_y - 1, TRUE);
+    hit_actor = ActorAt3x1Tile(tile_x, tile_y - 1, TRUE);
   } else if (actors[i].dir.y == 1) {
-    hit_actor = ActorAt3x1Tile(tile_x - 1, tile_y + 2, TRUE);
+    hit_actor = ActorAt3x1Tile(tile_x, tile_y + 2, TRUE);
   } else {
     if (actors[i].dir.x == -1) {
       hit_actor = ActorAt1x2Tile(tile_x - 2, tile_y, TRUE);
@@ -163,7 +163,7 @@ UBYTE CheckCollisionInDirection_b(UBYTE start_x, UBYTE start_y, UBYTE end_tile, 
     case CHECK_DIR_UP:  // Check up
       while (start_y != end_tile) {
         if (TileAt2x2(start_x, start_y - 2) ||                                      // Tile up
-            (ActorAt3x1Tile(start_x - 1, start_y - 2, FALSE) != NO_ACTOR_COLLISON)  // Actor up
+            (ActorAt3x1Tile(start_x, start_y - 2, FALSE) != NO_ACTOR_COLLISON)  // Actor up
         ) {
           return start_y;
         }
@@ -173,9 +173,9 @@ UBYTE CheckCollisionInDirection_b(UBYTE start_x, UBYTE start_y, UBYTE end_tile, 
     case CHECK_DIR_DOWN:  // Check down
       while (start_y != end_tile) {
         if (TileAt2x2(start_x, start_y) ||  // Tile down
-            ActorAt3x1Tile(start_x - 1, start_y + 1, FALSE) !=
+            ActorAt3x1Tile(start_x, start_y + 1, FALSE) !=
                 NO_ACTOR_COLLISON ||  // Actor down 1 tile
-            ActorAt3x1Tile(start_x - 1, start_y + 2, FALSE) !=
+            ActorAt3x1Tile(start_x, start_y + 2, FALSE) !=
                 NO_ACTOR_COLLISON  // Actor down 2 tiles
         ) {
           return start_y;
@@ -266,7 +266,7 @@ UBYTE ActorAt3x1Tile_b(UBYTE tx, UBYTE ty, UBYTE inc_noclip) __banked {
     a_ty = DIV_8(actors[a].pos.y);
 
 
-    if ((ty == a_ty) && (tx == a_tx || tx == a_tx - 1 || tx == a_tx - 2)) {
+    if ((ty == a_ty) && (tx == a_tx || tx == a_tx - 1 || tx == a_tx + 1)) {
       return a;
     }
   }

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -284,6 +284,8 @@ int core_start() {
     // Force Clear Emote
     move_sprite(0, 0, 0);
     move_sprite(1, 0, 0);
+    // Force Clear invoke stack
+    script_stack_ptr = 0;
     // Force all palettes to update on switch
     #ifdef CGB
       palette_update_mask = 0x3F;

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -263,6 +263,10 @@ int core_start() {
     //BGP_REG = PAL_DEF(0U, 1U, 2U, 3U);
     //OBP0_REG = OBP1_REG = PAL_DEF(0U, 0U, 1U, 3U);
 
+    // Force Clear Emote
+    move_sprite(0, 0, 0);
+    move_sprite(1, 0, 0);
+
     UIInit();
     LoadScene(current_state);
 

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -23,7 +23,7 @@
 #include "main.h"
 
 UBYTE game_time = 0;
-UBYTE seededRand = FALSE;
+UBYTE seedRand = 2;
 UINT16 next_state;
 UINT8 delta_time;
 UINT16 current_state;
@@ -192,10 +192,19 @@ int core_start() {
       recent_joy = joy & ~last_joy;
     }
 
-    if (seededRand == FALSE) {
-      if (joy) {
-        seededRand = TRUE;
-        initrand((DIV_REG*256)+game_time);
+    if (seedRand) {
+      if(seedRand == 2){
+        // Seed on first button press
+        if (joy) {
+          seedRand--;
+          initrand((DIV_REG*256)+game_time);
+        }
+      } else {
+        // Seed on first button release
+          if (!joy) {
+          seedRand = FALSE;
+          initrand((DIV_REG*256)+game_time);
+        }
       }
     }
 

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -193,8 +193,8 @@ int core_start() {
     }
 
     if (seededRand == FALSE) {
-      seededRand = TRUE;
       if (joy) {
+        seededRand = TRUE;
         initrand((DIV_REG*256)+game_time);
       }
     }

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -266,6 +266,10 @@ int core_start() {
     // Force Clear Emote
     move_sprite(0, 0, 0);
     move_sprite(1, 0, 0);
+    // Force all palettes to update on switch
+    #ifdef CGB
+      palette_update_mask = 0x3F;
+    #endif
 
     UIInit();
     LoadScene(current_state);

--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -2,6 +2,7 @@
 
 #include <gb/cgb.h>
 #include <string.h>
+#include <rand.h>
 
 #include "Actor.h"
 #include "BankManager.h"
@@ -22,6 +23,7 @@
 #include "main.h"
 
 UBYTE game_time = 0;
+UBYTE seededRand = FALSE;
 UINT16 next_state;
 UINT8 delta_time;
 UINT16 current_state;
@@ -188,6 +190,13 @@ int core_start() {
     joy = joypad();
     if ((joy & INPUT_DPAD) != (last_joy & INPUT_DPAD)) {
       recent_joy = joy & ~last_joy;
+    }
+
+    if (seededRand == FALSE) {
+      seededRand = TRUE;
+      if (joy) {
+        initrand((DIV_REG*256)+game_time);
+      }
     }
 
     PUSH_BANK(1);

--- a/appData/src/gb/src/core/Math.c
+++ b/appData/src/gb/src/core/Math.c
@@ -1,7 +1,6 @@
 #include "Math.h"
 
 #include <gb/gb.h>
-#include <rand.h>
 
 INT16 DespRight(INT16 a, INT16 b) {
   return a >> b;
@@ -21,10 +20,4 @@ UBYTE Gt16(UINT16 a, UINT16 b) {
   UBYTE a_lo = a & 0xFF;
   UBYTE b_lo = b & 0xFF;
   return a_hi > b_hi || (a_hi == b_hi && a_lo > b_lo);
-}
-
-void SeedRand() {
-  UBYTE rnd;
-  rnd = *((UBYTE*)0xFF04);
-  initrand(rnd);
 }

--- a/appData/src/gb/src/core/ScriptRunner.c
+++ b/appData/src/gb/src/core/ScriptRunner.c
@@ -35,7 +35,6 @@ void ScriptRunnerInit() {
 }
 
 void ScriptStart(BankPtr* events_ptr) {
-  SeedRand();
 
   player.moving = FALSE;
 
@@ -50,8 +49,6 @@ void ScriptStart(BankPtr* events_ptr) {
 
 UBYTE ScriptStartBg(BankPtr* events_ptr, UBYTE owner) {
   UWORD new_ctx = 0;
-
-  SeedRand();
 
   // Run in background context
   new_ctx = ScriptCtxPoolNext();

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -2282,6 +2282,7 @@ void Script_ActorStopUpdate_b() {
   if (actors[active_script_ctx.script_actor].movement_ctx) {
     ScriptCtxPoolReturn(actors[active_script_ctx.script_actor].movement_ctx, active_script_ctx.script_actor);
   }
+  actors[active_script_ctx.script_actor].movement_ctx = 0; //@wtf fixes crash but still will not stop update script from same update script
 }
 
 void Script_ActorSetAnimate_b() {

--- a/appData/src/gb/src/core/ScriptRunner_b.c
+++ b/appData/src/gb/src/core/ScriptRunner_b.c
@@ -1839,6 +1839,8 @@ void Script_LoadVectors_b() {
  */
 void Script_ActorSetMoveSpeed_b() {
   actors[active_script_ctx.script_actor].move_speed = script_cmd_args[0];
+  actors[active_script_ctx.script_actor].pos.x = actors[active_script_ctx.script_actor].pos.x & 0xFFFC;
+  actors[active_script_ctx.script_actor].pos.y = actors[active_script_ctx.script_actor].pos.y & 0xFFFC;
 }
 
 /*

--- a/appData/src/gb/src/core/Scroll.c
+++ b/appData/src/gb/src/core/Scroll.c
@@ -222,7 +222,7 @@ void InitScroll() {
 }
 
 void RenderScreen() {
-  UINT8 i, temp;
+  UINT8 i;
   INT16 y;
 
   if (!fade_style)

--- a/appData/src/gb/src/core/UI.c
+++ b/appData/src/gb/src/core/UI.c
@@ -123,7 +123,7 @@ void UIShowAvatar(UBYTE avatar_index) {
 
 void UIShowChoice(UWORD flag_index, UBYTE bank, UWORD bank_offset) {
   UIShowMenu_b(flag_index, bank, bank_offset, 0,
-               MENU_CANCEL_ON_B_PRESSED | MENU_CANCEL_ON_LAST_OPTION);
+               /*MENU_CANCEL_ON_B_PRESSED | */MENU_CANCEL_ON_LAST_OPTION);
 }
 
 void UIShowMenu(UWORD flag_index,

--- a/appData/src/gb/src/core/UI.c
+++ b/appData/src/gb/src/core/UI.c
@@ -147,6 +147,9 @@ void UIMoveTo(UBYTE x, UBYTE y, UBYTE speed) {
   if (speed == 0) {
     win_pos_x = x;
     win_pos_y = y;
+    if (y == MENU_CLOSED_Y) {
+      win_speed = 0xFF;
+    }
   } else {
     win_speed = speed;
   }

--- a/appData/src/gb/src/core/UI_b.c
+++ b/appData/src/gb/src/core/UI_b.c
@@ -81,6 +81,10 @@ void UIUpdate_b() __banked {
     return;
   } else if (win_speed == 3 && ((game_time & 0x1) != 0)) {
     return;
+  } else if (win_speed == 0xFF) {
+    // UIIsClosed = true, but Wait for next frame to close
+    win_speed = 0;
+    return;
   }
 
   if (win_speed == 1) {

--- a/src/components/forms/CustomPalettePicker.js
+++ b/src/components/forms/CustomPalettePicker.js
@@ -239,7 +239,7 @@ class CustomPalettePicker extends Component {
       editHex = blackHex;
     }
 
-    this.setState({ selectedColor: colorIndex, currentCustomHex: "" });
+    this.setState({ selectedColor: colorIndex, currentCustomHex: "#"+hexToGBCHex(editHex).toLowerCase()});
     this.applyHexToState(editHex);
   };
 

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -192,6 +192,23 @@ const changes: EngineChange[] = [{
         "src/core/UI_a.s",
         "src/core/UI_b.c",
     ]
+}, {
+    version: "2.0.0-e18",
+    description: "Numerous bug fixes:\n" +
+    "   * Fix speed changes mid tile, emote clear on scene switch, palette event mask\n" +
+    "   * Fix crash with Stop On Update, B no longer default in multichoice\n" +
+    "   * Random seed generated on first button press/release to reduce bias",
+    modifiedFiles: [
+        "include/Math.h",
+        "src/core/Math.c",
+        "src/core/Actor_b.c",
+        "src/core/Core_Main.c",
+        "src/core/ScriptRunner.c",
+        "src/core/ScriptRunner_b.c",
+        "src/core/Scroll.c",
+        "src/core/UI.c",
+        "src/core/UI_b.c",
+    ]
 }];
 
 const ejectEngineChangelog = (currentVersion: string) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
Multichoice always picks option 2 when B pressed, some users mistake A and B.
Changing actor speed on attach or mid frame caused issues #629
Emote on simulscript like update not cleared on scene switch

* **What is the new behavior (if this is a feature change)?**
Multichoice no longer uses b for option 2 by default, menu unaffected.
Actor speed events clamp the actor position by 4 pixels, seems to fix the issue for any speed.
Emote sprite 0-1 is cleared on scene start

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
Todo:
- [ ] Update engine version, 
- [x] update changelog.
- Hard fix
- [ ] Ui blocking for simul scripts does not block while closing.
- [x] Textbox Flash of nothing #662 (perhaps need a frame counter if speed instant?)
- [x] Set Palette event with "Don't Modify" breaks Per Scene Palette selector
- [x] Fix #711 
- [x] Better random seeding
- Event changes?
- [ ] Faster camera speeds #636 move 1-4 pixels per frame, on top of 1 pixel every x frames.
- [ ] Switch Scene BG (I promised this, should be easy?)
- [ ] Engine field idea to test, toggle ui_block/Await close, May make textboxes on a timer and textboxes for location while mid game possible, and not interfere with any existing events.
