### PR TITLE
Construct rom path instead of using string

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -985,7 +985,7 @@ ipcMain.handle(
           `${outputRoot}/build/${buildType}`,
           `${projectRoot}/build/${buildType}`
         );
-        shell.openPath(`${projectRoot}/build/${buildType}`);
+        shell.openPath(Path.join(projectRoot, "build", buildType));
         buildLog(`-`);
         buildLog(
           `Success! ${
@@ -1109,7 +1109,7 @@ ipcMain.handle(
         warnings,
       });
 
-      const exportRoot = `${projectRoot}/build/src`;
+      const exportRoot = Path.join(projectRoot, "build", "src");
 
       if (exportType === "data") {
         const dataSrcTmpPath = Path.join(outputRoot, "src", "data");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (I think)

* **What is the current behavior?** (You can also link to an open issue here)

Reported by Tronimal via DM. Getting the following error when exporting to rom on Windows (rom exports fine and folder is created but it fails to open).

![image](https://github.com/chrismaltby/gb-studio/assets/54246642/c1ad3647-6d7c-4341-89e2-94ac2b086b75)

* **What is the new behavior (if this is a feature change)?**

I _think_ the issue should be solved, but I don't have a windows machine to test 😅 

I also changed the export path in case it was failing too.

