### PR TITLE
Add "Loop Do While" event

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -605,6 +605,7 @@
   "EVENT_LOOP": "Loop",
   "EVENT_LOOP_FOR": "Loop For",
   "EVENT_LOOP_WHILE": "Loop While",
+  "EVENT_LOOP_DO_WHILE": "Loop Do While",
   "EVENT_GROUP": "Event Group",
   "EVENT_COMMENT": "Comment",
   "EVENT_DEFINE_LABEL": "Label: Define",
@@ -759,6 +760,7 @@
   "EVENT_IDLE": "Idle",
   "EVENT_LOOP_FOR_LABEL": "For ({variable} = {from}; {variable} <= {to}; {variable} += {inc})",
   "EVENT_LOOP_WHILE_LABEL": "While ({expression})",
+  "EVENT_LOOP_DO_WHILE_LABEL": "Do While ({expression})",
 
   "// 10": "Menu -----------------------------------------------------",
 

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -4323,6 +4323,22 @@ extern void __mute_mask_${symbol};
     this._addNL();
   };
 
+  doWhileExpression = (
+    expression: string,
+    truePath: ScriptEvent[] | ScriptBuilderPathFunction = []
+  ) => {
+    const loopId = this.getNextLabel();
+    const endLabel = this.getNextLabel();
+    this._addComment(`Do While ${this._expressionToHumanReadable(expression)}`);
+    this._label(loopId);
+    this._compilePath(truePath);
+    this._stackPushEvaluatedExpression(expression);
+    this._ifConst(".EQ", ".ARG0", 0, endLabel, 1);
+    this._jump(loopId);
+    this._label(endLabel);
+    this._addNL();
+  };
+
   whileExpression = (
     expression: string,
     truePath: ScriptEvent[] | ScriptBuilderPathFunction = []

--- a/src/lib/events/eventLoopDoWhile.js
+++ b/src/lib/events/eventLoopDoWhile.js
@@ -1,0 +1,42 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_LOOP_DO_WHILE";
+const groups = ["EVENT_GROUP_CONTROL_FLOW"];
+
+const autoLabel = (fetchArg, args) => {
+  if (args.expression) {
+    return l10n("EVENT_LOOP_DO_WHILE_LABEL", {
+      expression: fetchArg("expression"),
+    });
+  } else {
+    return l10n("EVENT_LOOP_DO_WHILE");
+  }
+};
+
+const fields = [
+  {
+    key: "true",
+    type: "events",
+  },
+  {
+    key: "expression",
+    type: "matharea",
+    rows: 5,
+    placeholder: "e.g. $health >= 0...",
+    defaultValue: "",
+  },
+];
+
+const compile = (input, helpers) => {
+  const { doWhileExpression } = helpers;
+  const truePath = input.true;
+  doWhileExpression(input.expression || "0", truePath);
+};
+
+module.exports = {
+  id,
+  autoLabel,
+  groups,
+  fields,
+  compile,
+};


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a do while loop.
The event has the "true" path above the expression field intentionally to indicate to the user that the true path gets executed before the expression is evaluated.

* **What is the current behavior?** (You can also link to an open issue here)
Currently, there is no "do while" loop, only "for" and "while".


* **What is the new behavior (if this is a feature change)?**
Adds "do while" loop.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
For that one programmer in the world that uses "do while" loops, you're welcome! Haha.

It might be important to note in the documentation that if you put a "do while" loop within an actor's "On Update" script, it will run the body every time the "On Update" loops, so it may seem like it's not checking the condition, even though it is. "Do While" is most effective in areas that only run once, such as in "On Init" scripts or if you attach a script to a button. A similar warning should also be included about the "for" loop, since it modifies the value of the variable every time the "On Update" runs.