### PR TITLE
Add preview view to menu event

### DIFF
--- a/src/components/script/MenuPreview.tsx
+++ b/src/components/script/MenuPreview.tsx
@@ -3,28 +3,18 @@ import uniq from "lodash/uniq";
 import React, { FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { assetFilename } from "lib/helpers/gbstudio";
-import { textNumLines } from "lib/helpers/trimlines";
 import { RootState } from "store/configureStore";
-import {
-  avatarSelectors,
-  fontSelectors,
-} from "store/features/entities/entitiesState";
+import { fontSelectors } from "store/features/entities/entitiesState";
 import { loadFont, drawFrame, drawText, FontData } from "./TextPreviewHelper";
 
-interface DialoguePreviewProps {
-  text: string;
-  avatarId?: string;
+interface MenuPreviewProps {
+  items: string[];
+  layout: string;
 }
 
-export const DialoguePreview: FC<DialoguePreviewProps> = ({
-  text,
-  avatarId,
-}) => {
+export const MenuPreview: FC<MenuPreviewProps> = ({ items, layout }) => {
   const projectRoot = useSelector((state: RootState) => state.document.root);
   const uiVersion = useSelector((state: RootState) => state.editor.uiVersion);
-  const avatarAsset = useSelector((state: RootState) =>
-    avatarId ? avatarSelectors.selectById(state, avatarId) : undefined
-  );
   const fonts = useSelector((state: RootState) =>
     fontSelectors.selectAll(state)
   );
@@ -37,7 +27,7 @@ export const DialoguePreview: FC<DialoguePreviewProps> = ({
   );
 
   const [frameImage, setFrameImage] = useState<HTMLImageElement>();
-  const [avatarImage, setAvatarImage] = useState<HTMLCanvasElement>();
+  const [cursorImage, setCursorImage] = useState<HTMLImageElement>();
   const [fontsData, setFontsData] = useState<Record<string, FontData>>({});
   const [drawn, setDrawn] = useState<boolean>(false);
   const ref = useRef<HTMLCanvasElement>(null);
@@ -55,19 +45,28 @@ export const DialoguePreview: FC<DialoguePreviewProps> = ({
     frameAsset
   )}?_v=${uiVersion}`;
 
-  const avatarFilename = avatarAsset
-    ? `file:///${assetFilename(projectRoot, "avatars", avatarAsset)}?_v=${
-        avatarAsset._v || 0
-      }`
-    : "";
+  const cursorAsset = {
+    id: "cursor",
+    name: "Window Cursor",
+    filename: `cursor.png`,
+    _v: uiVersion,
+  };
+
+  const cursorFilename = `file:///${assetFilename(
+    projectRoot,
+    "ui",
+    cursorAsset
+  )}?_v=${uiVersion}`;
 
   useEffect(() => {
     async function fetchData() {
       const usedFontIds = uniq(
-        ([] as string[]).concat(
-          defaultFontId,
-          (String(text).match(/(!F:[0-9a-f-]+!)/g) || []) // Add fonts referenced in text
-            .map((id) => id.substring(3).replace(/!$/, ""))
+        items.flatMap((item) =>
+          ([] as string[]).concat(
+            defaultFontId,
+            (String(item).match(/(!F:[0-9a-f-]+!)/g) || []) // Add fonts referenced in text
+              .map((id) => id.substring(3).replace(/!$/, ""))
+          )
         )
       );
       const usedFonts = usedFontIds.map((id) => fontsLookup[id] || fonts[0]);
@@ -77,7 +76,7 @@ export const DialoguePreview: FC<DialoguePreviewProps> = ({
       setFontsData(keyBy(usedFontData, "id"));
     }
     fetchData();
-  }, [text, defaultFontId, fonts, fontsLookup, projectRoot]);
+  }, [defaultFontId, fonts, fontsLookup, items, projectRoot]);
 
   // Load frame image
   useEffect(() => {
@@ -88,79 +87,55 @@ export const DialoguePreview: FC<DialoguePreviewProps> = ({
     };
   }, [frameFilename]);
 
-  // Load frame image
+  // Load cursor image
   useEffect(() => {
     const img = new Image();
-    img.src = frameFilename;
+    img.src = cursorFilename;
     img.onload = () => {
-      setFrameImage(img);
+      setCursorImage(img);
     };
-  }, [frameFilename]);
-
-  // Load Avatar image
-  useEffect(() => {
-    if (avatarFilename) {
-      const img = new Image();
-      img.src = avatarFilename;
-      img.onload = () => {
-        // Make green background color transparent
-        const tmpCanvas = document.createElement("canvas");
-        const tmpCtx = tmpCanvas.getContext("2d");
-        if (!tmpCtx) {
-          return;
-        }
-        tmpCtx.drawImage(img, 0, 0);
-        const imgData = tmpCtx?.getImageData(0, 0, 16, 16);
-        if (imgData) {
-          for (let i = 0; i < imgData.data.length; i += 4) {
-            const g = imgData.data[i + 1];
-            const b = imgData.data[i + 2];
-            const a = imgData.data[i + 3];
-            if ((g > 250 && b < 100) || a < 10) {
-              imgData.data[i + 3] = 0;
-            }
-          }
-          tmpCtx.putImageData(imgData, 0, 0);
-        }
-        setAvatarImage(tmpCanvas);
-      };
-    } else {
-      setAvatarImage(undefined);
-    }
-  }, [avatarFilename]);
+  }, [cursorFilename]);
 
   useLayoutEffect(() => {
-    if (ref.current && frameImage && (!avatarId || avatarImage)) {
+    if (ref.current && frameImage && cursorImage) {
       const canvas = ref.current;
       const ctx = canvas.getContext("2d");
       // eslint-disable-next-line no-self-assign
       canvas.width = canvas.width;
       if (ctx) {
-        const tileWidth = 20;
-        const tileHeight = textNumLines(text) + 2;
+        const tileWidth = layout === "dialogue" ? 20 : 10;
+        const tileHeight =
+          (layout === "dialogue" ? Math.min(items.length, 4) : items.length) +
+          2;
         canvas.width = tileWidth * 8;
         canvas.height = tileHeight * 8;
         drawFrame(ctx, frameImage, tileWidth, tileHeight);
-        if (avatarId) {
-          drawText(ctx, text, 24, 8, fontsData, defaultFontId, fonts[0]?.id);
-          if (avatarImage) {
-            ctx.drawImage(avatarImage, 8, 8);
-          }
-        } else {
-          drawText(ctx, text, 8, 8, fontsData, defaultFontId, fonts[0]?.id);
-        }
+        items.forEach((item, i) => {
+          const x = layout === "dialogue" ? 16 + 9 * 8 * Math.floor(i / 4) : 16;
+          const y = layout === "dialogue" ? 8 + (i % 4) * 8 : 8 + i * 8;
+          drawText(
+            ctx,
+            item || `Item ${i + 1}`,
+            x,
+            y,
+            fontsData,
+            defaultFontId,
+            fonts[0]?.id
+          );
+        });
+        ctx.drawImage(cursorImage, 8, 8);
       }
       setDrawn(true);
     }
   }, [
     ref,
-    text,
-    avatarId,
     frameImage,
-    avatarImage,
     fontsData,
     defaultFontId,
     fonts,
+    layout,
+    items,
+    cursorImage,
   ]);
 
   return (
@@ -169,7 +144,7 @@ export const DialoguePreview: FC<DialoguePreviewProps> = ({
       width={160}
       height={48}
       style={{
-        width: 240,
+        width: layout === "dialogue" ? 240 : 120,
         imageRendering: "pixelated",
         boxShadow: "5px 5px 10px 0px rgba(0,0,0,0.5)",
         borderRadius: 4,

--- a/src/components/script/MenuPreview.tsx
+++ b/src/components/script/MenuPreview.tsx
@@ -9,7 +9,7 @@ import { loadFont, drawFrame, drawText, FontData } from "./TextPreviewHelper";
 
 interface MenuPreviewProps {
   items: string[];
-  layout: string;
+  layout: "dialogue" | "menu";
 }
 
 export const MenuPreview: FC<MenuPreviewProps> = ({ items, layout }) => {

--- a/src/components/script/ScriptEditorEventHelper.tsx
+++ b/src/components/script/ScriptEditorEventHelper.tsx
@@ -62,7 +62,23 @@ export const ScriptEditorEventHelper: FC<ScriptEditorEventHelperProps> = ({
 
     return (
       <RelativePortal offsetX={-10} offsetY={10} pin="top-right">
-        <MenuPreview items={items} layout={toString(event.args?.layout)} />
+        <MenuPreview
+          items={items}
+          layout={event.args?.layout === "dialogue" ? "dialogue" : "menu"}
+        />
+      </RelativePortal>
+    );
+  }
+
+  if (event.command === "EVENT_CHOICE") {
+    const items = [
+      toString(event.args?.trueText),
+      toString(event.args?.falseText),
+    ];
+
+    return (
+      <RelativePortal offsetX={-10} offsetY={10} pin="top-right">
+        <MenuPreview items={items} layout="dialogue" />
       </RelativePortal>
     );
   }

--- a/src/components/script/ScriptEditorEventHelper.tsx
+++ b/src/components/script/ScriptEditorEventHelper.tsx
@@ -4,6 +4,7 @@ import { RootState } from "store/configureStore";
 import { ScriptEvent } from "store/features/entities/entitiesTypes";
 import { RelativePortal } from "ui/layout/RelativePortal";
 import { DialoguePreview } from "./DialoguePreview";
+import { MenuPreview } from "./MenuPreview";
 
 interface ScriptEditorEventHelperProps {
   event: ScriptEvent;
@@ -11,6 +12,10 @@ interface ScriptEditorEventHelperProps {
 
 const toString = (input: unknown): string => {
   return typeof input === "string" ? input : "";
+};
+
+const toInt = (input: unknown): number => {
+  return typeof input === "number" ? input : 0;
 };
 
 export const ScriptEditorEventHelper: FC<ScriptEditorEventHelperProps> = ({
@@ -39,6 +44,25 @@ export const ScriptEditorEventHelper: FC<ScriptEditorEventHelperProps> = ({
             avatarId={toString(event.args?.avatarId)}
           />
         )}
+      </RelativePortal>
+    );
+  }
+
+  if (event.command === "EVENT_MENU") {
+    const items = [
+      toString(event.args?.option1),
+      toString(event.args?.option2),
+      toString(event.args?.option3),
+      toString(event.args?.option4),
+      toString(event.args?.option5),
+      toString(event.args?.option6),
+      toString(event.args?.option7),
+      toString(event.args?.option8),
+    ].splice(0, toInt(event.args?.items));
+
+    return (
+      <RelativePortal offsetX={-10} offsetY={10} pin="top-right">
+        <MenuPreview items={items} layout={toString(event.args?.layout)} />
       </RelativePortal>
     );
   }

--- a/src/components/script/TextPreviewHelper.ts
+++ b/src/components/script/TextPreviewHelper.ts
@@ -1,0 +1,182 @@
+import { Font } from "store/features/entities/entitiesTypes";
+import { lexText } from "lib/fonts/lexText";
+import { encodeChar } from "lib/helpers/encodings";
+import { assetFilename } from "lib/helpers/gbstudio";
+
+export interface FontData {
+  id: string;
+  img: HTMLImageElement;
+  isMono: boolean;
+  widths: number[];
+  mapping: Record<string, number>;
+}
+
+const DOLLAR_CHAR = 4;
+const HASH_CHAR = 3;
+
+export const isTransparent = (r: number, g: number, b: number): boolean => {
+  return (
+    (r === 255 && b === 255 && g === 0) || (g === 255 && r === 0 && b === 0)
+  );
+};
+
+export const drawFrame = (
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement,
+  width: number,
+  height: number
+) => {
+  ctx.drawImage(img, 0, 0, 8, 8, 0, 0, 8, 8); // TL
+  ctx.drawImage(img, 16, 0, 8, 8, (width - 1) * 8, 0, 8, 8); // TR
+  ctx.drawImage(img, 0, 16, 8, 8, 0, (height - 1) * 8, 8, 8); // BL
+  ctx.drawImage(img, 16, 16, 8, 8, (width - 1) * 8, (height - 1) * 8, 8, 8); // BR
+  for (let i = 0; i < height - 2; i++) {
+    ctx.drawImage(img, 0, 8, 8, 8, 0, (i + 1) * 8, 8, 8); // L
+    ctx.drawImage(img, 16, 8, 8, 8, (width - 1) * 8, (i + 1) * 8, 8, 8); // R
+  }
+  for (let i = 0; i < width - 2; i++) {
+    ctx.drawImage(img, 8, 0, 8, 8, (i + 1) * 8, 0, 8, 8); // T
+    ctx.drawImage(img, 8, 16, 8, 8, (i + 1) * 8, (height - 1) * 8, 8, 8); // B
+  }
+  for (let i = 0; i < height - 2; i++) {
+    for (let j = 0; j < width - 2; j++) {
+      ctx.drawImage(img, 8, 8, 8, 8, (j + 1) * 8, (i + 1) * 8, 8, 8); // C
+    }
+  }
+};
+
+const loadImage = async (src: string): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.src = src;
+    img.onload = () => {
+      resolve(img);
+    };
+    img.onerror = (error) => {
+      reject(error);
+    };
+  });
+};
+
+export const loadFont = async (
+  projectRoot: string,
+  font: Font
+): Promise<FontData> => {
+  const fontFilename = `file:///${assetFilename(
+    projectRoot,
+    "fonts",
+    font
+  )}?_v=${font._v || 0}`;
+  const img = await loadImage(fontFilename);
+  const widths: number[] = [];
+  let isMono = true;
+
+  // Make green background color transparent
+  const tmpCanvas = document.createElement("canvas");
+  const tmpCtx = tmpCanvas.getContext("2d");
+  if (!tmpCtx) {
+    throw new Error("Unable to get canvas context while loading font");
+  }
+  tmpCtx.drawImage(img, 0, 0);
+  const imgData = tmpCtx?.getImageData(0, 0, img.width, img.height);
+  if (imgData) {
+    const charsX = Math.floor(img.width / 8);
+    const charsY = Math.floor(img.height / 8);
+
+    for (let yi = 0; yi < charsY; yi++) {
+      for (let xi = 0; xi < charsX; xi++) {
+        let width = 0;
+        while (width < 8) {
+          const i = 4 * (yi * 8 * img.width + xi * 8 + width);
+          const r = imgData.data[i];
+          const g = imgData.data[i + 1];
+          const b = imgData.data[i + 2];
+          if (isTransparent(r, g, b)) {
+            isMono = false;
+            break;
+          }
+          width++;
+        }
+        widths.push(width);
+      }
+    }
+  }
+
+  return {
+    id: font.id,
+    img,
+    isMono,
+    widths,
+    mapping: font.mapping,
+  };
+};
+
+export const drawText = (
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  xOffset: number,
+  yOffset: number,
+  fontsData: Record<string, FontData>,
+  defaultFontId: string,
+  fallbackFontId: string
+) => {
+  let drawX = 0;
+  let drawY = 0;
+
+  let font = fontsData[defaultFontId];
+
+  if (!font) {
+    font = fontsData[fallbackFontId];
+  }
+
+  if (!font) {
+    return;
+  }
+
+  const drawCharCode = (char: number) => {
+    const lookupX = char % 16;
+    const lookupY = Math.floor(char / 16);
+    ctx.drawImage(
+      font.img,
+      lookupX * 8,
+      lookupY * 8,
+      font.widths[char],
+      8,
+      drawX + xOffset,
+      drawY + yOffset,
+      font.widths[char],
+      8
+    );
+    drawX += font.widths[char];
+  };
+
+  const textTokens = lexText(text);
+  textTokens.forEach((token) => {
+    if (token.type === "text") {
+      const string = token.value;
+      for (let i = 0; i < string.length; i++) {
+        if (string[i] === "\n") {
+          drawX = 0;
+          drawY += 8;
+          continue;
+        }
+        const char =
+          (encodeChar(string[i], font.mapping) - 32) % font.widths.length;
+        drawCharCode(char);
+      }
+    } else if (token.type === "variable") {
+      drawCharCode(DOLLAR_CHAR);
+      drawCharCode(DOLLAR_CHAR);
+      drawCharCode(DOLLAR_CHAR);
+    } else if (token.type === "char") {
+      drawCharCode(HASH_CHAR);
+      drawCharCode(HASH_CHAR);
+      drawCharCode(HASH_CHAR);
+    } else if (token.type === "font") {
+      const newFont = fontsData[token.fontId];
+      if (newFont) {
+        font = newFont;
+      }
+    }
+  });
+};

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -648,15 +648,25 @@ export const precompileFonts = async (
     }
   };
 
+  const addFontsFromString = (s) => {
+    (s.match(/(!F:[0-9a-f-]+!)/g) || [])
+      .map((id) => id.substring(3).replace(/!$/, ""))
+      .forEach(addFont);
+  };
+  
   walkScenesEvents(scenes, (cmd) => {
     if (cmd.args && cmd.args.fontId !== undefined) {
       addFont(cmd.args.fontId || fonts[0].id);
     }
     if (cmd.args && cmd.args.text !== undefined) {
       // Add fonts referenced in text
-      (String(cmd.args.text).match(/(!F:[0-9a-f-]+!)/g) || [])
-        .map((id) => id.substring(3).replace(/!$/, ""))
-        .forEach(addFont);
+      addFontsFromString(String(cmd.args.text));
+    }
+    if (cmd.command && cmd.command === "EVENT_MENU" && cmd.args) {
+      // Add fonts referenced in menu items
+      for (let i = 1; i <= cmd.args.items; i++) {
+        addFontsFromString(String(cmd.args[`option${i}`]));
+      }
     }
   });
 

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -2057,7 +2057,7 @@ class ScriptBuilder {
   ) => {
     const variableAlias = this.getVariableAlias(setVariable);
     const optionsText = options.map(
-      (option, index) => trimlines(option || "", 6, 1) || `Item ${index + 1}`
+      (option, index) => textCodeSetFont(0) + (option || `Item ${index + 1}`)
     );
     const height =
       layout === "menu" ? options.length : Math.min(options.length, 4);

--- a/src/lib/events/eventMenu.js
+++ b/src/lib/events/eventMenu.js
@@ -1,9 +1,4 @@
-const trimlines = require("../helpers/trimlines");
 const l10n = require("../helpers/l10n").default;
-
-const trimMenuItem = (string) => {
-  return trimlines(string, 6, 1);
-};
 
 const id = "EVENT_MENU";
 const groups = ["EVENT_GROUP_DIALOGUE"];
@@ -51,7 +46,6 @@ const fields = [].concat(
           key: `option${i + 1}`,
           label: l10n("FIELD_SET_TO_VALUE_IF", { value: String(i + 1) }),
           type: "text",
-          updateFn: trimMenuItem,
           defaultValue: "",
           placeholder: l10n("FIELD_ITEM", { value: String(i + 1) }),
           conditions: [
@@ -65,7 +59,6 @@ const fields = [].concat(
           key: `option${i + 1}`,
           label: l10n("FIELD_SET_TO_VALUE_IF", { value: String(i + 1) }),
           type: "text",
-          updateFn: trimMenuItem,
           defaultValue: "",
           placeholder: l10n("FIELD_ITEM", { value: String(i + 1) }),
           conditions: [
@@ -83,7 +76,6 @@ const fields = [].concat(
           key: `option${i + 1}`,
           label: l10n("FIELD_SET_TO_VALUE_IF", { value: "0" }),
           type: "text",
-          updateFn: trimMenuItem,
           defaultValue: "",
           placeholder: l10n("FIELD_ITEM", { value: String(i + 1) }),
           conditions: [


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Menu events don't have a preview like the dialogue events do. Also, menu items are limited to 6 characters.

* **What is the new behavior (if this is a feature change)?**

Menu events now have a preview when selected. The character limit has been removed as the preview displays (more or less) when the menu will look broken in-game.

"more or less" because the preview doesn't take into account if the game runs on DMG or not and the tile limit for text is different based on that so, in some cases, the preview and the game will not match as the text will overflow in-game but not on the preview. Like the `8` in the following example.

![image](https://user-images.githubusercontent.com/54246642/131232156-1335194e-95c0-4385-ab82-8fd9f6c635ac.png)

@chrismaltby not sure what's the best course of action here, we could keep the character limit per item but extend it to a text line in monospaced font (16 characters IIRC) but this won't be very useful once non-monospaced fonts are used (see `Other Information` below).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I also added support for font changes in menus, but not the autocomplete functionality that dialogues have as it seems like something that will require some substantial refactor to be able to be reused. 

<img width="605" alt="image" src="https://user-images.githubusercontent.com/54246642/131232234-09d532b2-79f6-4e45-90d0-e8701e00b246.png">
