### PR TITLE
Fix bugs with custom scripts and math expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed blurry emulator when running web export on desktop Safari [@pau-tomas](https://github.com/pau-tomas)
 - Fix issue where replacing trigger OnLeave script would replace OnEnter [@pau-tomas](https://github.com/pau-tomas)
+- Fix issue replacing math expresion variables in custom events [@pau-tomas](https://github.com/pau-tomas)
 
 ## [3.0.2]
 

--- a/src/components/ui/form/MathTextarea.tsx
+++ b/src/components/ui/form/MathTextarea.tsx
@@ -12,6 +12,8 @@ import { RelativePortal } from "../layout/RelativePortal";
 import { SelectMenu, selectMenuStyleProps } from "./Select";
 import { VariableSelect } from "../../forms/VariableSelect";
 import l10n from "lib/helpers/l10n";
+import { useSelector } from "react-redux";
+import { RootState } from "store/configureStore";
 
 const varRegex = /\$([VLT0-9][0-9]*)\$/g;
 
@@ -297,6 +299,7 @@ export const MathTextarea: FC<MathTextareaProps> = ({
   placeholder,
 }) => {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const editorType = useSelector((state: RootState) => state.editor.type);
   const [variablesLookup, setVariablesLookup] = useState<
     Dictionary<NamedVariable>
   >({});
@@ -346,9 +349,15 @@ export const MathTextarea: FC<MathTextareaProps> = ({
                   const newValue = value.replace(varRegex, (match) => {
                     if (matches === editMode.index) {
                       matches++;
-                      return editMode.type === "var"
-                        ? `$${newId.padStart(2, "0")}$`
-                        : `#${newId.padStart(2, "0")}#`;
+                      if (editorType !== "customEvent") {
+                        return editMode.type === "var"
+                          ? `$${newId.padStart(2, "0")}$`
+                          : `#${newId.padStart(2, "0")}#`;
+                      } else {
+                        return editMode.type === "var"
+                          ? `$V${newId}$`
+                          : `#V${newId}#`;
+                      }
                     }
                     matches++;
                     return match;

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -579,8 +579,8 @@ class ScriptBuilder {
         if (token.type === "VAL") {
           rpn = rpn.int16(token.value);
         } else if (token.type === "VAR") {
-          const ref = this.getVariableAlias(token.symbol.replace(/\$/g, ""));
-          rpn = rpn.ref(ref);
+          const ref = token.symbol.replace(/\$/g, "");
+          rpn = rpn.refVariable(ref);
         } else if (token.type === "FUN") {
           const op = funToScriptOperator(token.function);
           rpn = rpn.operator(op);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Inside a custom script:

- When clicking in a variable within a math expression textarea and selecting a new one the variable is added as `$00$` which isn't a valid variable inside a custom script and not detected as a parameter (reported as a follow up for #918 )
- Variables within math expressions aren't correctly parsed in codegen leading to unexpected results (tl;dr - codegen isn't using `R_REF_IND` when referencing the arguments inside `VM_RPN`).

* **What is the new behavior (if this is a feature change)?**

Fixed the above bugs

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Hopefully not. I think the RPN change shouldn't break other parts of the codegen. 
