### PR TITLE
Add rumble support

### DIFF
--- a/appData/src/gb/Makefile.common
+++ b/appData/src/gb/Makefile.common
@@ -105,7 +105,7 @@ MBC3:
 	$(eval CART_MBC = 0x10)
 	@echo "Using MBC3"
 MBC5:
-	$(eval CART_MBC = 0x1B)
+	$(eval CART_MBC = 0x1E)
 	@echo "Using MBC5"
 
 hUGE:

--- a/src/components/settings/CartSettingsEditor.tsx
+++ b/src/components/settings/CartSettingsEditor.tsx
@@ -23,11 +23,11 @@ interface CartTypeOption {
 const cartOptions: CartTypeOption[] = [
   {
     value: "mbc5",
-    label: "MBC5",
+    label: "MBC5 (Rumble + RAM + Battery)",
   },
   {
     value: "mbc3",
-    label: "MBC3",
+    label: "MBC3 (Timer + RAM + Battery)",
   },
 ];
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -557,6 +557,8 @@
   "FIELD_TO_PATTERN": "To Pattern",
   "FIELD_JUMP_TO_NEXT_PATTERN": "Jump To Next Pattern",
   "FIELD_START_ROW": "Start Row",
+  "FIELD_RUMBLE_ON": "Turn on the rumble motor",
+  "FIELD_RUMBLE_OFF": "Turn off the rumble motor",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",
@@ -590,6 +592,7 @@
   "EVENT_GROUP_MUSIC": "Music & Sound Effects",
   "EVENT_GROUP_DIALOGUE": "Dialogue & Menus",
   "EVENT_GROUP_TIMER": "Timer",
+  "EVENT_GROUP_RUMBLE": "Rumble",
   "EVENT_SWITCH_SCENE": "Change Scene",
   "EVENT_WAIT": "Wait",
   "EVENT_CAMERA_SHAKE": "Camera Shake",
@@ -780,6 +783,8 @@
   "EVENT_IDLE": "Idle",
   "EVENT_LOOP_FOR_LABEL": "For ({variable} = {from}; {variable} {comparison} {to}; {variable} {operation} {val})",
   "EVENT_LOOP_WHILE_LABEL": "While ({expression})",
+  "EVENT_RUMBLE_ON": "Rumble On",
+  "EVENT_RUMBLE_OFF": "Rumble Off",
 
   "// 10": "Menu -----------------------------------------------------",
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -785,6 +785,8 @@
   "EVENT_LOOP_WHILE_LABEL": "While ({expression})",
   "EVENT_RUMBLE_ON": "Rumble On",
   "EVENT_RUMBLE_OFF": "Rumble Off",
+  "EVENT_RUMBLE_FOR": "Rumble For",
+  "EVENT_RUMBLE_FOR_LABEL": "Rumble For {time} {units}",
 
   "// 10": "Menu -----------------------------------------------------",
 

--- a/src/lib/compiler/buildMakeScript.js
+++ b/src/lib/compiler/buildMakeScript.js
@@ -256,7 +256,7 @@ export const buildLinkFlags = (
     .toUpperCase()
     .replace(/[^A-Z]*/g, "")
     .substring(0, 15);
-  const cart = cartType === "mbc3" ? "0x10" : "0x1B";
+  const cart = cartType === "mbc3" ? "0x10" : "0x1E";
   return [].concat(
     // General
     [

--- a/src/lib/compiler/eventTypes.js
+++ b/src/lib/compiler/eventTypes.js
@@ -137,6 +137,7 @@ export const EVENT_ENGINE_FIELD_STORE = "EVENT_ENGINE_FIELD_STORE";
 // Rumble
 export const EVENT_RUMBLE_ON = "EVENT_RUMBLE_ON";
 export const EVENT_RUMBLE_OFF = "EVENT_RUMBLE_OFF";
+export const EVENT_RUMBLE_FOR = "EVENT_RUMBLE_FOR";
 
 export const EventsOnlyForActors = [EVENT_ACTOR_PUSH];
 export const EventsHidden = [

--- a/src/lib/compiler/eventTypes.js
+++ b/src/lib/compiler/eventTypes.js
@@ -134,6 +134,10 @@ export const EVENT_CALL_CUSTOM_EVENT = "EVENT_CALL_CUSTOM_EVENT";
 export const EVENT_ENGINE_FIELD_SET = "EVENT_ENGINE_FIELD_SET";
 export const EVENT_ENGINE_FIELD_STORE = "EVENT_ENGINE_FIELD_STORE";
 
+// Rumble
+export const EVENT_RUMBLE_ON = "EVENT_RUMBLE_ON";
+export const EVENT_RUMBLE_OFF = "EVENT_RUMBLE_OFF";
+
 export const EventsOnlyForActors = [EVENT_ACTOR_PUSH];
 export const EventsHidden = [
   EVENT_MATH_ADD,

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -1981,6 +1981,16 @@ extern void __mute_mask_${symbol};
     this._addCmd("VM_RESERVE", size);
   };
 
+  _rumble = (enable: number) => {
+    const { settings } = this.options;
+    const cart = settings.cartType;
+    const rumbleAddr = {
+      "mbc3": 0x20,
+      "mbc5": 0x08
+    };
+    this._addCmd("VM_RUMBLE", rumbleAddr[cart], enable);
+  };
+
   // --------------------------------------------------------------------------
   // Actors
 
@@ -4803,6 +4813,18 @@ extern void __mute_mask_${symbol};
     this._label(falseLabel);
     this._compilePath(falsePath);
     this._label(endLabel);
+    this._addNL();
+  };
+
+  rumbleOn = () => {
+    this._addComment("Rumble On");
+    this._rumble(1);
+    this._addNL();
+  };
+
+  rumbleOff = () => {
+    this._addComment("Rumble Off");
+    this._rumble(0);
     this._addNL();
   };
 

--- a/src/lib/events/eventRumbleFor.js
+++ b/src/lib/events/eventRumbleFor.js
@@ -1,0 +1,85 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_RUMBLE_FOR";
+const groups = ["EVENT_GROUP_RUMBLE"];
+
+const autoLabel = (fetchArg, input) => {
+  if (input.units === "frames") {
+    return l10n("EVENT_RUMBLE_FOR_LABEL", {
+      time: fetchArg("frames"),
+      units: l10n("FIELD_FRAMES"),
+    });
+  }
+  return l10n("EVENT_RUMBLE_FOR_LABEL", {
+    time: fetchArg("time"),
+    units: l10n("FIELD_SECONDS"),
+  });
+};
+
+const fields = [
+  {
+    type: "group",
+    fields: [
+      {
+        key: "time",
+        type: "number",
+        label: l10n("FIELD_SECONDS"),
+        min: 0,
+        max: 60,
+        step: 0.1,
+        defaultValue: 0.5,
+        unitsField: "units",
+        unitsDefault: "time",
+        unitsAllowed: ["time", "frames"],
+        conditions: [
+          {
+            key: "units",
+            ne: "frames",
+          },
+        ],
+      },
+      {
+        key: "frames",
+        label: l10n("FIELD_FRAMES"),
+        type: "number",
+        min: 0,
+        max: 3600,
+        width: "50%",
+        defaultValue: 30,
+        unitsField: "units",
+        unitsDefault: "time",
+        unitsAllowed: ["time", "frames"],
+        conditions: [
+          {
+            key: "units",
+            eq: "frames",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const compile = (input, helpers) => {
+  const { rumbleOn, rumbleOff, wait } = helpers;
+  rumbleOn();
+  let frames = 0;
+  if (input.units === "frames") {
+    frames = typeof input.frames === "number" ? input.frames : 30;
+  } else {
+    const seconds = typeof input.time === "number" ? input.time : 0.5;
+    frames = Math.ceil(seconds * 60);
+  }
+  if (frames > 0) {
+    wait(frames);
+  }
+  rumbleOff();
+};
+
+module.exports = {
+  id,
+  autoLabel,
+  groups,
+  fields,
+  compile,
+};

--- a/src/lib/events/eventRumbleOff.js
+++ b/src/lib/events/eventRumbleOff.js
@@ -1,0 +1,22 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_RUMBLE_OFF";
+const groups = ["EVENT_GROUP_RUMBLE"];
+
+const fields = [
+  {
+    label: l10n("FIELD_RUMBLE_OFF"),
+  },
+];
+
+const compile = (input, helpers) => {
+  const { rumbleOff } = helpers;
+  rumbleOff();
+};
+
+module.exports = {
+  id,
+  groups,
+  fields,
+  compile,
+};

--- a/src/lib/events/eventRumbleOn.js
+++ b/src/lib/events/eventRumbleOn.js
@@ -1,0 +1,22 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_RUMBLE_ON";
+const groups = ["EVENT_GROUP_RUMBLE"];
+
+const fields = [
+  {
+    label: l10n("FIELD_RUMBLE_ON"),
+  },
+];
+
+const compile = (input, helpers) => {
+  const { rumbleOn } = helpers;
+  rumbleOn();
+};
+
+module.exports = {
+  id,
+  groups,
+  fields,
+  compile,
+};

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -111,6 +111,8 @@ export const ENGINE_FIELD_UPDATE_VAR = "ENGINE_FIELD_UPDATE_VAR";
 export const ENGINE_FIELD_UPDATE_VAR_WORD = "ENGINE_FIELD_UPDATE_VAR_WORD";
 export const ENGINE_FIELD_STORE = "ENGINE_FIELD_STORE";
 export const ENGINE_FIELD_STORE_WORD = "ENGINE_FIELD_STORE_WORD";
+export const RUMBLE_ON = "RUMBLE_ON";
+export const RUMBLE_OFF = "RUMBLE_OFF";
 
 export const scriptCommands = [
   END,
@@ -226,6 +228,8 @@ export const scriptCommands = [
   ENGINE_FIELD_UPDATE_VAR_WORD,
   ENGINE_FIELD_STORE,
   ENGINE_FIELD_STORE_WORD,
+  RUMBLE_ON,
+  RUMBLE_OFF,
 ];
 
 export const commandIndex = (key) => {

--- a/src/lib/events/scriptCommands.js
+++ b/src/lib/events/scriptCommands.js
@@ -113,6 +113,7 @@ export const ENGINE_FIELD_STORE = "ENGINE_FIELD_STORE";
 export const ENGINE_FIELD_STORE_WORD = "ENGINE_FIELD_STORE_WORD";
 export const RUMBLE_ON = "RUMBLE_ON";
 export const RUMBLE_OFF = "RUMBLE_OFF";
+export const RUMBLE_FOR = "RUMBLE_FOR";
 
 export const scriptCommands = [
   END,
@@ -230,6 +231,7 @@ export const scriptCommands = [
   ENGINE_FIELD_STORE_WORD,
   RUMBLE_ON,
   RUMBLE_OFF,
+  RUMBLE_FOR,
 ];
 
 export const commandIndex = (key) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds rumble support for MBC5 and MBC3.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, rumble support can only be activated using GBVM scripts and only supports a single, non-standard MBC3 cart.


* **What is the new behavior (if this is a feature change)?**
With slight changes to GBVM and GB Studio, MBC3 and MBC5 rumble is supported and can be accessed easily with the "Rumble On" and "Rumble Off" events.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
Requires [pull request 153 of GBVM](https://github.com/chrismaltby/gbvm/pull/153).
I've changed the cartridge type of MBC5 from 0x1B to 0x1E, which has all the same features as 0x1B but with rumble support. I am not sure if there was a reason for using 0x1B, so I replaced it. If 0x1B is needed, then I can revert that and simply add another MBC5 entry for 0x1E instead. However, 0x1E does output a ROM that rumbles the controller using the VisualBoyAdvance-M emulator (and partially rumbles the controller with mGBA), whereas 0x1B does not rumble in any emulator that I am aware of.