### PR TITLE
Use pattern key when loading/saving uge files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix rendering of garbage when no scene has loaded yet [untoxa](https://github.com/untoxa)
 - Fix overlay hide [untoxa](https://github.com/untoxa)
 - Fix issue where walking events was incorrectly replacing actorIds with $self$
+- Fix issue with saving/loading patterns from UGE files [@pau-tomas](https://github.com/pau-tomas)
 
 ## [3.0.2]
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Version 5 of the uge file format uses unique keys to reference each pattern, those keys aren't consecutive like in previous versions. 

GB Studio is skipping those patterns and using a consecutive id instead meaning that some uge files created with hUGETracker can't be opened with GB Studio because the patterns referenced in the sequence order *by key* have a different id when generated in GBS. #1006  is an example of this.

To make it worst. uge songs saved with GBS have a, related but different bug, where the pattern key is always set to `0`, `1, `2` and `3`... meaning that those files can't be open with hUGETracker because they contain duplicate pattern keys.

In short... a mess. Sorry.

* **What is the new behavior (if this is a feature change)?**

On load. If the file is version 5 the pattern key is read from the file and used as the pattern id. 

On save. A unique id is assigned to the pattern key of each pattern [read other information below to some more context about why not using the original pattern keys].

The fix for on load, breaks compatibility with the uge songs saved with the old (broken) save method. So, on load, detect if the song has duplicate patterns and is version 5, and in that case, default to the previous method (ignoring pattern key) so the song can be loaded properly. The song is fixed the moment it's saved again.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

As far as I can tell, no. 

* **Other information**:

So... why are the uge songs not saved using the pattern keys provided in the original uge file? 

All is due to a design decision from the early days on the tracker, that could be hard to revert as most of the UI is based around it.

In hUGETracker (an in the .uge format) a pattern is a set of 64 notes that can be used in any of the 4 channels. The sequence is made by orders that are a combination of one pattern for each channel. 

So an example of a sequence in uge is as follows

```
Order 0 [0, 1, 2, 3]
Order 1 [4, 5, 6, 7]
Order 2 [0, 1, 2, 3]
Order 3 [18, 5, 22, 3]
```

And the uge format stores all the patterns from 0 to 22, even if they're not used in the song orders.

In GB Studio a pattern is a combination of 4 set of 64 notes (one for each channel). And the song sequence is a list of Patterns. At load time we check for unique combinations of hUGETracker-style patterns and assign them to a GBS-style pattern.

So the example above becomes

```
Pattern 0 = [0, 1, 2, 3]
Pattern 1 = [4, 5, 6, 7]
Pattern 2 = [18, 5, 22, 3]
```

and the sequence

```
[Pattern 0, Pattern 1, Pattern 0, Pattern 3]
```

and any unused hUGETracker-style pattern is discarded (because it doesn't belong to any of the GBS-style patterns).

On save, we loop thru the sequence, and separate each GBS-style pattern into 4 hUGETracker-style patterns and generate the list of orders based on those newly generated patterns and their ids (which aren't related at all with the original ones they have when created in hUGETracker).

The result is a trimmed down .uge file that sounds the same and has the same structure for patterns, orders and sequence but they have different ids and only contains the used patterns. 

