### PR TITLE
[v3] Fix font codegen tests

### DIFF
--- a/test/data/compiler/compileEntityEvents.test.js
+++ b/test/data/compiler/compileEntityEvents.test.js
@@ -4,6 +4,7 @@ import {
   EVENT_TEXT,
   EVENT_IF_TRUE,
 } from "../../../src/lib/compiler/eventTypes";
+import { getDummyCompiledFont } from "../../dummydata";
 
 jest.mock("../../../src/consts");
 
@@ -48,7 +49,8 @@ _testname::
 `);
 });
 
-test("should output text command", () => {
+test("should output text command", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
   const input = [
     {
       command: EVENT_TEXT,
@@ -58,7 +60,7 @@ test("should output text command", () => {
     },
   ];
   const strings = ["HELLO WORLD"];
-  const output = compileEntityEvents("testname", input, { strings });
+  const output = compileEntityEvents("testname", input, { strings, fonts: [dummyCompiledFont] });
   expect(output).toEqual(`.include "vm.i"
 .include "data/game_globals.i"
 
@@ -83,7 +85,9 @@ _testname::
 `);
 });
 
-test("should output text with avatar command", () => {
+test("should output text with avatar command", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
+
   const input = [
     {
       command: EVENT_TEXT,
@@ -99,7 +103,10 @@ test("should output text with avatar command", () => {
       id: 2,
     },
   ];
-  const output = compileEntityEvents("testname", input, { strings, avatars });
+
+  const fonts = [dummyCompiledFont];
+
+  const output = compileEntityEvents("testname", input, { strings, avatars, fonts });
   expect(output).toEqual(`.include "vm.i"
 .include "data/game_globals.i"
 
@@ -124,7 +131,9 @@ _testname::
 `);
 });
 
-test("should allow conditional statements", () => {
+test("should allow conditional statements", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
+
   const input = [
     {
       command: EVENT_IF_TRUE,
@@ -153,7 +162,8 @@ test("should allow conditional statements", () => {
   ];
   const strings = ["HELLO WORLD", "TRUE PATH", "FALSE PATH"];
   const variables = ["1", "2", "3", "4"];
-  const output = compileEntityEvents("testname", input, { strings, variables });
+  const fonts = [dummyCompiledFont];
+  const output = compileEntityEvents("testname", input, { strings, variables, fonts });
   expect(output).toEqual(`.include "vm.i"
 .include "data/game_globals.i"
 
@@ -194,7 +204,8 @@ _testname::
 `);
 });
 
-test("should allow commands after conditional", () => {
+test("should allow commands after conditional", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
   const input = [
     {
       command: EVENT_IF_TRUE,
@@ -229,7 +240,8 @@ test("should allow commands after conditional", () => {
   ];
   const strings = ["HELLO WORLD", "TRUE PATH", "FALSE PATH", "AFTER"];
   const variables = ["1", "2", "3", "4"];
-  const output = compileEntityEvents("testname", input, { strings, variables });
+  const fonts = [dummyCompiledFont];
+  const output = compileEntityEvents("testname", input, { strings, variables, fonts });
   expect(output).toEqual(`.include "vm.i"
 .include "data/game_globals.i"
 

--- a/test/data/compiler/scriptBuilder2.test.ts
+++ b/test/data/compiler/scriptBuilder2.test.ts
@@ -1,5 +1,6 @@
 import ScriptBuilder from "../../../src/lib/compiler/scriptBuilder";
 import { ScriptEvent } from "../../../src/store/features/entities/entitiesTypes";
+import { getDummyCompiledFont } from "../../dummydata";
 
 test("Should be able to set active actor to player", () => {
   const output: string[] = [];
@@ -76,7 +77,7 @@ test("Should be able to wait for N frames to pass", () => {
       id: "scene1",
       actors: [],
       triggers: [],
-    },
+    }
   });
   sb.wait(20);
   expect(output).toEqual([
@@ -136,7 +137,8 @@ _MY_SCRIPT::
   );
 });
 
-test("Should be able to open dialogue boxes", () => {
+test("Should be able to open dialogue boxes", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
   const output: string[] = [];
   const sb = new ScriptBuilder(output, {
     scene: {
@@ -144,6 +146,7 @@ test("Should be able to open dialogue boxes", () => {
       actors: [],
       triggers: [],
     },
+    fonts: [dummyCompiledFont]
   });
   sb.textDialogue("Hello World");
   sb.scriptEnd();
@@ -234,7 +237,8 @@ _MY_SCRIPT::
   );
 });
 
-test("Should be able to conditionally execute if variable is true with function paths", () => {
+test("Should be able to conditionally execute if variable is true with function paths", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
   const output: string[] = [];
   const sb = new ScriptBuilder(output, {
     scene: {
@@ -249,6 +253,7 @@ test("Should be able to conditionally execute if variable is true with function 
       ],
       triggers: [],
     },
+    fonts: [dummyCompiledFont],
     // variables: ["0", "1"],
     compileEvents: (self: ScriptBuilder, events: ScriptEvent[]) => {
       if (events[0].id === "event1") {
@@ -309,7 +314,8 @@ _MY_SCRIPT::
   );
 });
 
-test("Should be able to conditionally execute if variable is true with nested function paths", () => {
+test("Should be able to conditionally execute if variable is true with nested function paths", async () => {
+  const dummyCompiledFont = await getDummyCompiledFont();
   const output: string[] = [];
   const sb = new ScriptBuilder(output, {
     scene: {
@@ -330,6 +336,7 @@ test("Should be able to conditionally execute if variable is true with nested fu
       ],
       triggers: [],
     },
+    fonts: [dummyCompiledFont],
     // variables: ["0", "1", "2"],
   });
 

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -25,6 +25,10 @@ import { initialState as initialClipboardState } from "../src/store/features/cli
 import { initialState as initialSpriteState } from "../src/store/features/sprite/spriteState";
 import { initialState as initialTrackerState } from "../src/store/features/tracker/trackerState";
 import { initialState as initialTrackerDocumentState } from "../src/store/features/trackerDocument/trackerDocumentState";
+import compileFonts, { PrecompiledFontData } from "../src/lib/compiler/compileFonts";
+import {
+  projectTemplatesRoot
+} from "../src/consts";
 
 export const dummyScene: SceneData = {
   id: "",
@@ -181,6 +185,24 @@ export const dummyProjectData: ProjectData = {
     batterylessEnabled: false,
   },
 };
+
+export const getDummyCompiledFont = async (): Promise<PrecompiledFontData> => {
+  const compiledFontsRet = await compileFonts([
+      {
+        id: "87d28862-ac4a-4f15-b678-d8d2e3e8787c",
+        name: "gbs-mono",
+        width: 128,
+        height: 112,
+        filename: "gbs-mono.png",
+        inode: "10414574138355865",
+        mapping: {},
+        _v: 1625435968911,
+        plugin: undefined,
+      }
+    ], `${projectTemplatesRoot}/gbhtml`);
+
+    return compiledFontsRet[0];
+}
 
 export const dummyRootState: RootState = {
   editor: {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR helps fix ~7-8 tests we had that were not passing the proper `font` data, thus introducing failing tests. They originally failed and looked like this:

![image](https://user-images.githubusercontent.com/9100169/124400904-bf931200-dcda-11eb-8189-25cb7df15c23.png)

But now pass as-expected

* **What is the current behavior?** (You can also link to an open issue here)

This PR fixes said tests

* **What is the new behavior (if this is a feature change)?**

N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I noticed there's still a failing text codegen test after this change, but it seems to be due to a changed number in the string output:

![image](https://user-images.githubusercontent.com/9100169/124400918-da658680-dcda-11eb-9331-23cc5f75b53f.png)

Is this expected behavior? Should we update the tests with the code's output string? Is the code wrong and we need to fix the codegen logic?