### PR TITLE
Improve palette select for sprites by using the "real name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to see where automatic Fade In event will appear in Scene "On Init" script with option to disable or change speed
 - Added missing label in Actor Show event [@ReyAnthony](https://github.com/ReyAnthony)
 - Add vertical scrolling in last parallax viewport is Speed=1 [@um3k](https://github.com/um3k)
+- Add palette name to tile palette select based on current preview scene [@ReyAnthony](https://github.com/ReyAnthony)
 
 ### Changed
 

--- a/src/components/forms/PaletteIndexSelect.tsx
+++ b/src/components/forms/PaletteIndexSelect.tsx
@@ -87,7 +87,7 @@ export const PaletteIndexSelect: FC<PaletteIndexSelectProps> = ({
               />
             }
           >
-            {option.palette?.name}
+            {option.label.concat( " ", "(", (option.palette?.name || ""),  ")")}
           </OptionLabelWithPreview>
         );
       }}
@@ -102,7 +102,7 @@ export const PaletteIndexSelect: FC<PaletteIndexSelectProps> = ({
               />
             }
           >
-            {currentValue?.palette?.name}
+            {currentValue?.label.concat( " ", "(", (currentValue?.palette?.name || ""),  ")")}
           </SingleValueWithPreview>
         ),
       }}

--- a/src/components/forms/PaletteIndexSelect.tsx
+++ b/src/components/forms/PaletteIndexSelect.tsx
@@ -87,7 +87,7 @@ export const PaletteIndexSelect: FC<PaletteIndexSelectProps> = ({
               />
             }
           >
-            {option.label}
+            {option.palette?.name}
           </OptionLabelWithPreview>
         );
       }}
@@ -102,7 +102,7 @@ export const PaletteIndexSelect: FC<PaletteIndexSelectProps> = ({
               />
             }
           >
-            {currentValue?.label}
+            {currentValue?.palette?.name}
           </SingleValueWithPreview>
         ),
       }}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
This commit adds a convenience feature to the sprite palette select for sprites by using the "real name" of the palette instead of just "Palette N"

* **What is the current behavior?** (You can also link to an open issue here)
When listing the available palettes for coloring a sprite, it shows a list of "palette N" 

* **What is the new behavior (if this is a feature change)?**
The list now uses the name of the palette (eg : default sprites) 

* **Breaking changes ?**
No, afaik