### PR TITLE
Fixes for UGE v6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ workflows:
                 - v2beta
                 - uge_v6
                 - brushtoolbar-ts
+                - uge_v6_fixes
       - "make:win32":
           requires:
             - checkout
@@ -169,6 +170,7 @@ workflows:
                 - v2beta
                 - uge_v6
                 - brushtoolbar-ts
+                - uge_v6_fixes
       - "make:win64":
           requires:
             - checkout
@@ -182,6 +184,7 @@ workflows:
                 - v2beta
                 - uge_v6
                 - brushtoolbar-ts
+                - uge_v6_fixes
       - "make:linux":
           requires:
             - checkout
@@ -195,6 +198,7 @@ workflows:
                 - v2beta
                 - uge_v6
                 - brushtoolbar-ts
+                - uge_v6_fixes
       - "upload_artifacts":
           requires:
             - "make:mac"
@@ -211,3 +215,4 @@ workflows:
                 - v2beta
                 - uge_v6
                 - brushtoolbar-ts
+                - uge_v6_fixes

--- a/src/components/library/Alert.css
+++ b/src/components/library/Alert.css
@@ -9,8 +9,22 @@
   color: #000;
 }
 
+.Alert-Info {
+  background-color: #03a9f4;
+  color: #000;
+}
+
 .AlertItem {
+  padding: 5px 0px;
+}
+
+.Alert-Warning .AlertItem {
   border-bottom: 1px solid #ffa000;
+  padding: 5px 0px;
+}
+
+.Alert-Info .AlertItem {
+  border-bottom: 1px solid #0088c7;
   padding: 5px 0px;
 }
 

--- a/src/components/library/Alert.js
+++ b/src/components/library/Alert.js
@@ -6,6 +6,7 @@ const Alert = ({ variant, children }) => (
   <div
     className={cx("Alert", {
       "Alert-Warning": variant === "warning",
+      "Alert-Info": variant === "info",
     })}
   >
     {children}
@@ -15,7 +16,7 @@ const Alert = ({ variant, children }) => (
 const AlertItem = ({ children }) => <div className="AlertItem">{children}</div>;
 
 Alert.propTypes = {
-  variant: PropTypes.oneOf(["warning"]),
+  variant: PropTypes.oneOf(["warning", "info"]),
   children: PropTypes.node,
 };
 

--- a/src/components/music/InstrumentDutyEditor.tsx
+++ b/src/components/music/InstrumentDutyEditor.tsx
@@ -184,6 +184,9 @@ export const InstrumentDutyEditor = ({
           {l10n("FIELD_TEST_INSTRUMENT")}
         </Button>
       </FormRow>
+      {instrument.subpattern_enabled && (
+        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+      )}
     </>
   );
 };

--- a/src/components/music/InstrumentDutyEditor.tsx
+++ b/src/components/music/InstrumentDutyEditor.tsx
@@ -10,6 +10,7 @@ import { InstrumentLengthForm } from "./InstrumentLengthForm";
 import { InstrumentVolumeEditor } from "./InstrumentVolumeEditor";
 import { ipcRenderer } from "electron";
 import { Button } from "ui/buttons/Button";
+import Alert, { AlertItem } from "components/library/Alert";
 
 const dutyOptions = [
   {
@@ -185,7 +186,11 @@ export const InstrumentDutyEditor = ({
         </Button>
       </FormRow>
       {instrument.subpattern_enabled && (
-        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+        <FormRow>
+          <Alert variant="info">
+            <AlertItem>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</AlertItem>
+          </Alert>
+        </FormRow>
       )}
     </>
   );

--- a/src/components/music/InstrumentNoiseEditor.tsx
+++ b/src/components/music/InstrumentNoiseEditor.tsx
@@ -11,6 +11,8 @@ import { InstrumentVolumeEditor } from "./InstrumentVolumeEditor";
 import { NoiseMacroEditorForm } from "./NoiseMacroEditorForm";
 import { ipcRenderer } from "electron";
 import { Button } from "ui/buttons/Button";
+import { SubPatternCell } from "lib/helpers/uge/song/SubPatternCell";
+import { cloneDeep } from "lodash";
 
 interface InstrumentNoiseEditorProps {
   id: string;
@@ -37,6 +39,21 @@ export const InstrumentNoiseEditor = ({
       );
     };
 
+  const onChangeSubpattern = (macros: number[]) => {
+    const newSubPattern = cloneDeep(instrument.subpattern);
+    macros.forEach((value, i) => {
+      newSubPattern[i].note = value + 36;
+    });
+
+    dispatch(
+      trackerDocumentActions.editSubPattern({
+        instrumentId: instrument.index,
+        instrumentType: "noise",
+        subpattern: newSubPattern,
+      })
+    );
+  };
+
   const onTestInstrument = () => {
     ipcRenderer.send("music-data-send", {
       action: "preview",
@@ -46,6 +63,14 @@ export const InstrumentNoiseEditor = ({
       square2: false,
     });
   };
+
+  const noiseMacros = !instrument.subpattern_enabled
+    ? []
+    : instrument.subpattern
+        // .slice(0, 6)
+        .map((subpatternCell: SubPatternCell) =>
+          subpatternCell && subpatternCell.note ? subpatternCell.note - 36 : 0
+        );
 
   return (
     <>
@@ -78,11 +103,14 @@ export const InstrumentNoiseEditor = ({
         />
       </FormRow>
 
-      {instrument.noise_macro ? (
-        <NoiseMacroEditorForm
-          macros={instrument.noise_macro}
-          onChange={onChangeField("noise_macro")}
-        />
+      {/* Disable the noise macro preview for now. In the future it should edit the subpattern visually  */}
+      {false ? ( // {instrument.noise_macro ? (
+        <>
+          <NoiseMacroEditorForm
+            macros={noiseMacros}
+            onChange={onChangeSubpattern}
+          />
+        </>
       ) : (
         ""
       )}
@@ -94,6 +122,9 @@ export const InstrumentNoiseEditor = ({
           {l10n("FIELD_TEST_INSTRUMENT")}
         </Button>
       </FormRow>
+      {instrument.subpattern_enabled && (
+        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+      )}
     </>
   );
 };

--- a/src/components/music/InstrumentNoiseEditor.tsx
+++ b/src/components/music/InstrumentNoiseEditor.tsx
@@ -13,6 +13,7 @@ import { ipcRenderer } from "electron";
 import { Button } from "ui/buttons/Button";
 import { SubPatternCell } from "lib/helpers/uge/song/SubPatternCell";
 import { cloneDeep } from "lodash";
+import Alert, { AlertItem } from "components/library/Alert";
 
 interface InstrumentNoiseEditorProps {
   id: string;
@@ -123,7 +124,11 @@ export const InstrumentNoiseEditor = ({
         </Button>
       </FormRow>
       {instrument.subpattern_enabled && (
-        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+        <FormRow>
+          <Alert variant="info">
+            <AlertItem>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</AlertItem>
+          </Alert>
+        </FormRow>
       )}
     </>
   );

--- a/src/components/music/InstrumentSubpatternEditor.tsx
+++ b/src/components/music/InstrumentSubpatternEditor.tsx
@@ -17,7 +17,7 @@ import {
 } from "./musicClipboardHelpers";
 import { KeyWhen, getKeys } from "lib/keybindings/keyBindings";
 import { Position } from "lib/sprite/spriteData";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import trackerActions from "store/features/tracker/trackerActions";
 import { SelectionRect } from "./SongPianoRoll";
 import scrollIntoView from "scroll-into-view-if-needed";
@@ -25,6 +25,7 @@ import trackerDocumentActions from "store/features/trackerDocument/trackerDocume
 import { cloneDeep, mergeWith } from "lodash";
 import clipboardActions from "store/features/clipboard/clipboardActions";
 import { clipboard } from "store/features/clipboard/clipboardHelpers";
+import { RootState } from "store/configureStore";
 
 const CHANNEL_FIELDS = 4;
 const ROW_SIZE = CHANNEL_FIELDS * 1;
@@ -217,6 +218,10 @@ export const InstrumentSubpatternEditor = ({
   );
 
   const [activeField, setActiveField] = useState<number | undefined>();
+
+  const subpatternEditorFocus = useSelector(
+    (state: RootState) => state.tracker.subpatternEditorFocus
+  );
 
   const activeFieldRef = useRef<HTMLSpanElement>(null);
   if (activeFieldRef && activeFieldRef.current) {
@@ -838,15 +843,17 @@ export const InstrumentSubpatternEditor = ({
 
   // Clipboard
   useEffect(() => {
-    window.addEventListener("copy", onCopy);
-    window.addEventListener("cut", onCut);
-    window.addEventListener("paste", onPaste);
-    return () => {
-      window.removeEventListener("copy", onCopy);
-      window.removeEventListener("cut", onCut);
-      window.removeEventListener("paste", onPaste);
-    };
-  }, [onCopy, onCut, onPaste]);
+    if (subpatternEditorFocus) {
+      window.addEventListener("copy", onCopy);
+      window.addEventListener("cut", onCut);
+      window.addEventListener("paste", onPaste);
+      return () => {
+        window.removeEventListener("copy", onCopy);
+        window.removeEventListener("cut", onCut);
+        window.removeEventListener("paste", onPaste);
+      };
+    }
+  }, [onCopy, onCut, onPaste, subpatternEditorFocus]);
 
   const onChangeField = useCallback(
     (editValue: boolean) => {

--- a/src/components/music/InstrumentSubpatternEditor.tsx
+++ b/src/components/music/InstrumentSubpatternEditor.tsx
@@ -191,8 +191,8 @@ const renderJump = (n: number | null): string => {
 
 const renderOffset = (n: number | null): string => {
   if (n === null) return "...";
-  if (n - 32 >= 0) return `+${(n - 32).toString().padStart(2, "0")}`;
-  return `-${Math.abs(n - 32)
+  if (n - 36 >= 0) return `+${(n - 36).toString().padStart(2, "0")}`;
+  return `-${Math.abs(n - 36)
     .toString()
     .padStart(2, "0")}`;
 };
@@ -401,11 +401,11 @@ export const InstrumentSubpatternEditor = ({
               if (el.innerText !== "...") {
                 newValue = Math.min(
                   10 * parseInt(el.innerText[2], 10) + value,
-                  32
+                  36
                 );
               }
           }
-          editSubPatternCell("note")(parseInt(`${newValue ?? 90}`) + 32);
+          editSubPatternCell("note")(parseInt(`${newValue ?? 90}`) + 36);
         }
       };
 

--- a/src/components/music/InstrumentWaveEditor.tsx
+++ b/src/components/music/InstrumentWaveEditor.tsx
@@ -119,6 +119,9 @@ export const InstrumentWaveEditor = ({
           {l10n("FIELD_TEST_INSTRUMENT")}
         </Button>
       </FormRow>
+      {instrument.subpattern_enabled && (
+        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+      )}
     </>
   );
 };

--- a/src/components/music/InstrumentWaveEditor.tsx
+++ b/src/components/music/InstrumentWaveEditor.tsx
@@ -9,6 +9,7 @@ import { InstrumentLengthForm } from "./InstrumentLengthForm";
 import { WaveEditorForm } from "./WaveEditorForm";
 import { ipcRenderer } from "electron";
 import { Button } from "ui/buttons/Button";
+import Alert, { AlertItem } from "components/library/Alert";
 
 const volumeOptions = [
   {
@@ -120,7 +121,11 @@ export const InstrumentWaveEditor = ({
         </Button>
       </FormRow>
       {instrument.subpattern_enabled && (
-        <FormRow>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</FormRow>
+        <FormRow>
+          <Alert variant="info">
+            <AlertItem>{l10n("MESSAGE_NOT_PREVIEW_SUBPATTERN")}</AlertItem>
+          </Alert>
+        </FormRow>
       )}
     </>
   );

--- a/src/components/music/SongEditor.tsx
+++ b/src/components/music/SongEditor.tsx
@@ -263,18 +263,18 @@ export const SongEditor: FC<SongEditorProps> = ({ multiColumn }) => {
                   onChange={onChangeInstrumentName(selectedInstrument.type)}
                 />
 
-                <DropdownButton
+                {/* <DropdownButton
                   size="small"
                   variant="transparent"
                   menuDirection="right"
                 >
-                  {/* <MenuItem onClick={onCopyVar}>
+                  <MenuItem onClick={onCopyVar}>
                   {l10n("MENU_VARIABLE_COPY_EMBED")}
                 </MenuItem>
                 <MenuItem onClick={onCopyChar}>
                   {l10n("MENU_VARIABLE_COPY_EMBED_CHAR")}
-                </MenuItem> */}
-                </DropdownButton>
+                </MenuItem>
+                </DropdownButton> */}
               </FormHeader>
 
               <StickyTabs>

--- a/src/components/music/SongPianoRoll.tsx
+++ b/src/components/music/SongPianoRoll.tsx
@@ -297,7 +297,7 @@ export const SongPianoRoll = ({
 
   const setPlaybackPosition = useCallback(
     (e: any) => {
-      const col = Math.floor(e.offsetX / CELL_SIZE);
+      const col = clamp(Math.floor(e.offsetX / CELL_SIZE), 0, 63);
 
       dispatch(
         trackerActions.setDefaultStartPlaybackPosition([sequenceId, col])
@@ -537,7 +537,7 @@ export const SongPianoRoll = ({
   const handleMouseDown = useCallback(
     (e: any) => {
       if (!pattern) return;
-      const col = Math.floor(e.offsetX / CELL_SIZE);
+      const col = clamp(Math.floor(e.offsetX / CELL_SIZE), 0, 63);
       const note = 12 * 6 - 1 - Math.floor(e.offsetY / CELL_SIZE);
       const cell = pattern[col][selectedChannel];
 

--- a/src/components/music/helpers/player.ts
+++ b/src/components/music/helpers/player.ts
@@ -420,34 +420,34 @@ function patchRom(targetRomFile: Uint8Array, song: Song, startAddr: number) {
 
   for (let n = 0; n < song.duty_instruments.length; n++) {
     const instr = song.duty_instruments[n];
-    if (instr.subpattern_enabled) {
-      subpatternAddr[`DutySP${instr.index}`] = addr;
-      const pattern = song.duty_instruments[n].subpattern;
-      for (let idx = 0; idx < 32; idx++) {
-        writeSubPatternCell(pattern[idx], idx === 32 - 1);
-      }
+    subpatternAddr[`DutySP${instr.index}`] = instr.subpattern_enabled
+      ? addr
+      : 0;
+    const pattern = song.duty_instruments[n].subpattern;
+    for (let idx = 0; idx < 32; idx++) {
+      writeSubPatternCell(pattern[idx], idx === 32 - 1);
     }
   }
 
   for (let n = 0; n < song.wave_instruments.length; n++) {
     const instr = song.wave_instruments[n];
-    if (instr.subpattern_enabled) {
-      subpatternAddr[`WaveSP${instr.index}`] = addr;
-      const pattern = song.wave_instruments[n].subpattern;
-      for (let idx = 0; idx < 32; idx++) {
-        writeSubPatternCell(pattern[idx], idx === 32 - 1);
-      }
+    subpatternAddr[`WaveSP${instr.index}`] = instr.subpattern_enabled
+      ? addr
+      : 0;
+    const pattern = song.wave_instruments[n].subpattern;
+    for (let idx = 0; idx < 32; idx++) {
+      writeSubPatternCell(pattern[idx], idx === 32 - 1);
     }
   }
 
   for (let n = 0; n < song.noise_instruments.length; n++) {
     const instr = song.noise_instruments[n];
-    if (instr.subpattern_enabled) {
-      subpatternAddr[`NoiseSP${instr.index}`] = addr;
-      const pattern = song.noise_instruments[n].subpattern;
-      for (let idx = 0; idx < 32; idx++) {
-        writeSubPatternCell(pattern[idx], idx === 32 - 1);
-      }
+    subpatternAddr[`NoiseSP${instr.index}`] = instr.subpattern_enabled
+      ? addr
+      : 0;
+    const pattern = song.noise_instruments[n].subpattern;
+    for (let idx = 0; idx < 32; idx++) {
+      writeSubPatternCell(pattern[idx], idx === 32 - 1);
     }
   }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1322,5 +1322,6 @@
   "MESSAGE_ADD_MOD_FILES": "Please add .mod files to the project assets/music folder.",
   "MESSAGE_WHAT_ABOUT_UGE": "What about .uge files?",
   "MESSAGE_USE_UGE_FILES": "To use .uge files in your project, change the music format from MOD to UGE in 'Settings'. You can change this at any time in 'Settings'.",
-  "MESSAGE_ENABLE_HUGE": "Enable UGE file format"
+  "MESSAGE_ENABLE_HUGE": "Enable UGE file format",
+  "MESSAGE_NOT_PREVIEW_SUBPATTERN": "Instrument and note preview might not be accurate when subpattern is enabled."
 }

--- a/src/lib/helpers/uge/ugeHelper.ts
+++ b/src/lib/helpers/uge/ugeHelper.ts
@@ -125,10 +125,9 @@ export const loadUGESong = (data: ArrayBuffer): Song | null => {
         subpattern.push({
           note: note === 90 ? null : note,
           jump,
-          effectcode:
-            effectcode === 0 && effectparam === 90 ? null : effectcode,
+          effectcode: effectcode === 0 && effectparam === 0 ? null : effectcode,
           effectparam:
-            effectcode === 0 && effectparam === 90 ? null : effectparam,
+            effectcode === 0 && effectparam === 0 ? null : effectparam,
         });
       }
     }
@@ -456,7 +455,7 @@ export const saveUGESong = (song: Song): ArrayBuffer => {
       addUint32(0);
       addUint32(subpattern.jump ?? 0);
       addUint32(subpattern.effectcode ?? 0);
-      addUint8(subpattern.effectparam ?? 90);
+      addUint8(subpattern.effectparam ?? 0);
     }
   }
   function addDutyInstrument(type: number, i: DutyInstrument) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes

* **What is the current behavior?** (You can also link to an open issue here)
A set of bugs reported by Tronimal with the new uge v6 support

* **What is the new behavior (if this is a feature change)?**

Fixes:

- Write empty subpatterns to song preview rom to avoid change on the memory address of patterns and orders that were causing playback preview not working when disabling or enabling subpatterns for an instrument
- Fix empty effect rendering in subpatterns (use 000 instead of 05A)
- Fix crash when clicking the rightmost line of the grid

Temp changes:

- Show message about note/instrument preview maybe incorrect when subpattern enabled
- Hide noise macro editor for now


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
