### PR TITLE
Global variables in Custom Scripts

### DIFF
--- a/src/components/script/AddScriptEventMenu.tsx
+++ b/src/components/script/AddScriptEventMenu.tsx
@@ -609,7 +609,7 @@ const AddScriptEventMenu = ({
           data: [
             instanciateScriptEvent(newEvent, {
               defaultActorId: "player",
-              defaultVariableId: scope === "customEvent" ? "0" : "L0",
+              defaultVariableId: scope === "customEvent" ? "V0" : "L0",
               defaultMusicId: String(lastMusicId),
               defaultSceneId: String(lastSceneId),
               defaultSpriteId: String(lastSpriteId),

--- a/src/components/script/ScriptEventForm.tsx
+++ b/src/components/script/ScriptEventForm.tsx
@@ -56,9 +56,16 @@ const getScriptEventFields = (
       Object.values(customEvent?.variables || []).map((v) => {
         return {
           label: `${v?.name || ""}`,
-          defaultValue: "LAST_VARIABLE",
           key: `$variable[${v?.id || ""}]$`,
-          type: "variable",
+          type: "union",
+          types: ["number", "variable"],
+          defaultType: "variable",
+          min: 0,
+          max: 255,
+          defaultValue: {
+            number: 0,
+            variable: "LAST_VARIABLE",
+          },
         };
       }) || [];
     const usedActors =

--- a/src/components/script/ScriptEventFormInput.tsx
+++ b/src/components/script/ScriptEventFormInput.tsx
@@ -143,7 +143,7 @@ const ScriptEventFormInput = ({
               ]
             : undefined;
         if (defaultUnionValue === "LAST_VARIABLE") {
-          replaceValue = editorType === "customEvent" ? "0" : "L0";
+          replaceValue = editorType === "customEvent" ? "V0" : "L0";
         } else if (defaultUnionValue !== undefined) {
           replaceValue = defaultUnionValue;
         }

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -172,7 +172,7 @@ type ScriptBuilderPathFunction = () => void;
 
 type VariablesLookup = { [name: string]: Variable | undefined };
 
-type ScriptArgumentStackItem = 
+type ScriptArgumentStackItem =
   | {
       type: "variable";
       index: number;
@@ -185,7 +185,7 @@ type ScriptArgumentStackItem =
       arg: any;
       value: number;
     };
- 
+
 // - Helpers --------------
 
 const getActorIndex = (actorId: string, scene: ScriptBuilderScene) => {
@@ -231,6 +231,14 @@ export const isVariableLocal = (variable: string) => {
 
 export const isVariableTemp = (variable: string) => {
   return ["T0", "T1"].indexOf(variable) > -1;
+};
+
+export const isVariableCustomEvent = (variable: string) => {
+  return (
+    ["V0", "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9"].indexOf(
+      variable
+    ) > -1
+  );
 };
 
 const toValidLabel = (label: string): string => {
@@ -2666,7 +2674,7 @@ class ScriptBuilder {
       return argLookup[type][value];
     };
 
-    const argStack:ScriptArgumentStackItem[] = [];
+    const argStack: ScriptArgumentStackItem[] = [];
     let referencesLen = 0;
 
     if (variableArgs) {
@@ -2723,7 +2731,9 @@ class ScriptBuilder {
 
       if (type === "variable") {
         if (typeof variableValue !== "string") {
-          throw new Error(`Custom script argument ${variableArg.id} value isn't a string`);
+          throw new Error(
+            `Custom script argument ${variableArg.id} value isn't a string`
+          );
         }
         const variableAlias = this.getVariableAlias(variableValue);
         const arg = registerArg("variable", variableArg.id);
@@ -2758,12 +2768,19 @@ class ScriptBuilder {
           const argValue = e.args[arg];
           // Update variable fields
           if (isVariableField(e.command, arg, e.args)) {
-            if (isUnionVariableValue(argValue) && argValue.value) {
+            if (
+              isUnionVariableValue(argValue) &&
+              argValue.value &&
+              isVariableCustomEvent(argValue.value)
+            ) {
               e.args[arg] = {
                 ...argValue,
                 value: getArg("variable", argValue.value),
               };
-            } else if (typeof argValue === "string") {
+            } else if (
+              typeof argValue === "string" &&
+              isVariableCustomEvent(argValue)
+            ) {
               e.args[arg] = getArg("variable", argValue);
             }
           }

--- a/src/lib/helpers/variables.tsx
+++ b/src/lib/helpers/variables.tsx
@@ -35,8 +35,8 @@ export const namedVariablesByContext = (
   customEvent: CustomEvent | undefined
 ): NamedVariable[] => {
   if (context === "customEvent") {
-    if (customEvent) {
-      return namedCustomEventVariables(customEvent);
+    if (customEvent && variablesLookup) {
+      return namedCustomEventVariables(customEvent, variablesLookup);
     }
     return [];
   }
@@ -47,17 +47,23 @@ export const namedVariablesByContext = (
 };
 
 export const namedCustomEventVariables = (
-  customEvent: CustomEvent
+  customEvent: CustomEvent,
+  variablesLookup: VariablesLookup
 ): NamedVariable[] => {
-  if (customEvent) {
-    return customEventVariables.map((variable) => ({
-      id: variable,
+  return ([] as NamedVariable[]).concat(
+    customEventVariables.map((variable) => ({
+      id: customEventVariableCode(variable),
       code: customEventVariableCode(variable),
       name: customEventVariableName(variable, customEvent),
-      group: "",
-    }));
-  }
-  return [];
+      group: "Parameters",
+    })),
+    allVariables.map((variable) => ({
+      id: variable,
+      code: globalVariableCode(variable),
+      name: globalVariableName(variable, variablesLookup),
+      group: "Global",
+    }))
+  );
 };
 
 export const namedEntityVariables = (

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -64,6 +64,7 @@ import {
 } from "./entitiesHelpers";
 import { clone } from "lib/helpers/clone";
 import spriteActions from "../sprite/spriteActions";
+import { isVariableCustomEvent } from "lib/compiler/scriptBuilder";
 
 const MIN_SCENE_X = 60;
 const MIN_SCENE_Y = 30;
@@ -2069,7 +2070,7 @@ const refreshCustomEventArgs: CaseReducer<
         if (isVariableField(scriptEvent.command, arg, args)) {
           const addVariable = (variable: string) => {
             const letter = String.fromCharCode(
-              "A".charCodeAt(0) + parseInt(variable)
+              "A".charCodeAt(0) + parseInt(variable[1])
             );
             variables[variable] = {
               id: variable,
@@ -2077,9 +2078,16 @@ const refreshCustomEventArgs: CaseReducer<
             };
           };
           const variable = args[arg];
-          if (isUnionVariableValue(variable) && variable.value) {
+          if (
+            isUnionVariableValue(variable) &&
+            variable.value &&
+            isVariableCustomEvent(variable.value)
+          ) {
             addVariable(variable.value);
-          } else if (typeof variable === "string") {
+          } else if (
+            typeof variable === "string" &&
+            isVariableCustomEvent(variable)
+          ) {
             addVariable(variable);
           }
         }
@@ -2114,9 +2122,10 @@ const refreshCustomEventArgs: CaseReducer<
               const letter = String.fromCharCode(
                 "A".charCodeAt(0) + parseInt(variable, 10)
               ).toUpperCase();
-              variables[variable] = {
-                id: variable,
-                name: oldVariables[variable]?.name || `Variable ${letter}`,
+              const variableId = `V${variable}`;
+              variables[variableId] = {
+                id: variableId,
+                name: oldVariables[variableId]?.name || `Variable ${letter}`,
               };
             });
           }


### PR DESCRIPTION
**DRAFT** need to do some further checks and fix the tests and add migration.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Global variables can't be used inside custom scripts, limiting their use cases. 

* **What is the new behavior (if this is a feature change)?**

Global variables now appear in the variable selector inside Custom Scripts.

![custom_script_global_vars](https://user-images.githubusercontent.com/54246642/147393031-2522a3a7-5bbe-48b8-a6c4-789b20d8b48b.gif)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Hopefully not. But it requires a migration script, as now the "parameter" variables use `Vn` as the id as opposed to just `n` to differentiate them from the global variables. 

* **Other information**:

This draft is built on top of #818 which should be much safer to merge before this one. 