### PR TITLE
Rename constants & variables for consistency

### DIFF
--- a/appData/src/gb/engine.json
+++ b/appData/src/gb/engine.json
@@ -4,7 +4,7 @@
     {
       "key": "INPUT_PLATFORM_JUMP",
       "label": "FIELD_INPUT_JUMP",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "select",
       "options": [
         ["INPUT_A", "A"],
@@ -17,7 +17,7 @@
     {
       "key": "INPUT_PLATFORM_RUN",
       "label": "FIELD_INPUT_RUN",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "select",
       "options": [
         ["INPUT_A", "A"],
@@ -29,7 +29,7 @@
     {
       "key": "INPUT_PLATFORM_INTERACT",
       "label": "FIELD_INPUT_INTERACT",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "select",
       "options": [
         ["INPUT_A", "A"],
@@ -41,9 +41,9 @@
       "defaultValue": "INPUT_A"
     },        
     {
-      "key": "plat_min_vel",
+      "key": "platform_min_vel",
       "label": "FIELD_MIN_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 304,
@@ -51,9 +51,9 @@
       "max": 16384
     },
     {
-      "key": "plat_walk_vel",
+      "key": "platform_walk_vel",
       "label": "FIELD_WALK_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 6400,
@@ -61,9 +61,9 @@
       "max": 16384
     },
     {
-      "key": "plat_run_vel",
+      "key": "platform_run_vel",
       "label": "FIELD_RUN_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 10496,
@@ -71,9 +71,9 @@
       "max": 16384
     },
     {
-      "key": "plat_climb_vel",
+      "key": "platform_climb_vel",
       "label": "FIELD_CLIMB_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 4000,
@@ -81,9 +81,9 @@
       "max": 16384
     },    
     {
-      "key": "plat_walk_acc",
+      "key": "platform_walk_acc",
       "label": "FIELD_WALK_ACC",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 152,
@@ -91,9 +91,9 @@
       "max": 768
     },
     {
-      "key": "plat_run_acc",
+      "key": "platform_run_acc",
       "label": "FIELD_RUN_ACC",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 228,
@@ -101,9 +101,9 @@
       "max": 768
     },
     {
-      "key": "plat_dec",
+      "key": "platform_dec",
       "label": "FIELD_DECELERATION",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 208,
@@ -111,9 +111,9 @@
       "max": 768
     },
     {
-      "key": "plat_jump_vel",
+      "key": "platform_jump_vel",
       "label": "FIELD_JUMP_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 16384,
@@ -121,9 +121,9 @@
       "max": 32768
     },   
     {
-      "key": "plat_grav",
+      "key": "platform_grav",
       "label": "FIELD_GRAVITY",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 1792,
@@ -131,9 +131,9 @@
       "max": 8192
     },   
     {
-      "key": "plat_hold_grav",
+      "key": "platform_hold_grav",
       "label": "FIELD_GRAVITY_JUMP",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 512,
@@ -141,9 +141,9 @@
       "max": 8192
     },       
     {
-      "key": "plat_max_fall_vel",
+      "key": "platform_max_fall_vel",
       "label": "FIELD_MAX_FALL_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 20000,
@@ -151,7 +151,7 @@
       "max": 24560
     },
     {
-      "key": "shooter_scroll_speed",
+      "key": "shmup_scroll_speed",
       "label": "FIELD_SCROLL_SPEED",
       "group": "GAMETYPE_SHMUP",
       "type": "slider",
@@ -163,7 +163,7 @@
     {
       "key": "INPUT_TOPDOWN_INTERACT",
       "label": "FIELD_INPUT_INTERACT",
-      "group": "GAMETYPE_TOP_DOWN",
+      "group": "GAMETYPE_TOPDOWN",
       "type": "select",
       "options": [
         ["INPUT_A", "A"],
@@ -175,7 +175,7 @@
     {
       "key": "topdown_grid",
       "label": "FIELD_GRID_SIZE",
-      "group": "GAMETYPE_TOP_DOWN",
+      "group": "GAMETYPE_TOPDOWN",
       "type": "select",
       "options": [
         [8, "FIELD_GRID_8PX"],

--- a/appData/src/gb/include/states/platform.h
+++ b/appData/src/gb/include/states/platform.h
@@ -6,18 +6,18 @@
 void platform_init();
 void platform_update();
 
-extern WORD pl_vel_x;
-extern WORD pl_vel_y;
-extern WORD plat_min_vel;
-extern WORD plat_walk_vel;
-extern WORD plat_run_vel;
-extern WORD plat_climb_vel;
-extern WORD plat_walk_acc;
-extern WORD plat_run_acc;
-extern WORD plat_dec;
-extern WORD plat_jump_vel;
-extern WORD plat_grav;
-extern WORD plat_hold_grav;
-extern WORD plat_max_fall_vel;
+extern WORD platform_vel_x;
+extern WORD platform_vel_y;
+extern WORD platform_min_vel;
+extern WORD platform_walk_vel;
+extern WORD platform_run_vel;
+extern WORD platform_climb_vel;
+extern WORD platform_walk_acc;
+extern WORD platform_run_acc;
+extern WORD platform_dec;
+extern WORD platform_jump_vel;
+extern WORD platform_grav;
+extern WORD platform_hold_grav;
+extern WORD platform_max_fall_vel;
 
 #endif

--- a/appData/src/gb/include/states/pointnclick.h
+++ b/appData/src/gb/include/states/pointnclick.h
@@ -1,5 +1,5 @@
-#ifndef STATE_POINT_N_CLICK_H
-#define STATE_POINT_N_CLICK_H
+#ifndef STATE_POINTNCLICK_H
+#define STATE_POINTNCLICK_H
 
 #include <gb/gb.h>
 

--- a/appData/src/gb/include/states/topdown.h
+++ b/appData/src/gb/include/states/topdown.h
@@ -1,5 +1,5 @@
-#ifndef STATE_TOP_DOWN_H
-#define STATE_TOP_DOWN_H
+#ifndef STATE_TOPDOWN_H
+#define STATE_TOPDOWN_H
 
 #include <gb/gb.h>
 

--- a/appData/src/gb/src/states/platform.c
+++ b/appData/src/gb/src/states/platform.c
@@ -32,25 +32,25 @@
 
 UBYTE grounded;
 UBYTE on_ladder;
-WORD pl_vel_x;
-WORD pl_vel_y;
-WORD plat_min_vel;
-WORD plat_walk_vel;
-WORD plat_climb_vel;
-WORD plat_run_vel;
-WORD plat_walk_acc;
-WORD plat_run_acc;
-WORD plat_dec;
-WORD plat_jump_vel;
-WORD plat_grav;
-WORD plat_hold_grav;
-WORD plat_max_fall_vel;
+WORD platform_vel_x;
+WORD platform_vel_y;
+WORD platform_min_vel;
+WORD platform_walk_vel;
+WORD platform_climb_vel;
+WORD platform_run_vel;
+WORD platform_walk_acc;
+WORD platform_run_acc;
+WORD platform_dec;
+WORD platform_jump_vel;
+WORD platform_grav;
+WORD platform_hold_grav;
+WORD platform_max_fall_vel;
 
 void platform_init() BANKED {
     UBYTE tile_x, tile_y;
 
-    pl_vel_x = 0;
-    pl_vel_y = plat_grav << 2;
+    platform_vel_x = 0;
+    platform_vel_y = platform_grav << 2;
 
     if (PLAYER.dir == DIR_UP || PLAYER.dir == DIR_DOWN) {
         PLAYER.dir = DIR_RIGHT;
@@ -91,18 +91,18 @@ void platform_update() BANKED {
     if (on_ladder) {
         // PLAYER.pos.x = 0;
         UBYTE tile_x_mid = ((PLAYER.pos.x >> 4) + PLAYER.bounds.left + p_half_width) >> 3; 
-        pl_vel_y = 0;
+        platform_vel_y = 0;
         if (INPUT_UP) {
             // Climb laddder
             UBYTE tile_y = ((PLAYER.pos.y >> 4) + PLAYER.bounds.top + 1) >> 3;
             if (tile_at(tile_x_mid, tile_y) & TILE_PROP_LADDER) {
-                pl_vel_y = -plat_climb_vel;
+                platform_vel_y = -platform_climb_vel;
             }
         } else if (INPUT_DOWN) {
             // Descend ladder
             UBYTE tile_y = ((PLAYER.pos.y >> 4) + PLAYER.bounds.bottom + 1) >> 3;
             if (tile_at(tile_x_mid, tile_y) & TILE_PROP_LADDER) {
-                pl_vel_y = plat_climb_vel;
+                platform_vel_y = platform_climb_vel;
             }
         } else if (INPUT_LEFT) {
             on_ladder = FALSE;
@@ -129,36 +129,36 @@ void platform_update() BANKED {
                 tile_start++;
             }
         }
-        PLAYER.pos.y += (pl_vel_y >> 8);
+        PLAYER.pos.y += (platform_vel_y >> 8);
     } else {
 
         // Horizontal Movement
         if (INPUT_LEFT) {
             if (INPUT_PLATFORM_RUN) {
-                pl_vel_x -= plat_run_acc;
-                pl_vel_x = CLAMP(pl_vel_x, -plat_run_vel, -plat_min_vel);
+                platform_vel_x -= platform_run_acc;
+                platform_vel_x = CLAMP(platform_vel_x, -platform_run_vel, -platform_min_vel);
             } else {
-                pl_vel_x -= plat_walk_acc;
-                pl_vel_x = CLAMP(pl_vel_x, -plat_walk_vel, -plat_min_vel);
+                platform_vel_x -= platform_walk_acc;
+                platform_vel_x = CLAMP(platform_vel_x, -platform_walk_vel, -platform_min_vel);
             } 
         } else if (INPUT_RIGHT) {
             if (INPUT_PLATFORM_RUN) {
-                pl_vel_x += plat_run_acc;
-                pl_vel_x = CLAMP(pl_vel_x, plat_min_vel, plat_run_vel);
+                platform_vel_x += platform_run_acc;
+                platform_vel_x = CLAMP(platform_vel_x, platform_min_vel, platform_run_vel);
             } else {
-                pl_vel_x += plat_walk_acc;
-                pl_vel_x = CLAMP(pl_vel_x, plat_min_vel, plat_walk_vel);
+                platform_vel_x += platform_walk_acc;
+                platform_vel_x = CLAMP(platform_vel_x, platform_min_vel, platform_walk_vel);
             }
         } else if (grounded) {
-            if (pl_vel_x < 0) {
-                pl_vel_x += plat_dec;
-                if (pl_vel_x > 0) {
-                    pl_vel_x = 0;
+            if (platform_vel_x < 0) {
+                platform_vel_x += platform_dec;
+                if (platform_vel_x > 0) {
+                    platform_vel_x = 0;
                 }
-            } else if (pl_vel_x > 0) {
-                pl_vel_x -= plat_dec;
-                if (pl_vel_x < 0) {
-                    pl_vel_x = 0;
+            } else if (platform_vel_x > 0) {
+                platform_vel_x -= platform_dec;
+                if (platform_vel_x < 0) {
+                    platform_vel_x = 0;
                 }
             }
         }
@@ -171,7 +171,7 @@ void platform_update() BANKED {
             if (tile_at(tile_x_mid, tile_y) & TILE_PROP_LADDER) {
                 PLAYER.pos.x = (((tile_x_mid << 3) + 4 - (PLAYER.bounds.left + p_half_width) << 4));
                 on_ladder = TRUE;
-                pl_vel_x = 0;
+                platform_vel_x = 0;
             }
         } else if (INPUT_DOWN) {
             // Grab downwards ladder
@@ -180,39 +180,39 @@ void platform_update() BANKED {
             if (tile_at(tile_x_mid, tile_y) & TILE_PROP_LADDER) {
                 PLAYER.pos.x = (((tile_x_mid << 3) + 4 - (PLAYER.bounds.left + p_half_width) << 4));
                 on_ladder = TRUE;
-                pl_vel_x = 0;
+                platform_vel_x = 0;
             }
         }
 
         // Gravity
-        if (INPUT_PLATFORM_JUMP && pl_vel_y < 0) {
-            pl_vel_y += plat_hold_grav;
+        if (INPUT_PLATFORM_JUMP && platform_vel_y < 0) {
+            platform_vel_y += platform_hold_grav;
         } else {
-            pl_vel_y += plat_grav;
+            platform_vel_y += platform_grav;
         }
 
         // Step X
         tile_start = (((PLAYER.pos.y >> 4) + PLAYER.bounds.top)    >> 3);
         tile_end   = (((PLAYER.pos.y >> 4) + PLAYER.bounds.bottom) >> 3) + 1;
-        if (pl_vel_x > 0) {
-            UWORD new_x = PLAYER.pos.x + (pl_vel_x >> 8);
+        if (platform_vel_x > 0) {
+            UWORD new_x = PLAYER.pos.x + (platform_vel_x >> 8);
             UBYTE tile_x = ((new_x >> 4) + PLAYER.bounds.right) >> 3;
             while (tile_start != tile_end) {
                 if (tile_at(tile_x, tile_start) & COLLISION_LEFT) {
                     new_x = (((tile_x << 3) - PLAYER.bounds.right) << 4) - 1;
-                    pl_vel_x = 0;
+                    platform_vel_x = 0;
                     break;
                 }
                 tile_start++;
             }
             PLAYER.pos.x = MIN((image_width - 16) << 4, new_x);
-        } else if (pl_vel_x < 0) {
-            WORD new_x = PLAYER.pos.x + (pl_vel_x >> 8);
+        } else if (platform_vel_x < 0) {
+            WORD new_x = PLAYER.pos.x + (platform_vel_x >> 8);
             UBYTE tile_x = ((new_x >> 4) + PLAYER.bounds.left) >> 3;
             while (tile_start != tile_end) {
                 if (tile_at(tile_x, tile_start) & COLLISION_RIGHT) {
                     new_x = ((((tile_x + 1) << 3) - PLAYER.bounds.left) << 4) + 1;
-                    pl_vel_x = 0;
+                    platform_vel_x = 0;
                     break;
                 }
                 tile_start++;
@@ -224,26 +224,26 @@ void platform_update() BANKED {
         grounded = FALSE;    
         tile_start = (((PLAYER.pos.x >> 4) + PLAYER.bounds.left)  >> 3);
         tile_end   = (((PLAYER.pos.x >> 4) + PLAYER.bounds.right) >> 3) + 1;
-        if (pl_vel_y > 0) {
-            UWORD new_y = PLAYER.pos.y + (pl_vel_y >> 8);
+        if (platform_vel_y > 0) {
+            UWORD new_y = PLAYER.pos.y + (platform_vel_y >> 8);
             UBYTE tile_y = ((new_y >> 4) + PLAYER.bounds.bottom) >> 3;
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y) & COLLISION_TOP) {
                     new_y = ((((tile_y) << 3) - PLAYER.bounds.bottom) << 4) - 1;
                     grounded = TRUE;
-                    pl_vel_y = 0;
+                    platform_vel_y = 0;
                     break;
                 }
                 tile_start++;
             }
             PLAYER.pos.y = new_y;
-        } else if (pl_vel_y < 0) {
-            UWORD new_y = PLAYER.pos.y + (pl_vel_y >> 8);
+        } else if (platform_vel_y < 0) {
+            UWORD new_y = PLAYER.pos.y + (platform_vel_y >> 8);
             UBYTE tile_y = (((new_y >> 4) + PLAYER.bounds.top) >> 3);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y) & COLLISION_BOTTOM) {
                     new_y = ((((UBYTE)(tile_y + 1) << 3) - PLAYER.bounds.top) << 4) + 1;
-                    pl_vel_y = 0;
+                    platform_vel_y = 0;
                     break;
                 }
                 tile_start++;
@@ -252,7 +252,7 @@ void platform_update() BANKED {
         }
 
         // Clamp Y Velocity
-        pl_vel_y = MIN(pl_vel_y, plat_max_fall_vel);
+        platform_vel_y = MIN(platform_vel_y, platform_max_fall_vel);
     }
 
     UBYTE tile_x_mid = ((PLAYER.pos.x >> 4) + ((PLAYER.bounds.right - PLAYER.bounds.left) >> 2)) >> 3;
@@ -281,20 +281,20 @@ void platform_update() BANKED {
 
     // Jump
     if (INPUT_PRESSED(INPUT_PLATFORM_JUMP) && grounded && can_jump) {
-        pl_vel_y = -plat_jump_vel;
+        platform_vel_y = -platform_jump_vel;
         grounded = FALSE;
     }
 
     // Player animation
     if (on_ladder) {
         actor_set_anim(&PLAYER, ANIM_CLIMB);
-        if (pl_vel_y == 0) {
+        if (platform_vel_y == 0) {
             actor_stop_anim(&PLAYER);
         }
     } else if (grounded) {
-        if (pl_vel_x < 0) {
+        if (platform_vel_x < 0) {
             actor_set_dir(&PLAYER, DIR_LEFT, TRUE);
-        } else if (pl_vel_x > 0) {
+        } else if (platform_vel_x > 0) {
             actor_set_dir(&PLAYER, DIR_RIGHT, TRUE);
         } else {
             actor_set_anim_idle(&PLAYER);

--- a/appData/src/gb/src/states/pointnclick.c
+++ b/appData/src/gb/src/states/pointnclick.c
@@ -11,8 +11,8 @@
 #include "trigger.h"
 #include "vm.h"
 
-#ifndef POINT_N_CLICK_CAMERA_DEADZONE
-#define POINT_N_CLICK_CAMERA_DEADZONE 24
+#ifndef POINTNCLICK_CAMERA_DEADZONE
+#define POINTNCLICK_CAMERA_DEADZONE 24
 #endif
 
 UBYTE last_hit_trigger = MAX_TRIGGERS;
@@ -20,8 +20,8 @@ UBYTE last_hit_trigger = MAX_TRIGGERS;
 void pointnclick_init() BANKED {
     camera_offset_x = 0;
     camera_offset_y = 0;
-    camera_deadzone_x = POINT_N_CLICK_CAMERA_DEADZONE;
-    camera_deadzone_y = POINT_N_CLICK_CAMERA_DEADZONE;
+    camera_deadzone_x = POINTNCLICK_CAMERA_DEADZONE;
+    camera_deadzone_y = POINTNCLICK_CAMERA_DEADZONE;
     PLAYER.dir = DIR_RIGHT;
     actor_set_anim(&PLAYER, ANIM_CURSOR);
 }

--- a/appData/src/gb/src/states/shmup.c
+++ b/appData/src/gb/src/states/shmup.c
@@ -12,14 +12,14 @@
 #include "trigger.h"
 #include "vm.h"
 
-#ifndef SHOOTER_HURT_IFRAMES
-#define SHOOTER_HURT_IFRAMES 10
+#ifndef SHMUP_HURT_IFRAMES
+#define SHMUP_HURT_IFRAMES 10
 #endif
 
-UINT8 shooter_scroll_speed = 16;
-UBYTE shooter_reached_end;
-UWORD shooter_dest;
-direction_e shooter_direction;
+UINT8 shmup_scroll_speed = 16;
+UBYTE shmup_reached_end;
+UWORD shmup_dest;
+direction_e shmup_direction;
 
 void shmup_init() BANKED {
 
@@ -28,27 +28,27 @@ void shmup_init() BANKED {
     camera_deadzone_x = 0;
     camera_deadzone_y = 0;
 
-    shooter_direction = PLAYER.dir;
+    shmup_direction = PLAYER.dir;
 
-    if (shooter_direction == DIR_LEFT) {
+    if (shmup_direction == DIR_LEFT) {
         // Right to left scrolling
         camera_offset_x = 48;
-        shooter_dest = (SCREEN_WIDTH_HALF + 48) << 4;
-    } else if (shooter_direction == DIR_RIGHT) {
+        shmup_dest = (SCREEN_WIDTH_HALF + 48) << 4;
+    } else if (shmup_direction == DIR_RIGHT) {
         // Left to right scrolling
         camera_offset_x = -64;
-        shooter_dest = (image_width - SCREEN_WIDTH_HALF - 64) << 4;
-    } else if (shooter_direction == DIR_UP) {
+        shmup_dest = (image_width - SCREEN_WIDTH_HALF - 64) << 4;
+    } else if (shmup_direction == DIR_UP) {
         // Bottom to top scrolling
         camera_offset_y = 48;
-        shooter_dest = (SCREEN_WIDTH_HALF + 40) << 4;
+        shmup_dest = (SCREEN_WIDTH_HALF + 40) << 4;
     } else {
         // Top to bottom scrolling
         camera_offset_y = -48;
-        shooter_dest = (image_height - SCREEN_WIDTH_HALF - 40) << 4;
+        shmup_dest = (image_height - SCREEN_WIDTH_HALF - 40) << 4;
     }
 
-    shooter_reached_end = FALSE;
+    shmup_reached_end = FALSE;
 }
 
 void shmup_update() BANKED {
@@ -57,7 +57,7 @@ void shmup_update() BANKED {
     direction_e new_dir = DIR_NONE;
     player_moving = FALSE;
 
-    if (IS_DIR_HORIZONTAL(shooter_direction)) {
+    if (IS_DIR_HORIZONTAL(shmup_direction)) {
         if (INPUT_UP) {
             player_moving = TRUE;
             new_dir = DIR_UP;
@@ -65,7 +65,7 @@ void shmup_update() BANKED {
             player_moving = TRUE;
             new_dir = DIR_DOWN;
         } else {
-            new_dir = shooter_direction;
+            new_dir = shmup_direction;
         }
     } else {
         if (INPUT_LEFT) {
@@ -75,7 +75,7 @@ void shmup_update() BANKED {
             player_moving = TRUE;
             new_dir = DIR_RIGHT;
         } else {
-            new_dir = shooter_direction;
+            new_dir = shmup_direction;
         }
     }
 
@@ -92,7 +92,7 @@ void shmup_update() BANKED {
         point_translate_dir(&new_pos, PLAYER.dir, PLAYER.move_speed);
 
         // Check for tile collisions
-        if (IS_DIR_HORIZONTAL(shooter_direction)) {
+        if (IS_DIR_HORIZONTAL(shmup_direction)) {
             // Step Y
             tile_start = (((PLAYER.pos.x >> 4) + PLAYER.bounds.left)  >> 3);
             tile_end   = (((PLAYER.pos.x >> 4) + PLAYER.bounds.right) >> 3) + 1;
@@ -146,22 +146,22 @@ void shmup_update() BANKED {
     }
 
     // Auto scroll background
-    if (!shooter_reached_end) {
-        point_translate_dir(&PLAYER.pos, shooter_direction, shooter_scroll_speed);
+    if (!shmup_reached_end) {
+        point_translate_dir(&PLAYER.pos, shmup_direction, shmup_scroll_speed);
 
         // Check if reached end of screen
-        if ((shooter_direction == DIR_RIGHT) && (PLAYER.pos.x > shooter_dest)) {
-            shooter_reached_end = TRUE;
-            PLAYER.pos.x = shooter_dest;
-        } else if ((shooter_direction == DIR_LEFT) && (PLAYER.pos.x < shooter_dest)) {
-            shooter_reached_end = TRUE;
-            PLAYER.pos.x = shooter_dest;
-        } else if ((shooter_direction == DIR_DOWN) && (PLAYER.pos.y > shooter_dest)) {
-            shooter_reached_end = TRUE;
-            PLAYER.pos.y = shooter_dest;
-        } else if ((shooter_direction == DIR_UP) && (PLAYER.pos.y < shooter_dest)) {
-            shooter_reached_end = TRUE;
-            PLAYER.pos.y = shooter_dest;
+        if ((shmup_direction == DIR_RIGHT) && (PLAYER.pos.x > shmup_dest)) {
+            shmup_reached_end = TRUE;
+            PLAYER.pos.x = shmup_dest;
+        } else if ((shmup_direction == DIR_LEFT) && (PLAYER.pos.x < shmup_dest)) {
+            shmup_reached_end = TRUE;
+            PLAYER.pos.x = shmup_dest;
+        } else if ((shmup_direction == DIR_DOWN) && (PLAYER.pos.y > shmup_dest)) {
+            shmup_reached_end = TRUE;
+            PLAYER.pos.y = shmup_dest;
+        } else if ((shmup_direction == DIR_UP) && (PLAYER.pos.y < shmup_dest)) {
+            shmup_reached_end = TRUE;
+            PLAYER.pos.y = shmup_dest;
         }
     }
 

--- a/src/components/forms/AnimationTypeSelect.tsx
+++ b/src/components/forms/AnimationTypeSelect.tsx
@@ -39,13 +39,13 @@ const options: AnimationTypeOptGroup[] = [
     ],
   },
   {
-    label: l10n("GAMETYPE_PLATFORMER"),
+    label: l10n("GAMETYPE_PLATFORM"),
     options: [
-      { label: l10n("FIELD_PLATFORMER_PLAYER"), value: "platform_player" },
+      { label: l10n("FIELD_PLATFORM_PLAYER"), value: "platform_player" },
     ],
   },
   {
-    label: l10n("GAMETYPE_POINT_N_CLICK"),
+    label: l10n("GAMETYPE_POINTNCLICK"),
     options: [{ label: l10n("FIELD_CURSOR"), value: "cursor" }],
   },
 ];

--- a/src/components/forms/SceneTypeSelect.tsx
+++ b/src/components/forms/SceneTypeSelect.tsx
@@ -19,11 +19,11 @@ interface SceneTypeOption {
 }
 
 export const options: SceneTypeOption[] = [
-  { value: "TOPDOWN", label: l10n("GAMETYPE_TOP_DOWN") },
-  { value: "PLATFORM", label: l10n("GAMETYPE_PLATFORMER") },
+  { value: "TOPDOWN", label: l10n("GAMETYPE_TOPDOWN") },
+  { value: "PLATFORM", label: l10n("GAMETYPE_PLATFORM") },
   { value: "ADVENTURE", label: l10n("GAMETYPE_ADVENTURE") },
   { value: "SHMUP", label: l10n("GAMETYPE_SHMUP") },
-  { value: "POINTNCLICK", label: l10n("GAMETYPE_POINT_N_CLICK") },
+  { value: "POINTNCLICK", label: l10n("GAMETYPE_POINTNCLICK") },
   { value: "LOGO", label: l10n("GAMETYPE_LOGO") },
 ];
 

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -573,9 +573,9 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Platformer",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Platformer",
   "GAMETYPE_ADVENTURE": "Adventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click"
+  "GAMETYPE_POINTNCLICK": "Point and Click"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -338,7 +338,7 @@
   "FIELD_MULTI_DIRECTION": "Four Directions",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "Fixed Direction + Movement",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "Four Directions + Movement",
-  "FIELD_PLATFORMER_PLAYER": "Platformer Player",
+  "FIELD_PLATFORM_PLAYER": "Platformer Player",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "Flip 'Right' To Create 'Left' Facing Frames",
   "FIELD_CANVAS_SIZE": "Canvas Size",
   "FIELD_COLLISION_BOUNDING_BOX": "Collision Bounding Box",
@@ -986,11 +986,11 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Platformer",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Platformer",
   "GAMETYPE_ADVENTURE": "Adventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click",
+  "GAMETYPE_POINTNCLICK": "Point and Click",
   "GAMETYPE_LOGO": "Logo",
 
   "// 20": "Compiler -----------------------------------------------------",

--- a/src/lang/fr-FR.json
+++ b/src/lang/fr-FR.json
@@ -322,7 +322,7 @@
   "FIELD_MULTI_DIRECTION": "Quatre Directions",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "Direction fixe + Mouvement",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "Quatre Directions + Mouvement",
-  "FIELD_PLATFORMER_PLAYER": "Joueur Platformer",
+  "FIELD_PLATFORM_PLAYER": "Joueur Platformer",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "Retourner à 'droite' pour créer des images orientées à 'gauche'",
   "FIELD_CANVAS_SIZE": "Taille du cadre",
   "FIELD_COLLISION_BOUNDING_BOX": "Boîte de délimitation des collisions",
@@ -910,11 +910,11 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Platformer",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Platformer",
   "GAMETYPE_ADVENTURE": "Aventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click",
+  "GAMETYPE_POINTNCLICK": "Point and Click",
   "GAMETYPE_LOGO": "Logo",
 
   "// 20": "Compiler -----------------------------------------------------",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -322,7 +322,7 @@
   "FIELD_MULTI_DIRECTION": "Quatre Directions",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "Direction fixe + Mouvement",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "Quatre Directions + Mouvement",
-  "FIELD_PLATFORMER_PLAYER": "Joueur Platformer",
+  "FIELD_PLATFORM_PLAYER": "Joueur Platformer",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "Retourner à 'droite' pour créer des images orientées à 'gauche'",
   "FIELD_CANVAS_SIZE": "Taille du cadre",
   "FIELD_COLLISION_BOUNDING_BOX": "Boîte de délimitation des collisions",
@@ -910,11 +910,11 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Platformer",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Platformer",
   "GAMETYPE_ADVENTURE": "Aventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click",
+  "GAMETYPE_POINTNCLICK": "Point and Click",
   "GAMETYPE_LOGO": "Logo",
 
   "// 20": "Compiler -----------------------------------------------------",

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -334,7 +334,7 @@
   "FIELD_MULTI_DIRECTION": "Cztery kierunki",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "Ustalony kierunek + Ruch",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "Cztery kierunki + Ruch",
-  "FIELD_PLATFORMER_PLAYER": "Gracz platformowy",
+  "FIELD_PLATFORM_PLAYER": "Gracz platformowy",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "Odbij klatki 'Prawej strony', aby stworzyć klatki 'Lewej strony'",
   "FIELD_CANVAS_SIZE": "Rozmiar płótna",
   "FIELD_COLLISION_BOUNDING_BOX": "Ramka ograniczająca kolizję",
@@ -978,11 +978,11 @@
   
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "2D RPG (widok z góry - top down 2D)",
-  "GAMETYPE_PLATFORMER": "Platformówka",
+  "GAMETYPE_TOPDOWN": "2D RPG (widok z góry - top down 2D)",
+  "GAMETYPE_PLATFORM": "Platformówka",
   "GAMETYPE_ADVENTURE": "Przygodówka",
   "GAMETYPE_SHMUP": "Strzelanka (SHMUP)",
-  "GAMETYPE_POINT_N_CLICK": "Wskaż i kliknij (point and click)",
+  "GAMETYPE_POINTNCLICK": "Wskaż i kliknij (point and click)",
   "GAMETYPE_LOGO": "Logo",
   
   "// 20": "Compiler -----------------------------------------------------",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -582,9 +582,9 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Plataforma",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Plataforma",
   "GAMETYPE_ADVENTURE": "Aventura",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Apontar e Clicar"
+  "GAMETYPE_POINTNCLICK": "Apontar e Clicar"
 }

--- a/src/lang/pt-PT.json
+++ b/src/lang/pt-PT.json
@@ -330,7 +330,7 @@
   "FIELD_MULTI_DIRECTION": "Quatro Direcções",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "Direcção Fixa + Movimento",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "Quatro Direcções + Movimento",
-  "FIELD_PLATFORMER_PLAYER": "Jogador de Plataforma",
+  "FIELD_PLATFORM_PLAYER": "Jogador de Plataforma",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "Inverter 'Direita' para criar frames orientados para a 'Esquerda'.",
   "FIELD_CANVAS_SIZE": "Tamanho de Tela",
   "FIELD_COLLISION_BOUNDING_BOX": "Limites de Colisões",
@@ -915,11 +915,11 @@
 
   "// 19 ": "Tipo de Jogo --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "Top Down 2D",
-  "GAMETYPE_PLATFORMER": "Plataformer",
+  "GAMETYPE_TOPDOWN": "Top Down 2D",
+  "GAMETYPE_PLATFORM": "Plataformer",
   "GAMETYPE_ADVENTURE": "Adventure",
   "GAMETYPE_SHMUP": "Shoot Em' Up",
-  "GAMETYPE_POINT_N_CLICK": "Point and Click",
+  "GAMETYPE_POINTNCLICK": "Point and Click",
   "GAMETYPE_LOGO": "Logo",
 
   "// 20": "Compilador -----------------------------------------------------",

--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -333,7 +333,7 @@
   "FIELD_MULTI_DIRECTION": "四个方向",
   "FIELD_FIXED_DIRECTION_MOVEMENT": "固定方向 + 运动",
   "FIELD_MULTI_DIRECTION_MOVEMENT": "四个方向 + 运动",
-  "FIELD_PLATFORMER_PLAYER": "平台游戏玩家",
+  "FIELD_PLATFORM_PLAYER": "平台游戏玩家",
   "FIELD_FLIP_RIGHT_TO_CREATE_LEFT": "翻转“右”以创建“左”面帧",
   "FIELD_CANVAS_SIZE": "画布尺寸",
   "FIELD_COLLISION_BOUNDING_BOX": "碰撞边界框",
@@ -969,11 +969,11 @@
 
   "// 19 ": "Game Type --------------------------------------------------",
 
-  "GAMETYPE_TOP_DOWN": "自上而下的 2D 游戏",
-  "GAMETYPE_PLATFORMER": "平台游戏",
+  "GAMETYPE_TOPDOWN": "自上而下的 2D 游戏",
+  "GAMETYPE_PLATFORM": "平台游戏",
   "GAMETYPE_ADVENTURE": "冒险游戏",
   "GAMETYPE_SHMUP": "射击游戏",
-  "GAMETYPE_POINT_N_CLICK": "指向并单击",
+  "GAMETYPE_POINTNCLICK": "指向并单击",
   "GAMETYPE_LOGO": "标志",
 
   "// 20": "Compiler -----------------------------------------------------",

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -2366,7 +2366,7 @@ extern void __mute_mask_${symbol};
     } else if (height === "high") {
       value = -0x6000;
     }
-    this._setConstMemInt16("pl_vel_y", value);
+    this._setConstMemInt16("platform_vel_y", value);
     this._addNL();
   };
 

--- a/test/data/projects/Test_Eject/assets/engine/engine.json
+++ b/test/data/projects/Test_Eject/assets/engine/engine.json
@@ -4,7 +4,7 @@
     {
       "key": "test_field_1",
       "label": "FIELD_MIN_VEL",
-      "group": "GAMETYPE_PLATFORMER",
+      "group": "GAMETYPE_PLATFORM",
       "type": "slider",
       "cType": "WORD",
       "defaultValue": 304,
@@ -14,7 +14,7 @@
     {
       "key": "test_field_2",
       "label": "FIELD_GRID_SIZE",
-      "group": "GAMETYPE_TOP_DOWN",
+      "group": "GAMETYPE_TOPDOWN",
       "type": "select",
       "options": [
         [8, "FIELD_GRID_8PX"],

--- a/test/store/features/engine/engineMiddleware.test.ts
+++ b/test/store/features/engine/engineMiddleware.test.ts
@@ -44,7 +44,7 @@ test("Should be able to scan ejected engine for new fields", async () => {
       {
         cType: "WORD",
         defaultValue: 304,
-        group: "GAMETYPE_PLATFORMER",
+        group: "GAMETYPE_PLATFORM",
         key: "test_field_1",
         label: "FIELD_MIN_VEL",
         max: 16384,
@@ -54,7 +54,7 @@ test("Should be able to scan ejected engine for new fields", async () => {
       {
         cType: "UBYTE",
         defaultValue: 8,
-        group: "GAMETYPE_TOP_DOWN",
+        group: "GAMETYPE_TOPDOWN",
         key: "test_field_2",
         label: "FIELD_GRID_SIZE",
         options: [


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Several gametype constants and variables were named inconsistently, making the code more difficult to read through or modify. I have renamed these variables and constants to be consistent with the file names of the states (i.e., "shooter" changed to "shmup" to be consistent with "appData/src/gb/src/states/shmup.c").


* **What is the current behavior?** (You can also link to an open issue here)
Several variables and constants are inconsistently named, for instance, "pl_", "plat_", "platform_", "platformer_".


* **What is the new behavior (if this is a feature change)?**
The variables and constants are now consistent with the file name associated with the gametype ("platform_").


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
