### PR TITLE
Fixes for #1146

### DIFF
--- a/src/components/script/AddScriptEventMenu.tsx
+++ b/src/components/script/AddScriptEventMenu.tsx
@@ -182,9 +182,17 @@ const eventToOption =
     const localisedKey = l10n(event.id); //.replace(/[^:*]*:[ ]*/g, "");
     const name =
       localisedKey !== event.id ? localisedKey : event.name || event.id;
-    const groupName = (("groups" in event && event.groups) || [])
-      .map((key) => l10n(key))
-      .join(" ");
+
+    let eventGroups: string[] = [];
+    if ("groups" in event) {
+      if (Array.isArray(event.groups)) {
+        eventGroups = event.groups;
+      } else if (typeof event.groups === "string") {
+        eventGroups = [event.groups];
+      }
+    }
+
+    const groupName = eventGroups.map((key) => l10n(key)).join(" ");
 
     return {
       label: name,

--- a/src/lib/compiler/compileData.js
+++ b/src/lib/compiler/compileData.js
@@ -946,6 +946,7 @@ export const precompileScenes = (
 
     return {
       ...scene,
+      playerSpriteSheetId: playerSprite.id,
       background,
       actors,
       sprites: sceneSpriteIds.reduce((memo, spriteId) => {

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -2497,11 +2497,11 @@ extern void __mute_mask_${symbol};
   };
 
   actorInvoke = () => {
-    const { scene, scenes } = this.options;
-    const sceneIndex = scenes.indexOf(scene);
-    if (this.actorIndex > 0) {
+    const { scene } = this.options;
+    const actor = scene.actors[this.actorIndex];
+    if (actor && actor.script.length > 0) {
       this._addComment("Invoke Actor Interact Script");
-      this._callFar(`script_s${sceneIndex}a${this.actorIndex - 1}_interact`, 0);
+      this._callFar(`${actor.symbol}_interact`, 0);
     }
   };
 

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -2,7 +2,11 @@ import { inputDec, textSpeedDec } from "./helpers";
 import { decBin, decHex, decOct, hexDec } from "../helpers/8bit";
 import trimlines from "../helpers/trimlines";
 import { is16BitCType } from "../helpers/engineFields";
-import { localVariableName, tempVariableName } from "../helpers/variables";
+import {
+  globalVariableDefaultName,
+  localVariableName,
+  tempVariableName,
+} from "../helpers/variables";
 import {
   ActorDirection,
   CustomEvent,
@@ -3473,7 +3477,7 @@ extern void __mute_mask_${symbol};
     const id = getVariableId(variable, entity);
 
     const namedVariable = variablesLookup[id || "0"];
-    if (namedVariable && namedVariable.symbol) {
+    if (namedVariable && namedVariable.symbol && !isVariableLocal(variable)) {
       const symbol = namedVariable.symbol.toUpperCase();
       variableAliasLookup[id] = symbol;
       return symbol;
@@ -3501,7 +3505,7 @@ extern void __mute_mask_${symbol};
       name = tempVariableName(num);
     } else {
       const num = toVariableNumber(variable || "0");
-      name = num;
+      name = globalVariableDefaultName(num);
     }
 
     const alias = "VAR_" + toASMVar(name);

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -4688,13 +4688,7 @@ extern void __mute_mask_${symbol};
         maxDepth: this.options.maxDepth - 1,
       }
     );
-    const key = compiledSubScript.replace(new RegExp(symbol, "g"), type);
-    const existing = this.options.additionalScripts[key];
-    if (existing) {
-      this._deregisterSymbol(symbol);
-      return existing.symbol;
-    }
-    this.options.additionalScripts[key] = {
+    this.options.additionalScripts[symbol] = {
       symbol,
       compiledScript: compiledSubScript,
     };

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -30,7 +30,7 @@ export interface EventHandler {
   ) => string;
   fields: ScriptEventFieldSchema[];
   name?: string;
-  groups?: string[];
+  groups?: string[] | string;
   deprecated?: boolean;
   isConditional?: boolean;
   editableSymbol?: boolean;

--- a/src/lib/project/loadProjectData.js
+++ b/src/lib/project/loadProjectData.js
@@ -11,8 +11,12 @@ import loadAllSoundData from "./loadSoundData";
 import migrateProject from "./migrateProject";
 import { indexByFn, indexBy } from "../helpers/array";
 
+const toUnixFilename = (filename) => {
+  return filename.replace(/\\/g, "/");
+};
+
 const elemKey = (elem) => {
-  return (elem.plugin ? `${elem.plugin}/` : "") + elem.filename;
+  return (elem.plugin ? `${elem.plugin}/` : "") + toUnixFilename(elem.filename);
 };
 
 const indexByFilename = indexByFn(elemKey);

--- a/src/lib/project/migrateProject.js
+++ b/src/lib/project/migrateProject.js
@@ -1552,6 +1552,12 @@ export const migrateFrom300r2To300r3 = (data) => {
         ),
       };
     }),
+    variables: data.variables.map((variable, variableIndex) => {
+      return {
+        ...variable,
+        symbol: toValidSymbol(`var_${variable.name || variableIndex + 1}`),
+      };
+    }),
   };
 };
 

--- a/src/lib/project/migrateProject.js
+++ b/src/lib/project/migrateProject.js
@@ -1552,7 +1552,7 @@ export const migrateFrom300r2To300r3 = (data) => {
         ),
       };
     }),
-    variables: data.variables.map((variable, variableIndex) => {
+    variables: (data.variables || []).map((variable, variableIndex) => {
       return {
         ...variable,
         symbol: toValidSymbol(`var_${variable.name || variableIndex + 1}`),

--- a/test/data/compiler/compileEntityEvents.test.js
+++ b/test/data/compiler/compileEntityEvents.test.js
@@ -200,7 +200,7 @@ ___bank_testname = 255
 
 _testname::
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_4, 0, 1$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_4, 0, 1$, 0
         ; Text Dialogue
         VM_LOAD_TEXT            0
         .asciz "FALSE PATH"
@@ -285,7 +285,7 @@ ___bank_testname = 255
 
 _testname::
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_4, 0, 1$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_4, 0, 1$, 0
         ; Text Dialogue
         VM_LOAD_TEXT            0
         .asciz "FALSE PATH"

--- a/test/data/compiler/scriptBuilder2.test.ts
+++ b/test/data/compiler/scriptBuilder2.test.ts
@@ -304,7 +304,7 @@ ___bank_MY_SCRIPT = 255
 
 _MY_SCRIPT::
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_1, 0, 1$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_1, 0, 1$, 0
         VM_DEBUG                0
         .asciz "False Path"
         VM_JUMP                 2$
@@ -379,7 +379,7 @@ ___bank_MY_SCRIPT = 255
 
 _MY_SCRIPT::
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_0, 0, 1$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_0, 0, 1$, 0
         ; Text Dialogue
         VM_LOAD_TEXT            0
         .asciz "Goodbye World"
@@ -472,9 +472,9 @@ ___bank_MY_SCRIPT = 255
 
 _MY_SCRIPT::
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_0, 0, 1$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_0, 0, 1$, 0
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_2, 0, 3$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_2, 0, 3$, 0
         ; Text Dialogue
         VM_LOAD_TEXT            0
         .asciz "0=FALSE 2=FALSE"
@@ -502,7 +502,7 @@ _MY_SCRIPT::
         VM_JUMP                 2$
 1$:
         ; If Variable True
-        VM_IF_CONST             .GT, VAR_1, 0, 5$, 0
+        VM_IF_CONST             .GT, VAR_VARIABLE_1, 0, 5$, 0
         ; Text Dialogue
         VM_LOAD_TEXT            0
         .asciz "0=TRUE 1=FALSE"

--- a/test/migrate/migrate300releases.test.js
+++ b/test/migrate/migrate300releases.test.js
@@ -9,10 +9,12 @@ test("should not fail on empty project", () => {
   const oldProject = {
     scenes: [],
     customEvents: [],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [],
     customEvents: [],
+    variables: [],
   });
 });
 
@@ -26,6 +28,7 @@ test("should add generated symbols to scenes based on scene name", () => {
       },
     ],
     customEvents: [],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [
@@ -37,6 +40,7 @@ test("should add generated symbols to scenes based on scene name", () => {
       },
     ],
     customEvents: [],
+    variables: [],
   });
 });
 
@@ -55,6 +59,7 @@ test("should add generate the same symbol for two scenes with the same name (thi
       },
     ],
     customEvents: [],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [
@@ -72,6 +77,7 @@ test("should add generate the same symbol for two scenes with the same name (thi
       },
     ],
     customEvents: [],
+    variables: [],
   });
 });
 
@@ -90,6 +96,7 @@ test("should generate symbol based on index for scenes with empty name", () => {
       },
     ],
     customEvents: [],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [
@@ -107,6 +114,7 @@ test("should generate symbol based on index for scenes with empty name", () => {
       },
     ],
     customEvents: [],
+    variables: [],
   });
 });
 
@@ -118,6 +126,7 @@ test("should add generated symbols to custom events based on name", () => {
         name: "Hello World",
       },
     ],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [],
@@ -127,6 +136,7 @@ test("should add generated symbols to custom events based on name", () => {
         symbol: "script_hello_world",
       },
     ],
+    variables: [],
   });
 });
 
@@ -141,6 +151,7 @@ test("should generate symbol based on index for custom events with empty name", 
         name: "",
       },
     ],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [],
@@ -154,6 +165,7 @@ test("should generate symbol based on index for custom events with empty name", 
         symbol: "script_2",
       },
     ],
+    variables: [],
   });
 });
 
@@ -181,6 +193,7 @@ test("should add generated symbols to actors and triggers based on name", () => 
       },
     ],
     customEvents: [],
+    variables: [],
   };
   expect(migrateFrom300r2To300r3(oldProject)).toEqual({
     scenes: [
@@ -210,6 +223,7 @@ test("should add generated symbols to actors and triggers based on name", () => 
       },
     ],
     customEvents: [],
+    variables: [],
   });
 });
 

--- a/test/migrate/migrateProject.test.js
+++ b/test/migrate/migrateProject.test.js
@@ -108,6 +108,7 @@ test("should migrate conditional events from 1.0.0 to 2.0.0", () => {
     backgrounds: [],
     customEvents: [],
     spriteSheets: [],
+    variables: [],
     engineFieldValues: [
       {
         id: "fade_style",
@@ -153,6 +154,7 @@ test("should migrate conditional events from 1.2.0 to 2.0.0", () => {
     ],
     backgrounds: [],
     spriteSheets: [],
+    variables: [],
   };
   const newProject = JSON.parse(JSON.stringify(migrateProject(oldProject)));
   expect(newProject).toEqual({
@@ -229,5 +231,6 @@ test("should migrate conditional events from 1.2.0 to 2.0.0", () => {
         value: 0,
       },
     ],
+    variables: [],
   });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes

* **What is the current behavior?** (You can also link to an open issue here)
As reported in #1146 there are a number of issues migrating projects from 3.0.0 to 3.1.0 alpha0

* **What is the new behavior (if this is a feature change)?**
    - Fix issue causing crash when adding events if any plugin event contains a string for the `groups` value
    - Default migrated variable symbols closer match v3.0.0 to improve compatibility with GBVM scripts
    - Fix broken actorInvoke event
    - Fix an issue where some custom scripts were not being compiled
    - Fix an issue where projects created on Mac/Linux would reload assets within folders (and create new ids) if project was created in Windows (need to confirm this works the other way around before I merge this)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It shouldn't.

* **Other information**:
@Anima-SodoDev there's a few other things needed to fix your project beyond this, some of the GBVM you're using is out of date, and your plugins are slightly broken too. I've managed to get your project running so will be in touch separately to let you know what I did once I'm ready to merge this