### PR TITLE
[v2beta] Fixing various problems with map panning/zooming

### DIFF
--- a/src/components/world/Scene.js
+++ b/src/components/world/Scene.js
@@ -18,6 +18,7 @@ import { assetFilename } from "../../lib/helpers/gbstudio";
 import SceneCursor from "./SceneCursor";
 import ColorizedImage from "./ColorizedImage";
 import {
+  MIDDLE_MOUSE,
   TOOL_COLORS,
   TOOL_COLLISIONS,
   TOOL_ERASER,
@@ -90,12 +91,14 @@ class Scene extends Component {
 
   onStartDrag = (e) => {
     const { id, selectScene } = this.props;
-    this.lastPageX = e.pageX;
-    this.lastPageY = e.pageY;
-
-    selectScene({ sceneId: id });
-
-    this.dragging = true;
+    if (e.nativeEvent.which !== MIDDLE_MOUSE) {
+      this.lastPageX = e.pageX;
+      this.lastPageY = e.pageY;
+  
+      selectScene({ sceneId: id });
+  
+      this.dragging = true;
+    }
   };
 
   onMoveDrag = (e) => {

--- a/src/components/world/SceneCursor.js
+++ b/src/components/world/SceneCursor.js
@@ -9,7 +9,7 @@ import settingsActions from "../../store/features/settings/settingsActions";
 import entitiesActions from "../../store/features/entities/entitiesActions";
 
 import { SceneShape, VariableShape } from "../../store/stateShape";
-import { TOOL_COLORS, TOOL_COLLISIONS, TOOL_ERASER, TOOL_TRIGGERS, TOOL_ACTORS, BRUSH_FILL, BRUSH_16PX, TOOL_SELECT, COLLISION_ALL, TILE_PROPS } from "../../consts";
+import { MIDDLE_MOUSE, TOOL_COLORS, TOOL_COLLISIONS, TOOL_ERASER, TOOL_TRIGGERS, TOOL_ACTORS, BRUSH_FILL, BRUSH_16PX, TOOL_SELECT, COLLISION_ALL, TILE_PROPS } from "../../consts";
 
 class SceneCursor extends Component {
   constructor() {
@@ -90,6 +90,8 @@ class SceneCursor extends Component {
       hoverPalette,
       setSelectedPalette,
     } = this.props;
+    
+    if (e.nativeEvent.which === MIDDLE_MOUSE) return; // Do nothing on middle click
 
     this.lockX = undefined;
     this.lockY = undefined;

--- a/src/components/world/World.js
+++ b/src/components/world/World.js
@@ -82,8 +82,9 @@ class World extends Component {
     if (scroll && loaded && !prevProps.loaded) {
       scroll.scrollTo(scrollX, scrollY);
     }
-
-    if(onlyMatchingScene && (onlyMatchingScene !== prevProps.onlyMatchingScene)) {
+    
+    const sceneMatchesPrevious = !!(onlyMatchingScene !== null && prevProps.onlyMatchingScene !== null && onlyMatchingScene.id === prevProps.onlyMatchingScene.id);
+    if(onlyMatchingScene && !sceneMatchesPrevious) {
       const view = this.scrollRef.current;
       const viewContents = this.scrollContentsRef.current;
       const halfViewWidth = 0.5 * view.clientWidth;
@@ -94,7 +95,7 @@ class World extends Component {
       view.scroll({
         top: newScrollY,
         left: newScrollX
-      });      
+      });
     }
   }
 
@@ -208,6 +209,7 @@ class World extends Component {
   startWorldDragIfAltOrMiddleClick = e => {
     if (e.altKey || e.nativeEvent.which === MIDDLE_MOUSE) {
       this.worldDragging = true;
+      e.preventDefault();
       e.stopPropagation();
     }
   };

--- a/src/components/world/World.js
+++ b/src/components/world/World.js
@@ -33,8 +33,8 @@ class World extends Component {
     window.addEventListener("paste", this.onPaste);
     window.addEventListener("keydown", this.onKeyDown);
     window.addEventListener("mouseup", this.onMouseUp);
-    window.addEventListener("mousewheel", this.onMouseWheel, { passive: false });
     window.addEventListener("resize", this.onWindowResize);
+    this.scrollRef.current.addEventListener("mousewheel", this.onMouseWheel, { passive: false });
 
     const viewContents = this.scrollContentsRef.current;
     // Set zoom ratio on component mount incase it wasn't at 100%
@@ -105,7 +105,7 @@ class World extends Component {
     window.removeEventListener("keydown", this.onKeyDown);
     window.removeEventListener("click", this.onClick);
     window.removeEventListener("mouseup", this.onMouseUp);
-    window.removeEventListener("mousewheel", this.onMouseWheel);
+    this.scrollRef.current.removeEventListener("mousewheel", this.onMouseWheel);
   }
 
   onCopy = e => {
@@ -184,7 +184,9 @@ class World extends Component {
 
   onMouseWheel = e => {
     const { zoomIn, zoomOut } = this.props;
-    if (e.ctrlKey && !this.blockWheelZoom) {
+    // Only check ctrlKey on MacOS, as touch pad is more versitile for scrolling
+    const keyCheck = process.platform === 'darwin'? e.ctrlKey : true;
+    if (keyCheck && !this.blockWheelZoom) {
       e.preventDefault();
       if (e.wheelDelta > 0) {
         zoomIn({section: "world", delta: e.deltaY * 0.5});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

   - Bug fix: If you have a scene in the left sidebar selected, every time a scene updates in any way, the scene is panned to, centering it. This includes making a change to palettes and collisions of the scene. This made painting these basically impossible if your scene was larger than your view window.
   - Bug fix: Additionally, the middle mouse panning was broken on windows platforms (at least) as middle mouse by default puts the page into a mode where it scrolls towards your cursor, which was actively fighting the panning mechanic. This default is now prevented.
   - Bug fix: Scenes no longer accidentally move when panning with the middle mouse.
   - Bug fix: Fixes a bug where scrolling the wheel on the side bars would try and zoom the main window. 
   - Feature: Makes scroll-to-zoom the default behavior (no ctrl key) on non-Mac platforms.


* **What is the current behavior?** (You can also link to an open issue here)

   - The auto-panning bug was introduced in f01a3a4a2c642


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

   - There's no breaking change, unless you count not having to hold control to zoom (on Windows/Linux) such a change.


* **Other information**:
