### PR TITLE
Update "Start Actor's 'On Update' Script" event to use a GBVM command

### DIFF
--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -1325,6 +1325,10 @@ class ScriptBuilder {
     this._addCmd("VM_ACTOR_EMOTE", addr, `___bank_${symbol}`, `_${symbol}`);
   };
 
+  _actorBeginUpdate = (addr: string) => {
+    this._addCmd("VM_ACTOR_BEGIN_UPDATE", addr);
+  };
+
   _actorTerminateUpdate = (addr: string) => {
     this._addCmd("VM_ACTOR_TERMINATE_UPDATE", addr);
   };
@@ -2523,8 +2527,7 @@ extern void __mute_mask_${symbol};
   actorStartUpdate = () => {
     const actorRef = this._declareLocal("actor", 4);
     this._addComment("Actor Start Update Script");
-    this._actorDeactivate(actorRef);
-    this._actorActivate(actorRef);
+    this._actorBeginUpdate(actorRef);
     this._addNL();
   };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Replaces the "Deactivate Actor" + "Activate Actor" functions in the "Start Actor's 'On Update' Script" event with a proper GBVM command.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, "Deactivate Actor" + "Activate Actor" is used to restart an actor's "On Update" script, which works but was a bit hacky.


* **What is the new behavior (if this is a feature change)?**
Now the event uses a proper GBVM command as discussed in PR #1136.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
This requires [pull request 148 of GBVM](https://github.com/chrismaltby/gbvm/pull/148).