### PR TITLE
Check that plugin engine json has fields before adding

### DIFF
--- a/src/lib/project/engineFields.ts
+++ b/src/lib/project/engineFields.ts
@@ -103,7 +103,9 @@ export const initEngineFields = async (projectRoot: string) => {
     if (await pathExists(englinePluginJsonPath)) {
       try {
         const pluginEngine = await readJSON(englinePluginJsonPath);
-        fields = fields.concat(pluginEngine.fields);
+        if (pluginEngine.fields && pluginEngine.fields.length > 0) {
+          fields = fields.concat(pluginEngine.fields);
+        }
       } catch (e) {
         console.warn(e);
       }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

if an `engine.json` file is added to a plugin and it doesn't contain a `fields` array, then all the other engine fields won't load in the project settings 

![image](https://github.com/chrismaltby/gb-studio/assets/54246642/94bff008-6087-49c0-9212-25bf71568a19)

This is bad because we ask people to do exactly that to update their plugins to the latest version 🤦 

* **What is the new behavior (if this is a feature change)?**

Added a guard against empty field arrays.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope

* **Other information**:

Reported on Discord [here](https://discord.com/channels/554713715442712616/570925559346102273/1204800389476651028)