### PR TITLE
[V2 Beta] Fix compileEngineFields()

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -669,7 +669,7 @@ export const compileEngineFields = (engineFields, engineFieldValues, header) => 
       const prop = engineFieldValues.find((p) => p.id === engineField.key);
       const customValue = prop && prop.value;
       const value = customValue !== undefined ? Number(customValue) : Number(engineField.defaultValue);
-      fieldDef += `${header ? "extern " : ""}${engineField.cType} ${engineField.key}${!header && value ? ` = ${value}` : ""};\n`
+      fieldDef += `${header ? "extern " : ""}${engineField.cType} ${engineField.key}${!header && value !== undefined ? ` = ${value}` : ""};\n`
     }
     fieldDef += `${header ? "extern " : ""}UBYTE *engine_fields_addr${!header ? ` = &${engineFields[0].key}` : ""};\n`
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed an error where engine fields with a value of 0 would not initialise properly, resulting in issues on real hardware and other emulators.


* **What is the current behavior?** (You can also link to an open issue here)
Any engine field with a value of 0 may cause issues/glitches in real hardware or other emulators. Since fields with a value of 0 were left uninitialised, it was up to the emulator to set their values. With the built-in emulator in GB Studio, values are initialised to 0, and thus there are no problems, but in other emulators or real hardware, the values can and will be randomised, and thus, produce issues. This can be seen with "Fade to white" under the "Fade style" field, or with custom fields using a modified engine.json file.


* **What is the new behavior (if this is a feature change)?**
Issue is fixed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
Seems to be fixed in GB Studio 3.