### PR TITLE
Projectiles from 224 to 360 degrees now look up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where soft reset could lead to UI tiles over scene tiles [untoxa](https://github.com/untoxa)
 - Fix compiling noise macros for UGE songs [@pau-tomas](https://github.com/pau-tomas)
 - Fix setting music editor preview start position to a different pattern [@pau-tomas](https://github.com/pau-tomas)
+- Fix issue where projectiles launched at >224 degrees would be facing in wrong direction [@john-lay](https://github.com/john-lay)
 
 ### Removed
 

--- a/appData/src/gb/src/core/projectiles.c
+++ b/appData/src/gb/src/core/projectiles.c
@@ -154,7 +154,9 @@ void projectile_launch(UBYTE index, upoint16_t *pos, UBYTE angle) BANKED {
 
         // Set correct projectile frames based on angle
         UBYTE dir = DIR_UP;
-        if (angle > 160 && angle < 224 ) {
+        if (angle > 224) {
+            dir = DIR_UP;
+        } else if (angle > 160) {
             dir = DIR_LEFT;
         } else if (angle > 96) {
             dir = DIR_DOWN;


### PR DESCRIPTION
Bug fix to the `projectiles.c` file. The previous logic missed a scenario where projectiles greater than 224 degrees fell into the `(angle > 96)` condition.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tweak the projectile logic when setting the correct frame based on angle.


* **What is the current behavior?** (You can also link to an open issue here)
Projectiles between 224 and 360 degrees point down.


* **What is the new behavior (if this is a feature change)?**
Projectiles between 224 and 360 degrees point up.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
