### PR TITLE
Prevent user from creating projects ending with a period

### DIFF
--- a/src/components/app/Splash.tsx
+++ b/src/components/app/Splash.tsx
@@ -166,9 +166,14 @@ export default () => {
   };
 
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newName = e.currentTarget.value;
+    var newName = e.currentTarget.value;
+    if (newName.endsWith(".")) {
+      newName = newName.replace(/.$/,"");
+      setNameError(l10n("ERROR_PROJECT_NAME_ENDING_PERIOD"));
+    } else {
+      setNameError("");
+    }
     setName(newName);
-    setNameError("");
   };
 
   const onChangePath = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -904,6 +904,7 @@
   "ERROR_PLEASE_SELECT_A_DIFFERENT_LOCATION": "Please select a different location",
   "ERROR_PROJECT_PATH_INVALID": "Invalid directory path",
   "ERROR_MISSING_FONTS": "No fonts found in assets/fonts folder. An example font has been copied there for you to use.",
+  "ERROR_PROJECT_NAME_ENDING_PERIOD": "Project names cannot end with a period.",
 
   "// 13": "Splash -------------------------------------------------------",
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue with project names.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, if a Windows user creates a project with a project name ending with a period, the project folder is inaccessible and cannot be deleted by normal means.


* **What is the new behavior (if this is a feature change)?**
This now prevents a period from being entered as the last character in the project name and warns the user.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users now can't add a period to the end of their project names. I can't imagine this is a deal-breaker.


* **Other information**:
There might be other invalid characters that can be entered this way, resulting in folders that certain operating systems can't read. Might be good to eliminate them all at some point. This was just one I noticed when trying to create a project ending with a period myself. Whoops! Haha.