### PR TITLE
Add AppImage support for Linux

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -15,6 +15,10 @@ module.exports = {
       platforms: ["darwin", "win32"],
     },
     {
+      name: "@reforged/maker-appimage",
+      config: {},
+    },
+    {
       name: "@electron-forge/maker-deb",
       config: {},
     },

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "6.0.0-beta.57",
+    "@reforged/maker-appimage": "^1.1.3",
     "@electron-forge/maker-deb": "6.0.0-beta.57",
     "@electron-forge/maker-rpm": "6.0.0-beta.57",
     "@electron-forge/maker-squirrel": "6.0.0-beta.57",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds AppImage support when building GB Studio for Linux.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, electron-forge builds .deb and .rpm packages for Linux, which is good for Debian and Red Hat-based distros of Linux, but not so much for other distros such as those based on Arch. While the .deb/.rpm packages can be converted or extracted to work on Arch, it isn't recommended to do so. Additionally, all Linux distros are subject to "dependency hell" due to Linux's insistence on using shared libraries.


* **What is the new behavior (if this is a feature change)?**
Most, if not all, Linux distros are capable of running AppImages, and thus, it would be useful to a broader group of Linux users. Additionally, AppImage bundles all required dependencies into one convenient package, and thus shouldn't suffer from "dependency hell"-related issues in the future. It also isn't as controversial as other software packaging formats such as snap.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
[bTw I UsE ARcH](https://knowyourmeme.com/memes/btw-i-use-arch) ;)