### PR TITLE
Add the ability to launch a projectile at another actor

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -465,6 +465,7 @@
   "FIELD_ANGLE_VARIABLE": "Angle Variable",
   "FIELD_DIRECTION_VARIABLE": "Direction Variable",
   "FIELD_ACTOR_DIRECTION": "Actor Direction",
+  "FIELD_ACTOR_POSITION": "Actor Position",
   "FIELD_LIFE_TIME": "Life Time",
   "FIELD_LOCK_AXIS": "Lock Axis",
   "FIELD_FROM_SAVE_SLOT": "From Save Slot",

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -176,6 +176,7 @@ type ScriptBuilderRPNOperation =
   | ".ABS"
   | ".MIN"
   | ".MAX"
+  | ".ATAN2"
   | ScriptBuilderComparisonOperator;
 
 type ScriptBuilderOverlayMoveSpeed =
@@ -2720,6 +2721,40 @@ extern void __mute_mask_${symbol};
       .stop();
     this.setActorId(".ARG1", actorId);
     this._actorGetAngle(".ARG1", ".ARG1");
+    this._projectileLaunch(projectileIndex, ".ARG3");
+    this._stackPop(4);
+    this._addNL();
+  };
+
+  launchProjectileAtActor = (
+    projectileIndex: number,
+    x = 0,
+    y = 0,
+    otherActorId: string,
+    destroyOnHit = false,
+    loopAnim = false
+  ) => {
+    const actorRef = this._declareLocal("actor", 4);
+    const otherActorRef = this._declareLocal("other_actor", 3, true);
+    this._addComment("Launch Projectile At Actor");
+    this._actorGetPosition(actorRef);
+    this.setActorId(otherActorRef, otherActorId);
+    this._actorGetPosition(otherActorRef);
+    const rpn = this._rpnProjectilePosArgs(actorRef, x, y);
+    rpn
+      .ref(this._localRef(otherActorRef, 2))
+      .ref(this._localRef(actorRef, 2))
+      .operator(".SUB")
+      .int16(8 * 16)
+      .operator(".DIV")
+      .ref(this._localRef(otherActorRef, 1))
+      .ref(this._localRef(actorRef, 1))
+      .operator(".SUB")
+      .int16(8 * 16)
+      .operator(".DIV")
+      .operator(".ATAN2")
+      .int16(toProjectileFlags(destroyOnHit, loopAnim))
+      .stop();
     this._projectileLaunch(projectileIndex, ".ARG3");
     this._stackPop(4);
     this._addNL();

--- a/src/lib/events/eventLaunchProjectile.js
+++ b/src/lib/events/eventLaunchProjectile.js
@@ -67,6 +67,18 @@ const fields = [
         ],
       },
       {
+        key: "otherActorId",
+        label: l10n("FIELD_DIRECTION"),
+        type: "actor",
+        defaultValue: "$self$",
+        conditions: [
+          {
+            key: "directionType",
+            eq: "actorPos",
+          },
+        ],
+      },
+      {
         key: "direction",
         label: l10n("FIELD_DIRECTION"),
         type: "direction",
@@ -108,6 +120,7 @@ const fields = [
         options: [
           ["direction", l10n("FIELD_FIXED_DIRECTION")],
           ["actor", l10n("FIELD_ACTOR_DIRECTION")],
+          ["actorPos", l10n("FIELD_ACTOR_POSITION")],
           ["angle", l10n("FIELD_ANGLE")],
           ["anglevar", l10n("FIELD_ANGLE_VARIABLE")],
         ],
@@ -205,6 +218,7 @@ const compile = (input, helpers) => {
     launchProjectileInSourceActorDirection,
     launchProjectileInActorDirection,
     launchProjectileInAngleVariable,
+    launchProjectileAtActor,
     actorSetActive,
   } = helpers;
 
@@ -268,6 +282,15 @@ const compile = (input, helpers) => {
         input.loopAnim
       );
     }
+  } else if (input.directionType === "actorPos") {
+    launchProjectileAtActor(
+      projectileIndex,
+      input.x,
+      input.y,
+      input.otherActorId,
+      input.destroyOnHit,
+      input.loopAnim
+    );
   }
 };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to launch a projectile at another actor.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, there's no easy way to launch a projectile at another actor.


* **What is the new behavior (if this is a feature change)?**
You can now select "Actor Position" under the "Direction" field of the projectile event to launch a projectile at another actor.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I am aware of.


* **Other information**:
Requires [pull request 155 of GBVM](https://github.com/chrismaltby/gbvm/pull/155) for the atan2 function.