### PR TITLE
Use channel specific instrument names on instrument select dropdown

### DIFF
--- a/src/components/music/InstrumentSelect.tsx
+++ b/src/components/music/InstrumentSelect.tsx
@@ -1,4 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "store/configureStore";
+import { InstrumentType } from "store/features/editor/editorState";
 import styled from "styled-components";
 import {
   Option,
@@ -8,12 +11,12 @@ import {
   SelectCommonProps,
 } from "ui/form/Select";
 
-const instruments = Array(15)
+const defaultInstrumentOptions = Array(15)
   .fill("")
   .map((_, i) => ({
-    id: `${i}`,
-    name: `Instrument ${i + 1}`,
-  }));
+    value: `${i}`,
+    label: `Instrument ${i + 1}`,
+  })) as Option[];
 
 interface LabelColorProps {
   color: string;
@@ -36,50 +39,64 @@ interface InstrumentSelectProps extends SelectCommonProps {
   optional?: boolean;
   optionalLabel?: string;
   optionalDefaultInstrumentId?: string;
+  instrumentType?: InstrumentType;
 }
 
 export const InstrumentSelect: FC<InstrumentSelectProps> = ({
   value,
+  instrumentType,
   onChange,
   ...selectProps
 }) => {
   const [options, setOptions] = useState<Option[]>([]);
-  const [currentInstrument, setCurrentInstrument] =
-    useState<{ id: string; name: string }>();
+  const [currentInstrument, setCurrentInstrument] = useState<Option>();
   const [currentValue, setCurrentValue] = useState<Option>();
 
-  useEffect(() => {
-    setOptions(
-      ([] as Option[]).concat(
-        [] as Option[],
-        instruments.map((instrument) => ({
-          value: instrument.id,
-          label: instrument.name,
-        }))
-      )
-    );
-  }, []);
+  const song = useSelector(
+    (state: RootState) => state.trackerDocument.present.song
+  );
 
   useEffect(() => {
-    setCurrentInstrument(instruments.find((v) => v.id === value));
-  }, [value]);
+    let instruments = defaultInstrumentOptions;
+    if (song) {
+      switch (instrumentType) {
+        case "duty":
+          instruments = song?.duty_instruments.map((instrument, i) => ({
+            value: `${instrument.index}`,
+            label: instrument.name || `Duty ${instrument.index + 1}`,
+          }));
+          break;
+        case "wave":
+          instruments = song?.wave_instruments.map((instrument, i) => ({
+            value: `${instrument.index}`,
+            label: instrument.name || `Wave ${instrument.index + 1}`,
+          }));
+          break;
+        case "noise":
+          instruments = song?.noise_instruments.map((instrument, i) => ({
+            value: `${instrument.index}`,
+            label: instrument.name || `Noise ${instrument.index + 1}`,
+          }));
+          break;
+      }
+    }
+    setOptions(([] as Option[]).concat([] as Option[], instruments));
+  }, [instrumentType, song]);
+
+  useEffect(() => {
+    setCurrentInstrument(options.find((v) => v.value === value));
+  }, [options, value]);
 
   useEffect(() => {
     if (currentInstrument) {
-      setCurrentValue({
-        value: currentInstrument.id,
-        label: `${currentInstrument.name}`,
-      });
+      setCurrentValue(currentInstrument);
     } else {
-      const firstInstrument = instruments[0];
+      const firstInstrument = options[0];
       if (firstInstrument) {
-        setCurrentValue({
-          value: firstInstrument.id,
-          label: `${firstInstrument.name}`,
-        });
+        setCurrentValue(firstInstrument);
       }
     }
-  }, [currentInstrument]);
+  }, [currentInstrument, options]);
 
   const onSelectChange = (newValue: Option) => {
     onChange?.(newValue.value);

--- a/src/components/music/SongEditorToolsPanel.tsx
+++ b/src/components/music/SongEditorToolsPanel.tsx
@@ -26,6 +26,7 @@ import { Select } from "ui/form/Select";
 import { PianoRollToolType } from "store/features/tracker/trackerState";
 import { ipcRenderer } from "electron";
 import l10n from "lib/helpers/l10n";
+import { InstrumentType } from "store/features/editor/editorState";
 
 const octaveOffsetOptions: OctaveOffsetOptions[] = [0, 1, 2, 3].map((i) => ({
   value: i,
@@ -248,6 +249,33 @@ const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
     };
   });
 
+  const song = useSelector(
+    (state: RootState) => state.trackerDocument.present.song
+  );
+  const selectedChannel = useSelector(
+    (state: RootState) => state.tracker.selectedChannel
+  );
+  const [instrumentType, setInstrumentType] =
+    useState<InstrumentType | undefined>();
+  useEffect(() => {
+    if (view === "roll") {
+      switch (selectedChannel) {
+        case 0:
+        case 1:
+          setInstrumentType("duty");
+          break;
+        case 2:
+          setInstrumentType("wave");
+          break;
+        case 3:
+          setInstrumentType("noise");
+          break;
+      }
+    } else {
+      setInstrumentType(undefined);
+    }
+  }, [view, setInstrumentType, song, selectedChannel]);
+
   const themeContext = useContext(ThemeContext);
 
   const themePianoIcon =
@@ -338,6 +366,7 @@ const SongEditorToolsPanel = ({ selectedSong }: SongEditorToolsPanelProps) => {
           onChange={(newValue) => {
             setDefaultInstruments(parseInt(newValue));
           }}
+          instrumentType={instrumentType}
         />
         {view === "tracker" ? (
           <>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature or bug fix depends on how you look at it :)


* **What is the current behavior?** (You can also link to an open issue here)

Instrument Selector lists all the instruments as `Instrument n` not respecting the given instrument name. This is ok for the tracker view because there's no way to select a specific channel and it's impossible to know what specific instrument/channel combination is being used. However in piano roll only one channel is selected at a time so the instruments could be showing its proper name.

* **What is the new behavior (if this is a feature change)?**

In piano roll the names in the instruments select change to match the instrument name for that channel.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
