### PR TITLE
Add Emulicious debug support

### DIFF
--- a/buildTools/win32-x64/vscode/Readme Emulicious debugging.txt
+++ b/buildTools/win32-x64/vscode/Readme Emulicious debugging.txt
@@ -1,0 +1,17 @@
+"Enable Emulicious C debugging" will generate debug files for your rom, which you can use to step through code.
+
+Requires emulicious https://emulicious.net/
+vscode https://code.visualstudio.com/
+and the Emulicious Debugger extension https://marketplace.visualstudio.com/items?itemName=emulicious.emulicious-debugger  
+
+in VS Code, Configure emulicious debugger's "extension settings" and set the path, eg "C:\Emulicious\"
+
+Set your temporary folder in gbstudio to a convenient location in the prefrences (or here, since you found this file)
+Rename this folder from vscode to .vscode (you may need to close this file)
+Open this gbstudio temporary folder in vscode, 
+
+Generate a rom via the build or run buttons in gbstudio with "Enable Emulicious C debugging" checked
+
+you can press F5 to launch emulicious with your rom and begin debugging
+Or see other methods of running with emulicious in the extension's decription.
+

--- a/buildTools/win32-x64/vscode/launch.json
+++ b/buildTools/win32-x64/vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "type": "emulicious-debugger",
+            "request": "launch",
+            "name": "Launch in Emulicious",
+            "program": "${workspaceFolder}/_gbsbuild/build/rom/game.gb",
+            "port": 58870,
+            "stopOnEntry": true,
+            "additionalSrcFolders": "${workspaceFolder}/_gbsbuild/src",
+        },
+        {
+            "type": "emulicious-debugger",
+            "name": "Attach to Emulicious",
+            "request": "attach",
+            "port": 58870,
+            "additionalSrcFolders": "${workspaceFolder}/_gbsbuild/src"
+        }
+    ]
+}

--- a/src/components/pages/BuildPage.tsx
+++ b/src/components/pages/BuildPage.tsx
@@ -151,20 +151,18 @@ const BuildPage = () => {
             <Button onClick={onDeleteCache}>
               {l10n("BUILD_EMPTY_BUILD_CACHE")}
             </Button>
-            {process.env.NODE_ENV !== "production" && (
-              <>
-                <FixedSpacer width={10} />
-                <label htmlFor="enableProfile">
-                  <input
-                    id="enableProfile"
-                    type="checkbox"
-                    checked={profile}
-                    onChange={onToggleProfiling}
-                  />{" "}
-                  Enable BGB Profiling
-                </label>
-              </>
-            )}
+            <>
+              <FixedSpacer width={10} />
+              <label htmlFor="enableProfile">
+                <input
+                  id="enableProfile"
+                  type="checkbox"
+                  checked={profile}
+                  onChange={onToggleProfiling}
+                />{" "}
+                Enable Emulicious C debugging 
+              </label>
+            </>
           </>
         )}
 

--- a/src/lib/compiler/buildMakeScript.js
+++ b/src/lib/compiler/buildMakeScript.js
@@ -46,7 +46,7 @@ export default async (
   }
 
   if (profile) {
-    CFLAGS += " -Wf--profile";
+    CFLAGS += " -Wf--debug";
   }
 
   if (targetPlatform === "pocket") {
@@ -242,6 +242,7 @@ export const buildLinkFlags = (
   color = false,
   sgb = false,
   musicDriver = "gbtplayer",
+  profile = false,
   targetPlatform = "gb"
 ) => {
   const validName = name
@@ -270,6 +271,8 @@ export const buildLinkFlags = (
     sgb ? ["-Wm-ys"] : [],
     // Pocket
     targetPlatform === "pocket" ? ["-mgbz80:ap"] : [],
+    // Debug emulicious
+    profile ? ["-Wf--debug", "-Wl-y",] : [],
     // Music Driver
     musicDriver === "huge"
       ? // hugetracker

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -145,6 +145,7 @@ const makeBuild = async ({
     settings.customColorsEnabled,
     settings.sgbEnabled,
     settings.musicDriver,
+    env.profile,
     targetPlatform
   );
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
bgb profiling doesn't work, can not debug with c easily without setting up gbdk and external build tools,

* **What is the new behavior (if this is a feature change)?**
Changes the bgb profile button to instead export c debugging files.
Profile button exposed to regular builds.

Requires Emulicious, VSCode, and Emulicious debugger extension
https://github.com/Calindro/emulicious-debugger 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Regular builds are not changed.


* **Other information**:
Includes an example vscode\launch.json to point emulicious at the rom when you press F5 in vscode.
The folder should be named .vscode, but is ignored by github, have to rename it. Having this json file written could work?

A Readme is included with win64 build tools, only tested on windows 64bit, copy and amend this for macos if it works.
Debug compiler flags should work everywhere, unsure on debugging link for emulicious on other systems.

Extreme thanks to @Calindro for creating Emulicious and putting up with a long delay in publishing this simple pr. 

This should work as is, but any testing, improvements to the workflow, or suggestions on how to set flags would be appreciated. 

