### PR TITLE
Fallback to current song waveforms in song preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix overlay hide [untoxa](https://github.com/untoxa)
 - Fix issue where walking events was incorrectly replacing actorIds with $self$
 - Fixed issue where changing player sprite mid scene would write over actor tiles (still an issue using "Replace Default Sprite" with a larger than initial)  
+- Fix playing note preview when adding to wave channel [@pau-tomas](https://github.com/pau-tomas)
 
 ## [3.0.2]
 

--- a/src/components/music/helpers/player.js
+++ b/src/components/music/helpers/player.js
@@ -143,7 +143,11 @@ const play = (song) => {
 const preview = (note, type, instrument, square2, waves = []) => {
   console.log(note, instrument, square2);
   const noteFreq = note2freq[note];
-
+  
+  if (waves.length === 0) {
+    waves = current_song.waves;
+  }
+  
   switch (type) {
     case "duty":
       if (!square2) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Wave preview fails because no waveforms are passed to the function

* **What is the new behavior (if this is a feature change)?**

If no waveform are passed to the function use the current song waveforms. The parameter waveforms are only used for previewing from the instrument editor as they might be changed there.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
