### PR TITLE
Pass values to custom scripts as arguments

### DIFF
--- a/src/components/script/ScriptEventForm.tsx
+++ b/src/components/script/ScriptEventForm.tsx
@@ -56,9 +56,16 @@ const getScriptEventFields = (
       Object.values(customEvent?.variables || []).map((v) => {
         return {
           label: `${v?.name || ""}`,
-          defaultValue: "LAST_VARIABLE",
           key: `$variable[${v?.id || ""}]$`,
-          type: "variable",
+          type: "union",
+          types: ["number", "variable"],
+          defaultType: "variable",
+          min: 0,
+          max: 255,
+          defaultValue: {
+            number: 0,
+            variable: "LAST_VARIABLE",
+          },
         };
       }) || [];
     const usedActors =


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Custom Script only allow for Variables to be used as arguments when being called.  

* **What is the new behavior (if this is a feature change)?**

When calling a custom Scripts that has Variable arguments, the fields for those now allow to select `number` or `variable` as an option.

<img width="303" alt="image" src="https://user-images.githubusercontent.com/54246642/137209771-38b18c59-19f8-464f-bf1c-30984d7b1a35.png">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. The case where the argument is a variable and not an union (which will happen in old instances of the custom script events) is still covered in the `callScript` method (kind of forced by typescript as the actor parameters still come as a string in that case). 
  
* **Other information**:

I wonder if we should rename the `Variable A...J` parameters inside the custom script to `Number A...J`? As it might become a bit confusing?