### PR TITLE
[Events] Add missing actor label in eventActorShow.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to use values between -32768 and 32767 in variable events [@Rebusmind](https://github.com/Rebusmind)
 - Added ability to clamp to 8-bit while using multiply
 - Added ability to see where automatic Fade In event will appear in Scene "On Init" script with option to disable or change speed
+- Added missing label in Actor Show event [@ReyAnthony](https://github.com/ReyAnthony)
 
 ### Changed
 

--- a/src/lib/events/eventActorShow.js
+++ b/src/lib/events/eventActorShow.js
@@ -12,6 +12,7 @@ const autoLabel = (fetchArg) => {
 const fields = [
   {
     key: "actorId",
+    label: l10n("ACTOR"),
     type: "actor",
     defaultValue: "$self$",
   },


### PR DESCRIPTION
I was looking at the code to get some understanding of GBVM and noticed eventActorShow was missing a label as opposed to eventActorHide. I just added it back. 