### PR TITLE
Fix blurry emulator on Desktop Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fixed blurry emulator when running web export on desktop Safari [@pau-tomas](https://github.com/pau-tomas)
+
 ## [3.0.2]
 
 ### Added

--- a/appData/wasm/binjgb/js/script.js
+++ b/appData/wasm/binjgb/js/script.js
@@ -1054,10 +1054,10 @@ Audio.ctx = new AudioContext();
 class Video {
   constructor(module, e, el) {
     this.module = module;
-    // iPhone Safari doesn't upscale using image-rendering: pixelated on webgl
-    // canvases. See https://bugs.webkit.org/show_bug.cgi?id=193895.
+    // Both iPhone and Desktop Safari dont't upscale using image-rendering: pixelated
+    // on webgl canvases. See https://bugs.webkit.org/show_bug.cgi?id=193895.
     // For now, default to Canvas2D.
-    if (window.navigator.userAgent.match(/iPhone|iPad/)) {
+    if (window.navigator.userAgent.match(/iPhone|iPad|15.[0-9] Safari/)) {
       this.renderer = new Canvas2DRenderer(el);
     } else {
       try {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Reported on discord. Emulator appears blurry on Desktop Safari.

<img src="https://user-images.githubusercontent.com/54246642/147883173-ca3021a7-ce88-41bc-8a4e-4d9da6f3ee62.png" width=300/>
 
This is due to https://bugs.webkit.org/show_bug.cgi?id=193895

* **What is the new behavior (if this is a feature change)?**

Use Canvas2DRenderer on Safari Desktop until is fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

The user agent detection is a bit narrow (detecting only Safari 15.0 to 15.9) but hopefully the bug will be fixed soon 🤷 