### PR TITLE
Fix muting bug with FXH parser

### DIFF
--- a/src/lib/compiler/sounds/compileFXHammer.ts
+++ b/src/lib/compiler/sounds/compileFXHammer.ts
@@ -92,6 +92,10 @@ const compileFXHammerEffect = (
 
     if (options.usePan) {
       const currentPan = 0b01010101 | ch2pan | ch4pan;
+      // Failsafes to avoid muting channels
+      if (ch2pan == 0) currentPan |= 0b00100010; 
+      if (ch4pan == 0) currentPan |= 0b10001000;
+      
       if (oldPan !== currentPan) {
         count += 1;
         result += `,${binPrefix}01000100,${decHex(currentPan)}`;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds a two line bug fix to an error Beatscribe and I found with the FX Hammer parser, the first NR51 write ignores the used/unused channels, thus muting the unused channel.


* **What is the current behavior?** (You can also link to an open issue here)
If a sound effect only uses one channel, there's the chance the opposite channel will get muted via a null NR51 write.


* **What is the new behavior (if this is a feature change)?**
A failsafe check for CH2Pan and CH4pan that ORs the necessary bits if CH2Pan or CH4Pan are 0.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.
