### PR TITLE
Fix `TypeError: warnings is not a function`

### DIFF
--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -137,7 +137,6 @@ export const precompileBackgrounds = async (
   customEventsLookup,
   projectRoot,
   tmpPath,
-  genSymbol,
   { warnings } = {}
 ) => {
   const usedTilemaps = [];


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Compile fails when trying to display a warning when precompiling images

<img width="336" alt="image" src="https://user-images.githubusercontent.com/54246642/156918228-c4150992-7f18-4159-85da-14da7de10d91.png">


* **What is the new behavior (if this is a feature change)?**

Removed an unused parameter to fix the issue

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

N/A