### PR TITLE
Fix setting actor's position to another actor's position

### DIFF
--- a/src/lib/events/eventActorSetPosition.js
+++ b/src/lib/events/eventActorSetPosition.js
@@ -71,14 +71,15 @@ const compile = (input, helpers) => {
     variableFromUnion,
     temporaryEntityVariable,
   } = helpers;
-  actorSetActive(input.actorId);
   if (input.x.type === "number" && input.y.type === "number") {
     // If all inputs are numbers use fixed implementation
+    actorSetActive(input.actorId);
     actorSetPosition(input.x.value, input.y.value, input.units);
   } else {
     // If any value is not a number transfer values into variables and use variable implementation
     const xVar = variableFromUnion(input.x, temporaryEntityVariable(0));
     const yVar = variableFromUnion(input.y, temporaryEntityVariable(1));
+    actorSetActive(input.actorId);
     actorSetPositionToVariables(xVar, yVar, input.units);
   }
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes issue where setting an actor's position to another actor's X/Y coordinates causes the second actor to move instead of the first.


* **What is the current behavior?** (You can also link to an open issue here)
Setting an actor's position to another actor's X/Y coordinates causes the second actor to move instead of the first. I believe variableSetToProperty is overwriting which actor is active, so calling actorSetActive before variableFromUnion was ineffective.


* **What is the new behavior (if this is a feature change)?**
Setting an actor's position to another actor's X/Y coordinates now works as intended.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
~~This issue might affect other events as well? Will have to test.~~ It doesn't appear any other events are affected by this. Hurray! :D
Although it initially appeared to fix issue #1098, there is still something wrong with setting an actor's position to another actor's position via custom scripts. However, at least part of the issue should be resolved now.