### PR TITLE
Fix execution order on adjacent triggers

### DIFF
--- a/appData/src/gb/src/core/trigger.c
+++ b/appData/src/gb/src/core/trigger.c
@@ -78,7 +78,7 @@ UBYTE trigger_activate_at_intersection(bounding_box_t *bb, upoint16_t *offset, U
     if (last_trigger != NO_TRIGGER_COLLISON && 
         (hit_trigger == NO_TRIGGER_COLLISON || hit_trigger != last_trigger)) {
 
-    	if (triggers[last_trigger].script_flags & TRIGGER_HAS_LEAVE_SCRIPT) {
+        if (triggers[last_trigger].script_flags & TRIGGER_HAS_LEAVE_SCRIPT) {
             script_execute(
                 triggers[last_trigger].script.bank, 
                 triggers[last_trigger].script.ptr, 0, 1, 2);

--- a/appData/src/gb/src/core/trigger.c
+++ b/appData/src/gb/src/core/trigger.c
@@ -77,16 +77,16 @@ UBYTE trigger_activate_at_intersection(bounding_box_t *bb, upoint16_t *offset, U
 
     if (last_trigger != NO_TRIGGER_COLLISON && 
         (hit_trigger == NO_TRIGGER_COLLISON || hit_trigger != last_trigger)) {
-        
-        if (hit_trigger != NO_TRIGGER_COLLISON && triggers[hit_trigger].script_flags & TRIGGER_HAS_ENTER_SCRIPT) {
-            script_execute(triggers[hit_trigger].script.bank, triggers[hit_trigger].script.ptr, 0, 1, 1);
-            trigger_script_called = TRUE;
-        }
 
-        if (triggers[last_trigger].script_flags & TRIGGER_HAS_LEAVE_SCRIPT) {
+    	if (triggers[last_trigger].script_flags & TRIGGER_HAS_LEAVE_SCRIPT) {
             script_execute(
                 triggers[last_trigger].script.bank, 
                 triggers[last_trigger].script.ptr, 0, 1, 2);
+            trigger_script_called = TRUE;
+        }
+        
+        if (hit_trigger != NO_TRIGGER_COLLISON && triggers[hit_trigger].script_flags & TRIGGER_HAS_ENTER_SCRIPT) {
+            script_execute(triggers[hit_trigger].script.bank, triggers[hit_trigger].script.ptr, 0, 1, 1);
             trigger_script_called = TRUE;
         }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #1219


* **What is the current behavior?** (You can also link to an open issue here)
As #1219 mentions, adjacent triggers will have an incorrect order for executing "On Enter"/"On Leave" scripts.


* **What is the new behavior (if this is a feature change)?**
This is now resolved such that "On Leave" executes before the next "On Enter" script.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I'm aware of.


* **Other information**:
