### PR TITLE
Fix crash when plugin event not found

### DIFF
--- a/src/lib/helpers/eventHelpers.ts
+++ b/src/lib/helpers/eventHelpers.ts
@@ -229,7 +229,7 @@ export const calculateAutoFadeEventIdNormalised = (
   const events = require("../events").default;
   let fadeEventId = "";
   const checkEvent = (eventId: string) => (scriptEvent: ScriptEvent) => {
-    if (!fadeEventId && events[scriptEvent.command].waitUntilAfterInitFade) {
+    if (!fadeEventId && events[scriptEvent.command]?.waitUntilAfterInitFade) {
       if (scriptEvent.command === EVENT_FADE_IN) {
         fadeEventId = "MANUAL";
       } else {
@@ -258,7 +258,7 @@ export const calculateAutoFadeEventIdNormalised = (
           if (childEvent?.args?.__comment) {
             return false;
           }
-          if (events[childEvent.command].allowChildrenBeforeInitFade) {
+          if (events[childEvent.command]?.allowChildrenBeforeInitFade) {
             return false;
           }
           return true;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

App crashes when navigating to a script that uses a plugin event that doesn't exist anymore due to the `waitUntilAfterInitFade` and `allowChildrenBeforeInitFade` being check in an undefined object.

* **What is the new behavior (if this is a feature change)?**

Mark the plugin event as optional so it doesn't crash.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
