### PR TITLE
Rename Obj Palette selector to Monochrome Palette

### DIFF
--- a/src/components/forms/ObjPaletteSelect.tsx
+++ b/src/components/forms/ObjPaletteSelect.tsx
@@ -1,6 +1,11 @@
+import PaletteBlock from "components/library/PaletteBlock";
 import React, { FC } from "react";
 import { ObjPalette } from "store/features/entities/entitiesTypes";
-import { Select } from "ui/form/Select";
+import {
+  OptionLabelWithPreview,
+  Select,
+  SingleValueWithPreview,
+} from "ui/form/Select";
 
 interface ObjPaletteSelectProps {
   name: string;
@@ -11,11 +16,20 @@ interface ObjPaletteSelectProps {
 interface ObjPaletteOption {
   value: ObjPalette;
   label: string;
+  colors: string[];
 }
 
 const options: ObjPaletteOption[] = [
-  { value: "OBP0", label: "OBP0" },
-  { value: "OBP1", label: "OBP1" },
+  {
+    value: "OBP0",
+    label: "Palette 0: OBP0",
+    colors: ["E8F8E0", "B0F088", "", "202850"],
+  },
+  {
+    value: "OBP1",
+    label: "Palette 1: OBP1",
+    colors: ["E8F8E0", "509878", "", "202850"],
+  },
 ];
 
 export const ObjPaletteSelect: FC<ObjPaletteSelectProps> = ({
@@ -31,6 +45,32 @@ export const ObjPaletteSelect: FC<ObjPaletteSelectProps> = ({
       options={options}
       onChange={(newValue: ObjPaletteOption) => {
         onChange?.(newValue.value);
+      }}
+      formatOptionLabel={(option: ObjPaletteOption) => {
+        return (
+          <OptionLabelWithPreview
+            preview={
+              <PaletteBlock type="sprite" colors={option.colors} size={20} />
+            }
+          >
+            {option.label}
+          </OptionLabelWithPreview>
+        );
+      }}
+      components={{
+        SingleValue: () => (
+          <SingleValueWithPreview
+            preview={
+              <PaletteBlock
+                type="sprite"
+                colors={currentValue?.colors || []}
+                size={20}
+              />
+            }
+          >
+            {currentValue?.label}
+          </SingleValueWithPreview>
+        ),
       }}
     />
   );

--- a/src/components/sprites/SpriteEditor.tsx
+++ b/src/components/sprites/SpriteEditor.tsx
@@ -484,7 +484,10 @@ export const SpriteEditor = ({
               <FormDivider />
 
               <FormRow>
-                <FormField name="objPalette" label={l10n("FIELD_OBJ_PALETTE")}>
+                <FormField
+                  name="objPalette"
+                  label={l10n("FIELD_MONOCHROME_PALETTE")}
+                >
                   <ObjPaletteSelect
                     name="objPalette"
                     value={metaspriteTile.objPalette}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -491,7 +491,7 @@
   "FIELD_SEND_TO_BACK": "Send To Back",
   "FIELD_FLIP_HORIZONTAL": "Flip Horizontal",
   "FIELD_FLIP_VERTICAL": "Flip Vertical",
-  "FIELD_OBJ_PALETTE": "Obj Palette",
+  "FIELD_MONOCHROME_PALETTE": "Monochrome Palette",
   "FIELD_COLOR_PALETTE": "Color Palette",
   "FIELD_EDIT_IMAGE": "Edit Image",
   "FIELD_UNIQUE": "Unique",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Small silly improvement, I guess

* **What is the current behavior?** (You can also link to an open issue here)

The tile palette selector in the sprite editor is called `Obj Palette` and `OBP0` and `OBP1` which are terms that don't mean much without good understanding of how the GB works.

* **What is the new behavior (if this is a feature change)?**

Rename `Obj Palette` to `Monochrome Palette` and `OBP0` and `OBP1` to `Palette 1: OBP0` and `Palette 2: OBP1` also added a palette preview to both options in the dropdown. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Not sure how needed is this, but it was annoying me a bit :)

