### PR TITLE
Retry when saving uge songs

### DIFF
--- a/src/lib/helpers/fs/writeFileWithBackup.js
+++ b/src/lib/helpers/fs/writeFileWithBackup.js
@@ -31,7 +31,11 @@ export const writeFileWithBackup = (path, data, options, callback) => {
         if (writeError) {
           return callback(writeError);
         }
-        renameSync(`${path}.new`, path);
+        try {
+          renameSync(`${path}.new`, path);
+        } catch (renameError) {
+          return callback(renameError);
+        }
         return callback();
       }
     );


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

GB Studio will crash when saving .uge files if those are blocked by the operating system

* **What is the new behavior (if this is a feature change)?**

Introduce a retry with delay when saving a .uge file

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:

Still needs some more testing and a more grace way to fail when max retries and save is still failing.