### PR TITLE
Add noise macro preview for music editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for calling C functions directly from GBVM with `VM_CALL_NATIVE`, in conjunction engine plugins allows creation of plugin events which call new native C functions
 - Add compile time warning if too many unique projectiles are within a scene
 - Add effect editor to music editor piano roll [@pau-tomas](https://github.com/pau-tomas)
+- Add noise macro preview for music editor [@RichardULZ](https://github.com/RichardULZ)
 
 ### Changed
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -600,6 +600,7 @@ menu.on("checkUpdates", () => {
 menu.on("openMusic", () => {
   if (musicWindow) {
     musicWindow.show();
+    musicWindow.webContents.openDevTools();
   } else {
     dialog.showErrorBox(
       "No music process running",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix & feature


* **What is the current behavior?** (You can also link to an open issue here)
Noise preview will use the first position in the macro, and break when playing out of range notes, doesn't sound like the real song at all.
No length notes would preview for 3 seconds, since there's no stop on mouse/key up, this got obnoxious. 
Windows developers could not open the DevOps window for music process due to an electron issue.


* **What is the new behavior (if this is a feature change)?**
Noise macro will now (crudely) preview when placing a note, javascript timings may vary leading to inaccuracies, but it's way better than no preview and mathematically accurate. 
Bitstring will wrap around (8bit) values by splitting string if too long, instead of error, so high noise notes with macro will match preview.
Limits max preview note sound to 2 seconds, as there's no stop on release. Any envelope configurations will be finished by 1.6 seconds, so there is no downside. 
Opens devtools on music process window for developers (thanks for the solution @pau-tomas )
Changes updateTracker timer from 10ms to 1000/64, or 15.625 to match console and hUGEdriver.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that i can think of. 

* **Other information**:
The correct way might be to send a blank pattern with note to hUGEdriver, and play it as a song, so javascript timings aren't a factor, but that's complicated and would not work during song playback. 
