### PR TITLE
Properly detect grouped property fields for events inside custom scripts

### DIFF
--- a/src/lib/helpers/eventSystem.js
+++ b/src/lib/helpers/eventSystem.js
@@ -482,7 +482,7 @@ const isPropertyField = (cmd, fieldName, args) => {
   const events = require("../events").default;
   const event = events[cmd];
   if (!event) return false;
-  const field = event.fields.find((f) => f.key === fieldName);
+  const field = getField(cmd, fieldName, args);
   const fieldValue = args[fieldName];
   return (
     field &&


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When event fields where inside a group of fields (ie: `x` and `y` in `Move Actor To`) the property fields weren't not being properly detected inside custom scripts and the actor associated to the property wasn't being added to the parameters list.

* **What is the new behavior (if this is a feature change)?**

The `isPropertyField` function looks recursively for the field if there's a field group in the event.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
