### PR TITLE
Fix ActorMoveRelative and ActorSetPositionRelative moving in the wrong direction near top or left side of screen

### DIFF
--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -1720,9 +1720,13 @@ class ScriptBuilder {
       .ref("^/(ACTOR + 1)/")
       .int16(x * 8 * 16)
       .operator(".ADD")
+      .int16(0)
+      .operator(".MAX")
       .ref("^/(ACTOR + 2)/")
       .int16(y * 8 * 16)
       .operator(".ADD")
+      .int16(0)
+      .operator(".MAX")
       .stop();
 
     this._set("^/(ACTOR + 1 - 2)/", ".ARG1");
@@ -1771,9 +1775,13 @@ class ScriptBuilder {
       .ref("^/(ACTOR + 1)/")
       .int16(x * 8 * 16)
       .operator(".ADD")
+      .int16(0)
+      .operator(".MAX")
       .ref("^/(ACTOR + 2)/")
       .int16(y * 8 * 16)
       .operator(".ADD")
+      .int16(0)
+      .operator(".MAX")
       .stop();
 
     this._set("^/(ACTOR + 1 - 2)/", ".ARG1");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
ActorMoveRelative and ActorSetPositionRelative calculate a negative destination when they would move left or up past 0. This would overflow and become a large positive number, resulting in the actor moving right or down, or simply disappearing from the screen.


* **What is the new behavior (if this is a feature change)?**
The calculation results are now clamped to 0, so the actor will stop at the edge of the screen as expected.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't believe so.
