### PR TITLE
Update entitiesState.ts

### DIFF
--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -17,7 +17,7 @@ import {
   DRAG_TRIGGER,
   DRAG_ACTOR,
 } from "../../../consts";
-import { isVariableField, isPropertyField } from "lib/helpers/eventSystem";
+import { isActorField, isVariableField, isPropertyField } from "lib/helpers/eventSystem";
 import clamp from "lib/helpers/clamp";
 import { RootState } from "store/configureStore";
 import settingsActions from "../settings/settingsActions";
@@ -2167,35 +2167,27 @@ const refreshCustomEventArgs: CaseReducer<
       const args = scriptEvent.args;
       if (!args) return;
       if (args.__comment) return;
-      if (
-        args.actorId &&
-        args.actorId !== "player" &&
-        args.actorId !== "$self$" &&
-        typeof args.actorId === "string"
-      ) {
-        const letter = String.fromCharCode(
-          "A".charCodeAt(0) + parseInt(args.actorId)
-        );
-        actors[args.actorId] = {
-          id: args.actorId,
-          name: oldActors[args.actorId]?.name || `Actor ${letter}`,
-        };
-      }
-      if (
-        args.otherActorId &&
-        args.otherActorId !== "player" &&
-        args.otherActorId !== "$self$" &&
-        typeof args.otherActorId === "string"
-      ) {
-        const letter = String.fromCharCode(
-          "A".charCodeAt(0) + parseInt(args.otherActorId)
-        );
-        actors[args.otherActorId] = {
-          id: args.otherActorId,
-          name: oldActors[args.otherActorId]?.name || `Actor ${letter}`,
-        };
-      }
       Object.keys(args).forEach((arg) => {
+        if (isActorField(scriptEvent.command, arg, args, eventLookup)) {
+          const addActor = (actor: string) => {
+            const letter = String.fromCharCode(
+              "A".charCodeAt(0) + parseInt(actor)
+            );
+            actors[actor] = {
+              id: actor,
+              name: oldActors[actor]?.name || `Actor ${letter}`,
+            };
+          };
+          const actor = args[arg];
+          if (
+            actor &&
+            actor !== "player" &&
+            actor !== "$self$" &&
+            typeof actor === "string"
+          ) {
+            addActor(actor);
+          }
+        }
         if (isVariableField(scriptEvent.command, arg, args, eventLookup)) {
           const addVariable = (variable: string) => {
             const letter = String.fromCharCode(


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates entitiesState.ts so that events with actor fields that aren't named "actorId" or "otherActorId" show up in the "Custom Scripts"


* **What is the current behavior?** (You can also link to an open issue here)
Currently, "actorId" and "otherActorId" are hard-coded as the only actor fields that can be passed into custom scripts. While GB Studio only has events with these actor fields, it means that in the future, if an event is added with three or more actors, an additional actor ID must be hard-coded in a similar fashion.


* **What is the new behavior (if this is a feature change)?**
Now, GB Studio will scan for all actor fields when making custom scripts.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
It appears custom scripts from previous projects still work as before, so I don't think a migration script is needed for anything, but that's still not my area of expertise.