### PR TITLE
Fix small keyboard issues with tracker

### DIFF
--- a/src/components/music/SongEditorToolsPanel.tsx
+++ b/src/components/music/SongEditorToolsPanel.tsx
@@ -9,7 +9,6 @@ import {
   PencilIcon,
   EraserIcon,
   TrackerIcon,
-  SelectionIcon,
   PianoIcon,
   PianoInverseIcon,
 } from "ui/icons/Icons";
@@ -52,7 +51,6 @@ const FloatingPanelTools = styled(FloatingPanel)`
 
 const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
   const dispatch = useDispatch();
-  const projectRoot = useSelector((state: RootState) => state.document.root);
 
   const play = useSelector((state: RootState) => state.tracker.playing);
   const playerReady = useSelector(
@@ -130,7 +128,7 @@ const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
       if (e.target && (e.target as Node).nodeName === "INPUT") {
         return;
       }
-      if (e.ctrlKey || e.shiftKey || e.metaKey) {
+      if (!e.ctrlKey) {
         return;
       }
       if (e.code === "Digit1") {

--- a/src/components/music/SongEditorToolsPanel.tsx
+++ b/src/components/music/SongEditorToolsPanel.tsx
@@ -9,6 +9,7 @@ import {
   PencilIcon,
   EraserIcon,
   TrackerIcon,
+  SelectionIcon,
   PianoIcon,
   PianoInverseIcon,
 } from "ui/icons/Icons";
@@ -51,6 +52,7 @@ const FloatingPanelTools = styled(FloatingPanel)`
 
 const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
   const dispatch = useDispatch();
+  const projectRoot = useSelector((state: RootState) => state.document.root);
 
   const play = useSelector((state: RootState) => state.tracker.playing);
   const playerReady = useSelector(
@@ -128,7 +130,7 @@ const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
       if (e.target && (e.target as Node).nodeName === "INPUT") {
         return;
       }
-      if (!e.ctrlKey) {
+      if (e.ctrlKey || e.shiftKey || e.metaKey) {
         return;
       }
       if (e.code === "Digit1") {

--- a/src/components/music/SongTracker.tsx
+++ b/src/components/music/SongTracker.tsx
@@ -166,9 +166,9 @@ export const SongTracker = ({
         editPatternCell("note")(
           value === null ? null : value + octaveOffset * 12
         );
-        editPatternCell("instrument")(defaultInstrument);
 
         if (value !== null) {
+          editPatternCell("instrument")(defaultInstrument);
           setSelectedCell(selectedCell + ROW_SIZE * editStep);
         }
       };
@@ -345,7 +345,15 @@ export const SongTracker = ({
           editEffectParamCell(null);
       }
     },
-    [dispatch, editStep, octaveOffset, patternId, selectedCell]
+    [
+      defaultInstruments,
+      dispatch,
+      editStep,
+      octaveOffset,
+      patternId,
+      selectedCell,
+      song,
+    ]
   );
 
   const handleKeysUp = useCallback(

--- a/src/components/music/SongTracker.tsx
+++ b/src/components/music/SongTracker.tsx
@@ -291,6 +291,10 @@ export const SongTracker = ({
         if (e.code === "Delete" || e.code === "Backspace") editNoteCell(null);
       }
       if ((selectedCell - 1) % 4 === 0) {
+        if (e.ctrlKey) {
+          return;
+        }
+
         if (e.key === "0") editInstrumentCell(0);
         if (e.key === "1") editInstrumentCell(1);
         if (e.key === "2") editInstrumentCell(2);
@@ -305,6 +309,10 @@ export const SongTracker = ({
           editInstrumentCell(null);
       }
       if ((selectedCell - 2) % 4 === 0) {
+        if (e.ctrlKey) {
+          return;
+        }
+
         if (e.key === "0") editEffectCodeCell(0);
         if (e.key === "1") editEffectCodeCell(1);
         if (e.key === "2") editEffectCodeCell(2);
@@ -325,6 +333,10 @@ export const SongTracker = ({
           editEffectCodeCell(null);
       }
       if ((selectedCell - 3) % 4 === 0) {
+        if (e.ctrlKey) {
+          return;
+        }
+
         if (e.key === "0") editEffectParamCell(0);
         if (e.key === "1") editEffectParamCell(1);
         if (e.key === "2") editEffectParamCell(2);

--- a/src/components/music/SongTracker.tsx
+++ b/src/components/music/SongTracker.tsx
@@ -291,10 +291,6 @@ export const SongTracker = ({
         if (e.code === "Delete" || e.code === "Backspace") editNoteCell(null);
       }
       if ((selectedCell - 1) % 4 === 0) {
-        if (e.ctrlKey) {
-          return;
-        }
-
         if (e.key === "0") editInstrumentCell(0);
         if (e.key === "1") editInstrumentCell(1);
         if (e.key === "2") editInstrumentCell(2);
@@ -309,10 +305,6 @@ export const SongTracker = ({
           editInstrumentCell(null);
       }
       if ((selectedCell - 2) % 4 === 0) {
-        if (e.ctrlKey) {
-          return;
-        }
-
         if (e.key === "0") editEffectCodeCell(0);
         if (e.key === "1") editEffectCodeCell(1);
         if (e.key === "2") editEffectCodeCell(2);
@@ -333,10 +325,6 @@ export const SongTracker = ({
           editEffectCodeCell(null);
       }
       if ((selectedCell - 3) % 4 === 0) {
-        if (e.ctrlKey) {
-          return;
-        }
-
         if (e.key === "0") editEffectParamCell(0);
         if (e.key === "1") editEffectParamCell(1);
         if (e.key === "2") editEffectParamCell(2);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improvement/fix

* **What is the current behavior?** (You can also link to an open issue here)

~~- When pressing a numeric key in the tracker view the default instrument is changed, this interferes with the input of instrument and effect values in the tracker view.~~
- Default instrument is added to the tracker cell even when the note is being remove (backspace in the note field).
 
* **What is the new behavior (if this is a feature change)?**

~~- Changed default instrument selection to use ctrl+numeric key to avoid collision with the tracker numeric inputs~~
- Avoid adding default instrument when removing the note

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
~~An alternative for ctrl+numeric key would be to detect if the focus is in the tracker grid and don't change the instrument but I think it'll defeat the purpose of the keyboard shortcut as it's useful to be able to change default instrument without leaving the focus on the grid~~