### PR TITLE
[v2beta] Minor GB engine fixes.

### DIFF
--- a/appData/src/gb/src/core/Core_Main.c
+++ b/appData/src/gb/src/core/Core_Main.c
@@ -139,7 +139,7 @@ int core_start() {
   memset(&script_cmd_args, 0, sizeof(script_cmd_args));
   memset(&script_stack, 0, sizeof(script_stack));
   memset(&script_bank_stack, 0, sizeof(script_bank_stack));
-  memset(&script_start_stack, 0, sizeof(script_bank_stack));
+  memset(&script_start_stack, 0, sizeof(script_start_stack));
 
   memset(&actors, 0, sizeof(actors));
   memset(&active_script_ctx, 0, sizeof(active_script_ctx));

--- a/appData/src/gb/src/core/Scroll.c
+++ b/appData/src/gb/src/core/Scroll.c
@@ -240,8 +240,10 @@ void RenderScreen() {
       set_sprite_palette(0, 8, BkgPaletteBuffer);
     } else
     #endif
+    {
       OBP0_REG = 0xFF;
       BGP_REG = 0xFF;
+    }
   }
 
   // Clear pending rows/ columns


### PR DESCRIPTION
- Set the proper sizeof() for clearing script_start_stack. (Not applicable to gbvm)
- Fix the palette clearing routine in Scroll.c to match indentation/intent. (Different approach than fix in gbvm, but same effect)

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Minor fixes spotted while working with the codebase using a modern compiler.

* **What is the current behavior?** (You can also link to an open issue here)

These bugs aren't noticeable in emulators or play, but they seem good to take care of for the sake of consistency. While all the focus is on v3alpha, there's still a contingent of users on v2beta.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.