### PR TITLE
Fix for build error, cannot read property matchAll of undefined

### DIFF
--- a/src/lib/compiler/objCache.js
+++ b/src/lib/compiler/objCache.js
@@ -70,6 +70,7 @@ const generateIncludesLookup = async (buildIncludeRoot) => {
 
 const generateGameGlobalsLookup = (gameGlobalsContents) => {
   const lookup = {};
+  if (gameGlobalsContents === undefined || !gameGlobalsContents) return lookup;
   const globalMatches = [
     ...gameGlobalsContents.matchAll(/([A-Za-z_0-9]+)[\s]*=[\s]*([0-9]+)/g),
   ];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Project doesn't build
```
- TypeError: Cannot read property 'matchAll' of undefined
```

* **What is the new behavior (if this is a feature change)?**

- Fixed the `generateGameGlobalsLookup` function checking for it's param before doing the `matchAll` check.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No