### PR TITLE
Remove README line about outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,5 @@ Pull the latest code and run make:cli again, yarn link is only needed for the fi
 
 ## Documentation
 
-Documentation is not yet available for version 3.0, for previous builds refer to the following:
-
 [GB Studio Documentation](https://www.gbstudio.dev/docs)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **Other information**: 

3.0 documentation is out and (imo) appropriately complete for the new version. This disclaimer isn't needed anymore.

