### PR TITLE
Fix compile error when clamp used in math event

### DIFF
--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -2961,12 +2961,12 @@ class ScriptBuilder {
       if (operation === ".ADD") {
         this._stackPushConst(256);
         this._if(".GTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 255);
+        this._setConst(".ARG0", 255);
         this._label(clampLabel);
       } else if (operation === ".SUB") {
         this._stackPushConst(0);
         this._if(".LTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 0);
+        this._setConst(".ARG0", 0);
         this._label(clampLabel);
       }
     }
@@ -2995,12 +2995,12 @@ class ScriptBuilder {
       if (operation === ".ADD") {
         this._stackPushConst(256);
         this._if(".GTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 255);
+        this._setConst(".ARG0", 255);
         this._label(clampLabel);
       } else if (operation === ".SUB") {
         this._stackPushConst(0);
         this._if(".LTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 0);
+        this._setConst(".ARG0", 0);
         this._label(clampLabel);
       }
     }
@@ -3033,12 +3033,12 @@ class ScriptBuilder {
       if (operation === ".ADD") {
         this._stackPushConst(256);
         this._if(".GTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 255);
+        this._setConst(".ARG0", 255);
         this._label(clampLabel);
       } else if (operation === ".SUB") {
         this._stackPushConst(0);
         this._if(".LTE", ".ARG0", ".ARG1", clampLabel, 1);
-        this._setConst("ARG0", 0);
+        this._setConst(".ARG0", 0);
         this._label(clampLabel);
       }
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

When clamp is used in math event the compiler fails with error ```?ASlink-Warning-Undefined Global 'ARG0' referenced by module ''
1```


* **What is the new behavior (if this is a feature change)?**

Not failing :)



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
