### PR TITLE
[v3] Fix clipboard on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@typescript-eslint/parser": "^4.25.0",
     "babel-eslint": "^10.1.0",
     "css-loader": "^3.0.0",
-    "electron": "8.2.5",
+    "electron": "8.5.5",
     "eslint": "^7.21.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,10 +4289,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@8.2.5:
-  version "8.2.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-8.2.5.tgz#ae3cb23d5517b2189fd35298e487198d65d1a291"
-  integrity sha512-LxSCUwmlfJtRwthd3ofpYaZ+1C2hQSW8Ep1DD9K3VbnDItO+kb3t1z35daJgAab78j54aOwo9gMxJtvU0Ftj6w==
+electron@8.5.5:
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-8.5.5.tgz#17b12bd70139c0099f750fc5de0d480bf03acb96"
+  integrity sha512-e355H+tRDial0m+X2v+l+0SnaATAPw4sNjv9qmdk/6MJz/glteVJwVJEnxTjPfEELIJSChrBWDBVpjdDvoBF4Q==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

While testing GBS 3, I noticed that none of the copy+paste behavior worked as-intended

After doing a bit of debugging, I saw that `readBuffer` wasn't giving a proper output after the data was being stored 

![image](https://user-images.githubusercontent.com/9100169/120618372-df9b9100-c40f-11eb-8e4c-35027e8887db.png)

It turns out this was an upstream bug in the version of Electron we were using:

https://github.com/electron/electron/issues/24253

And a fix was published in version `8.4.1`:

https://www.electronjs.org/releases/stable?version=8&page=2#8.4.1

* **What is the current behavior?** (You can also link to an open issue here)

No copy+paste action worked on Windows

* **What is the new behavior (if this is a feature change)?**

Copy+paste now works in Windows

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes

* **Other information**:

Side note: I noticed that we're a fair few stable releases away from the most recent stable Electron version. I'd be happy to do some testing to see how far we're able to upgrade our dependencies - is that something that we'd want to do, or is there something I'm not aware of when it comes to our dep versions?