### PR TITLE
Fix assets not being watched or live updating from chokidar

### DIFF
--- a/src/lib/project/watchProject.js
+++ b/src/lib/project/watchProject.js
@@ -55,7 +55,7 @@ const watchProject = async (
   };
 
   const spriteWatcher = chokidar
-    .watch([`${spritesRoot}/**/*.png`,`${spritesRoot}/**/*.PNG`], {
+    .watch(`${spritesRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -65,7 +65,7 @@ const watchProject = async (
     .on("unlink", onRemoveSprite);
 
   const backgroundWatcher = chokidar
-    .watch([`${backgroundsRoot}/**/*.png`,`${backgroundsRoot}/**/*.PNG`], {
+    .watch(`${backgroundsRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -75,7 +75,7 @@ const watchProject = async (
     .on("unlink", onRemoveBackground);
 
   const uiWatcher = chokidar
-    .watch([`${uiRoot}/**/*.png`,`${uiRoot}/**/*.PNG`], {
+    .watch(`${uiRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -85,7 +85,7 @@ const watchProject = async (
     .on("unlink", onRemoveUI);
 
   const sgbWatcher = chokidar
-    .watch([`${sgbRoot}/**/*.png`,`${sgbRoot}/**/*.PNG`], {
+    .watch(`${sgbRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -95,8 +95,7 @@ const watchProject = async (
     .on("unlink", onRemoveUI);
 
   const musicWatcher = chokidar
-    .watch([`${musicRoot}/**/*.uge`,`${musicRoot}/**/*.UGE`,
-            `${musicRoot}/**/*.mod`,`${musicRoot}/**/*.MOD`], {
+    .watch(`${musicRoot}/**/*.{uge,UGE,mod,MOD}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish: musicAwaitWriteFinish,
@@ -106,7 +105,7 @@ const watchProject = async (
     .on("unlink", onRemoveMusic);
 
   const fontsWatcher = chokidar
-    .watch([`${fontsRoot}/**/*.png`,`${fontsRoot}/**/*.PNG`], {
+    .watch(`${fontsRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -116,7 +115,7 @@ const watchProject = async (
     .on("unlink", onRemoveFont);
 
   const avatarsWatcher = chokidar
-    .watch([`${avatarsRoot}/**/*.png`,`${avatarsRoot}/**/*.PNG`], {
+    .watch(`${avatarsRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -126,7 +125,7 @@ const watchProject = async (
     .on("unlink", onRemoveAvatar);
 
   const emotesWatcher = chokidar
-    .watch([`${emotesRoot}/**/*.png`,`${emotesRoot}/**/*.PNG`], {
+    .watch(`${emotesRoot}/**/*.{png,PNG}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -146,9 +145,7 @@ const watchProject = async (
     .on("unlink", onChangedEngineSchema);
 
   const pluginsWatcher = chokidar
-    .watch([`${pluginsRoot}/**/*.png`,`${pluginsRoot}/**/*.PNG`,
-            `${pluginsRoot}/**/*.mod`,`${pluginsRoot}/**/*.MOD`,
-            `${pluginsRoot}/**/*.uge`,`${pluginsRoot}/**/*.UGE`], {
+    .watch(`${pluginsRoot}/**/*.{png,PNG,uge,UGE,mod,MOD}`, {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,

--- a/src/lib/project/watchProject.js
+++ b/src/lib/project/watchProject.js
@@ -55,8 +55,7 @@ const watchProject = async (
   };
 
   const spriteWatcher = chokidar
-    .watch(spritesRoot, {
-      ignored: /^.*\.(?!(png|PNG)$)[^.]+$/,
+    .watch([`${spritesRoot}/**/*.png`,`${spritesRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -66,8 +65,7 @@ const watchProject = async (
     .on("unlink", onRemoveSprite);
 
   const backgroundWatcher = chokidar
-    .watch(backgroundsRoot, {
-      ignored: /^.*\.(?!(png|PNG)$)[^.]+$/,
+    .watch([`${backgroundsRoot}/**/*.png`,`${backgroundsRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -77,8 +75,7 @@ const watchProject = async (
     .on("unlink", onRemoveBackground);
 
   const uiWatcher = chokidar
-    .watch(uiRoot, {
-      ignored: /^.*\.(?!png$)[^.]+$/,
+    .watch([`${uiRoot}/**/*.png`,`${uiRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -88,8 +85,7 @@ const watchProject = async (
     .on("unlink", onRemoveUI);
 
   const sgbWatcher = chokidar
-    .watch(sgbRoot, {
-      ignored: /^.*\.(?!png$)[^.]+$/,
+    .watch([`${sgbRoot}/**/*.png`,`${sgbRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -99,8 +95,8 @@ const watchProject = async (
     .on("unlink", onRemoveUI);
 
   const musicWatcher = chokidar
-    .watch(musicRoot, {
-      ignored: /^.*\.(?!(mod|uge|MOD|UGE)$)[^.]+$/,
+    .watch([`${musicRoot}/**/*.uge`,`${musicRoot}/**/*.UGE`,
+            `${musicRoot}/**/*.mod`,`${musicRoot}/**/*.MOD`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish: musicAwaitWriteFinish,
@@ -110,8 +106,7 @@ const watchProject = async (
     .on("unlink", onRemoveMusic);
 
   const fontsWatcher = chokidar
-    .watch(fontsRoot, {
-      ignored: /^.*\.(?!(png|PNG)$)[^.]+$/,
+    .watch([`${fontsRoot}/**/*.png`,`${fontsRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -121,8 +116,7 @@ const watchProject = async (
     .on("unlink", onRemoveFont);
 
   const avatarsWatcher = chokidar
-    .watch(avatarsRoot, {
-      ignored: /^.*\.(?!(png|PNG)$)[^.]+$/,
+    .watch([`${avatarsRoot}/**/*.png`,`${avatarsRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -132,8 +126,7 @@ const watchProject = async (
     .on("unlink", onRemoveAvatar);
 
   const emotesWatcher = chokidar
-    .watch(emotesRoot, {
-      ignored: /^.*\.(?!(png|PNG)$)[^.]+$/,
+    .watch([`${emotesRoot}/**/*.png`,`${emotesRoot}/**/*.PNG`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,
@@ -153,8 +146,9 @@ const watchProject = async (
     .on("unlink", onChangedEngineSchema);
 
   const pluginsWatcher = chokidar
-    .watch(pluginsRoot, {
-      ignored: /^.*\.(?!(png|mod|uge|PNG|MOD|UGE)$)[^.]+$/,
+    .watch([`${pluginsRoot}/**/*.png`,`${pluginsRoot}/**/*.PNG`,
+            `${pluginsRoot}/**/*.mod`,`${pluginsRoot}/**/*.MOD`,
+            `${pluginsRoot}/**/*.uge`,`${pluginsRoot}/**/*.UGE`], {
       ignoreInitial: true,
       persistent: true,
       awaitWriteFinish,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix!


* **What is the current behavior?** (You can also link to an open issue here)
Assets added after project launch are not watched or updated, 
My best guess, chokidar watch latest update made the regular expressions exclude folders from the watch path?


* **What is the new behavior (if this is a feature change)?**
Use globs instead of regular expression for file type
Using path/**/.uge to search all subfolders with exact extension.
Tested on windows in live development build

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
uiRoot and sgbRoot now have lower and upper case png indexed, where previously only lowercase.
Was this to avoid a bug with uppercase PNG?

Plugins may not need Add directories anymore? leaving them in for now, better to over index than under?

* **Other information**:
What a bug! Big rabbit hole.

Reload assets only refreshes file timestamp, so if chokidar fails again, this button won't help.


