### PR TITLE
Add row/column hover to piano roll + fix off by 10px bug on piano rol…

### DIFF
--- a/src/components/music/RollChannelHover.tsx
+++ b/src/components/music/RollChannelHover.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+interface RollChannelHoverProps {
+  cellSize: number;
+  hoverColumn: number | null;
+  hoverRow: number | null;
+}
+
+interface WrapperProps {
+  rows: number;
+  cols: number;
+  size: number;
+}
+
+interface HorizontalHoverProps {
+  row: number;
+  size: number;
+}
+
+interface VerticalHoverProps {
+  col: number;
+  size: number;
+}
+
+const numRows = 12 * 6;
+const numCols = 64;
+
+const Wrapper = styled.div<WrapperProps>`
+  position: absolute;
+  top: 0;
+  overflow: hidden;
+  pointer-events: none;
+  ${(props) => css`
+    margin: 0 ${3 * props.size}px ${2 * props.size}px 10px;
+    width: ${props.cols * props.size}px;
+    height: ${props.rows * props.size}px;
+  `}
+`;
+
+const HorizontalHover = styled.div<HorizontalHoverProps>`
+  position: absolute;
+  left: 0;
+  ${(props) => css`
+    background: ${props.theme.colors.tracker.rollCell.border};
+    opacity: 0.3;
+    top: ${(numCols - props.row + 7) * props.size}px;
+    width: 100%;
+    height: ${props.size}px;
+  `}
+`;
+
+const VerticalHover = styled.div<VerticalHoverProps>`
+  position: absolute;
+  top: 0;
+  ${(props) => css`
+    background: ${props.theme.colors.tracker.rollCell.border};
+    opacity: 0.3;
+    left: ${props.col * props.size}px;
+    width: ${props.size}px;
+    height: 100%;
+  `}
+`;
+
+export const RollChannelHover = ({
+  cellSize,
+  hoverColumn,
+  hoverRow,
+}: RollChannelHoverProps) => {
+  if (hoverColumn === null || hoverRow == null) {
+    return null;
+  }
+  return (
+    <Wrapper rows={numRows} cols={numCols} size={cellSize}>
+      <HorizontalHover row={hoverRow} size={cellSize} />
+      <VerticalHover col={hoverColumn} size={cellSize} />
+    </Wrapper>
+  );
+};

--- a/src/components/music/SongPianoRoll.tsx
+++ b/src/components/music/SongPianoRoll.tsx
@@ -25,9 +25,11 @@ import {
 } from "./helpers";
 import { RollChannelEffectRow } from "./RollChannelEffectRow";
 import { WandIcon } from "ui/icons/Icons";
+import { RollChannelHover } from "./RollChannelHover";
 
 const CELL_SIZE = 16;
 const MAX_NOTE = 71;
+const GRID_MARGIN = 10;
 
 interface SongPianoRollProps {
   sequenceId: number;
@@ -615,7 +617,8 @@ export const SongPianoRoll = ({
         } else if (gridRef.current) {
           const bounds = gridRef.current.getBoundingClientRect();
           const x = clamp(
-            Math.floor((e.pageX - bounds.left) / CELL_SIZE) * CELL_SIZE,
+            Math.floor((e.pageX - bounds.left - GRID_MARGIN) / CELL_SIZE) *
+              CELL_SIZE,
             0,
             63 * CELL_SIZE
           );
@@ -702,7 +705,9 @@ export const SongPianoRoll = ({
 
       const bounds = gridRef.current.getBoundingClientRect();
 
-      const newColumn = Math.floor((e.pageX - bounds.left) / CELL_SIZE);
+      const newColumn = Math.floor(
+        (e.pageX - bounds.left - GRID_MARGIN) / CELL_SIZE
+      );
       const newRow = Math.floor((e.pageY - bounds.top) / CELL_SIZE);
       const newNote = 12 * 6 - 1 - newRow;
       if (newNote !== hoverNote) {
@@ -1082,6 +1087,11 @@ export const SongPianoRoll = ({
               }}
             >
               <RollChannelGrid cellSize={CELL_SIZE} />
+              <RollChannelHover
+                cellSize={CELL_SIZE}
+                hoverColumn={hoverColumn}
+                hoverRow={hoverNote}
+              />
               {v.map((i) => (
                 <RollChannel
                   channelId={i}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix + small UI change to music editor


* **What is the current behavior?** (You can also link to an open issue here)
Since adding the ability to set note effects, it's difficult to see which note aligns with the effect


* **What is the new behavior (if this is a feature change)?**
I've added a highlight on the currently hovered row + column to make it easier to see which effect is for which note.

<img width="514" alt="Screenshot 2022-07-27 at 22 03 10" src="https://user-images.githubusercontent.com/16776042/181371832-c8fd187f-472e-4401-a055-f3069c12ab3d.png">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Don't think so


* **Other information**:
While making this change I noticed the hoverColumn value was not taking into account the left margin of the piano roll grid so would often select the column to the right of the one you were hovering when doing things like dragging notes or creating a selection, I've updated the calculations to take account of the margins.
