### PR TITLE
Fix compile to .pocket

### DIFF
--- a/appData/src/gb/Makefile.common
+++ b/appData/src/gb/Makefile.common
@@ -63,7 +63,7 @@ all:	settings directories BUILD
 .SECONDARY:	$(OBJS)
 
 AP:
-	$(eval PLATFORM = -mgbz80:ap)
+	$(eval PLATFORM = -msm83:ap)
 	$(eval TARGET = $(patsubst %.gb,%.pocket,$(TARGET)))
 	@echo "Analogue pocket build"
 

--- a/src/lib/compiler/buildMakeScript.js
+++ b/src/lib/compiler/buildMakeScript.js
@@ -50,7 +50,7 @@ export default async (
   }
 
   if (targetPlatform === "pocket") {
-    CFLAGS += " -mgbz80:ap";
+    CFLAGS += " -msm83:ap";
   }
 
   const srcRoot = `${buildRoot}/src/**/*.@(c|s)`;
@@ -166,7 +166,7 @@ export const getBuildCommands = async (
       }
 
       if (targetPlatform === "pocket") {
-        buildArgs.push("-mgbz80:ap");
+        buildArgs.push("-msm83:ap");
       }
 
       buildArgs.push(
@@ -277,7 +277,7 @@ export const buildLinkFlags = (
     // SGB
     sgb ? ["-Wm-ys"] : [],
     // Pocket
-    targetPlatform === "pocket" ? ["-mgbz80:ap"] : [],
+    targetPlatform === "pocket" ? ["-msm83:ap"] : [],
     // Debug emulicious
     profile ? ["-Wf--debug", "-Wl-m", "-Wl-w", "-Wl-y"] : [],
     // Music Driver


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Compiling to pocket fails with a ```Error: ../_gbstools/gbdk/bin/lcc: old "gbz80" SDCC PORT name specified (in "-mgbz80:ap"). Use "sm83" instead. You must update your build settings.``` message

* **What is the new behavior (if this is a feature change)?**

Compiling to pocket works

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
