### PR TITLE
Added note about Windows cloning with symlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ Fork, then clone the repo:
 git clone git@github.com:your-username/gb-studio.git
 ```
 
+> If you're using Windows, you should clone using Symlink support, otherwise your tests will fail.
+>
+> To do this, you must've enabled Symlink support when installing Git for Windows.
+>
+> With it enabled, you must run your `git clone` command like this, with admin privileges:
+>
+> `git clone -c core.symlinks=true git@github.com:your-username/gb-studio.git`
+
 Install it:
 
 ```bash


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

While working on fixing our tests, I noticed that I had cloned the project without symlinks (as it requires admin mode + special command to clone that way on Windows). As such, our `l10n` tests were failing.

This PR adds a documentation note of this to our `CONTRIBUTING.md` document so others don't end up reporting errant test failures on Windows dev environments.

* **What is the current behavior?** (You can also link to an open issue here)

N/A

* **What is the new behavior (if this is a feature change)?**

N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
