### PR TITLE
[v3] Fix regression behavior when invalid background present

### DIFF
--- a/src/components/world/Scene.js
+++ b/src/components/world/Scene.js
@@ -161,7 +161,11 @@ class Scene extends Component {
       labelColor,
     } = scene;
 
-    const { tileColors } = image;
+    /**
+     * Image may potentially be `undefined` if a user has selected an image,
+     * then deleted it.
+     */
+    const { tileColors } = image || {};
 
     if (!visible) {
       return null;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
> I have done manual bug testing, but am not yet aware of how to do integration testing with GBS itself. I have done things like `react-testing-library` in past projects. Do we have something like that setup?
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If you have a scene in a GBS with an invalid `backgroundId`, say from setting an image file then deleting it, reopening GBS will throw an error and refuse to load any of the UI.

* **What is the new behavior (if this is a feature change)?**

Now, when loading a project w/ invalid scene background, the behavior is more consistent w/ GBS 2 beta, where the background appears blank instead

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes

* **Other information**:

This issue seems like it could have been discovered if this file was a TS file. (indicating that this could have been `undefined`, then forcing you to add destructure alt). I'll take some time to try and refactor this to TS/FC in another PR