### PR TITLE
Add $self$ to property select list

### DIFF
--- a/src/components/forms/PropertySelect.tsx
+++ b/src/components/forms/PropertySelect.tsx
@@ -143,6 +143,18 @@ export const PropertySelect = ({
     } else if (sceneActorIds) {
       setOptions(
         [
+          ...(editorType === "actor" && selfActor && selfIndex !== undefined
+            ? [
+                {
+                  label: `${l10n("FIELD_SELF")} (${actorName(
+                    selfActor,
+                    selfIndex
+                  )})`,
+                  value: "$self$",
+                  spriteSheetId: selfActor.spriteSheetId,
+                },
+              ]
+            : []),
           {
             label: "Player",
             value: "player",

--- a/src/lib/events/eventActorMoveTo.js
+++ b/src/lib/events/eventActorMoveTo.js
@@ -57,7 +57,7 @@ const fields = [
         defaultValue: {
           number: 0,
           variable: "LAST_VARIABLE",
-          property: "$self$:xpos",
+          property: "$self$:ypos",
         },
       },
     ],

--- a/src/lib/events/eventActorSetPosition.js
+++ b/src/lib/events/eventActorSetPosition.js
@@ -56,7 +56,7 @@ const fields = [
         defaultValue: {
           number: 0,
           variable: "LAST_VARIABLE",
-          property: "$self$:xpos",
+          property: "$self$:ypos",
         },
       },
     ],

--- a/src/lib/events/eventCameraMoveTo.js
+++ b/src/lib/events/eventCameraMoveTo.js
@@ -50,7 +50,7 @@ const fields = [
         defaultValue: {
           number: 0,
           variable: "LAST_VARIABLE",
-          property: "$self$:xpos",
+          property: "$self$:ypos",
         },
       },
     ],


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix?

* **What is the current behavior?** (You can also link to an open issue here)

Even if `$self$xpos` is the default value for the events that include a property selector (like the x and y fields of the move to events) there's no option to pick a property for `self` in the selector so the selector ends up defaulting to player.xpos.

This, for example, means that when trying to do a follower script (where an actor follows the player), the selector for the X field shows the player spritesheet and `Tile X` by default but the event is using `$self$:xpos` 

<img width="344" alt="image" src="https://user-images.githubusercontent.com/54246642/180892087-ae4b26e1-d9d5-4e2f-921e-f9d4a1b32c45.png">

```
{
    "command": "EVENT_ACTOR_MOVE_TO",
    "args": {
        "actorId": "$self$",
        "x": {
            "type": "property",
            "value": "$self$:xpos"
        },
        "y": {
            "type": "property",
            "value": "player:ypos"
        },
        "moveType": "horizontal",
        "useCollisions": false
    },
    "id": "09a01061-ad06-4f03-a472-f2a99e34b06f"
}
```

* **What is the new behavior (if this is a feature change)?**

Self is an option in the selector, so the default value is not player:xpos.

I also updated the events with `Y` property fields to default to `$self$:ypos`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

@chrismaltby I don't know if the lack of self on the property selector was on purpose because some side effect. If that's the case then the property events should default to `player:xpos` instead of `$self$:xpos` instead of this change.
