### PR TITLE
[v3] SceneCollisions TS migration

### DIFF
--- a/src/components/world/SceneCollisions.tsx
+++ b/src/components/world/SceneCollisions.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import {
   COLLISION_TOP,
   COLLISION_ALL,
@@ -21,9 +21,9 @@ const SceneCollisions = ({
   height,
   collisions,
 }: SceneCollisionsProps) => {
-  const canvas = React.useRef<HTMLCanvasElement>(null);
+  const canvas = useRef<HTMLCanvasElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (canvas.current) {
       // eslint-disable-next-line no-self-assign
       canvas.current.width = canvas.current.width; // Clear canvas

--- a/src/components/world/SceneCollisions.tsx
+++ b/src/components/world/SceneCollisions.tsx
@@ -103,13 +103,11 @@ const SceneCollisions = ({
   }, [collisions, height, width])
 
   return (
-    <div className="SceneCollisions">
-      <canvas
-        ref={canvas}
-        width={width * TILE_SIZE}
-        height={height * TILE_SIZE}
-      />
-    </div>
+    <canvas
+      ref={canvas}
+      width={width * TILE_SIZE}
+      height={height * TILE_SIZE}
+    />
   );
 }
 

--- a/src/components/world/SceneCollisions.tsx
+++ b/src/components/world/SceneCollisions.tsx
@@ -11,15 +11,15 @@ import {
 const TILE_SIZE = 8;
 
 interface SceneCollisionsProps {
-  width: number,
-  height: number,
-  collisions: number[]
+  width: number;
+  height: number;
+  collisions: number[];
 }
 
 const SceneCollisions = ({
   width,
   height,
-  collisions
+  collisions,
 }: SceneCollisionsProps) => {
   const canvas = React.useRef<HTMLCanvasElement>(null);
 
@@ -100,7 +100,7 @@ const SceneCollisions = ({
         }
       }
     }
-  }, [collisions, height, width])
+  }, [collisions, height, width]);
 
   return (
     <canvas
@@ -109,6 +109,6 @@ const SceneCollisions = ({
       height={height * TILE_SIZE}
     />
   );
-}
+};
 
 export default SceneCollisions;

--- a/src/components/world/SceneCollisions.tsx
+++ b/src/components/world/SceneCollisions.tsx
@@ -1,5 +1,4 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React from "react";
 import {
   COLLISION_TOP,
   COLLISION_ALL,
@@ -11,26 +10,26 @@ import {
 
 const TILE_SIZE = 8;
 
-class SceneCollisions extends Component {
-  constructor(props) {
-    super(props);
-    this.canvas = React.createRef();
-  }
+interface SceneCollisionsProps {
+  width: number,
+  height: number,
+  collisions: number[]
+}
 
-  componentDidMount() {
-    this.draw();
-  }
+const SceneCollisions = ({
+  width,
+  height,
+  collisions
+}: SceneCollisionsProps) => {
+  const canvas = React.useRef<HTMLCanvasElement>(null);
 
-  componentDidUpdate() {
-    this.draw();
-  }
-
-  draw = () => {
-    const { collisions, width, height } = this.props;
-    if (this.canvas.current) {
+  React.useEffect(() => {
+    if (canvas.current) {
       // eslint-disable-next-line no-self-assign
-      this.canvas.current.width = this.canvas.current.width; // Clear canvas
-      const ctx = this.canvas.current.getContext("2d");
+      canvas.current.width = canvas.current.width; // Clear canvas
+      const ctx = canvas.current.getContext("2d");
+
+      if (!ctx) return;
 
       for (let yi = 0; yi < height; yi++) {
         for (let xi = 0; xi < width; xi++) {
@@ -101,26 +100,17 @@ class SceneCollisions extends Component {
         }
       }
     }
-  };
+  }, [collisions, height, width])
 
-  render() {
-    const { width, height } = this.props;
-    return (
-      <div className="SceneCollisions">
-        <canvas
-          ref={this.canvas}
-          width={width * TILE_SIZE}
-          height={height * TILE_SIZE}
-        />
-      </div>
-    );
-  }
+  return (
+    <div className="SceneCollisions">
+      <canvas
+        ref={canvas}
+        width={width * TILE_SIZE}
+        height={height * TILE_SIZE}
+      />
+    </div>
+  );
 }
-
-SceneCollisions.propTypes = {
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-  collisions: PropTypes.arrayOf(PropTypes.number).isRequired,
-};
 
 export default SceneCollisions;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR refactors the `SceneCollisions` component to use TS & functional hooks

* **What is the current behavior?** (You can also link to an open issue here)

N/A

* **What is the new behavior (if this is a feature change)?**

There should be no behavioral changes after this PR.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

This PR was made as part of an effort to migrate Scene-related components to TS/FC after running into a regression that was fixed in #776

The other components I want to tackle before working on Scene would be:

- [ ] Scene
	- [x] SceneInfo (#777)
	- [x] EventHelper (#778)
	- [x] Actor (#779)
		- [x] SpriteSheetCanvas
	- [ ] Trigger
	- [ ] SceneCursor
	- [x] SceneCollisions (this PR)
	- [ ] ColorizedImage