### PR TITLE
Use default scene types if there's none in engine.json

### DIFF
--- a/appData/src/gb/engine.json
+++ b/appData/src/gb/engine.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-e4",
+  "version": "3.3.0-e0",
   "fields": [
     {
       "key": "INPUT_PLATFORM_JUMP",

--- a/src/lib/project/ejectEngineChangelog.ts
+++ b/src/lib/project/ejectEngineChangelog.ts
@@ -626,6 +626,16 @@ const changes: EngineChange[] = [
       ].join("\n"),
     modifiedFiles: ["include/sio.h", "src/core/sio.c"],
   },
+  {
+    version: "3.3.0-e0",
+    description:
+      "Updates\n" + ["   * Added scene types to engine.json"].join("\n"),
+    modifiedFiles: [
+      "engine.json",
+      "src/gb/include/data/scene_types.h",
+      "src/gb/include/gbs_types.h",
+    ],
+  },
 ];
 
 const ejectEngineChangelog = (currentVersion: string) => {

--- a/src/lib/project/sceneTypes.ts
+++ b/src/lib/project/sceneTypes.ts
@@ -15,6 +15,33 @@ export interface SceneTypeSyncResult {
 
 export const sceneTypesEmitter = new EventEmitter.EventEmitter();
 
+const defaultSceneTypes = [
+  {
+    key: "TOPDOWN",
+    label: "GAMETYPE_TOP_DOWN",
+  },
+  {
+    key: "PLATFORM",
+    label: "GAMETYPE_PLATFORMER",
+  },
+  {
+    key: "ADVENTURE",
+    label: "GAMETYPE_ADVENTURE",
+  },
+  {
+    key: "SHMUP",
+    label: "GAMETYPE_SHMUP",
+  },
+  {
+    key: "POINTNCLICK",
+    label: "GAMETYPE_POINT_N_CLICK",
+  },
+  {
+    key: "LOGO",
+    label: "GAMETYPE_LOGO",
+  },
+];
+
 export const loadSceneTypes = async (
   projectRoot: string
 ): Promise<SceneTypeSchema[]> => {
@@ -42,6 +69,10 @@ export const loadSceneTypes = async (
     sceneTypes = localEngine.sceneTypes;
   } else if (defaultEngine && defaultEngine.sceneTypes) {
     sceneTypes = defaultEngine.sceneTypes;
+  }
+
+  if (!sceneTypes || (sceneTypes && sceneTypes.length === 0)) {
+    sceneTypes = defaultSceneTypes;
   }
 
   const enginePlugins = glob.sync(`${pluginsPath}/*/engine`);

--- a/src/store/features/engine/engineState.ts
+++ b/src/store/features/engine/engineState.ts
@@ -22,7 +22,6 @@ export type EngineFieldSchema = {
 export type SceneTypeSchema = {
   key: string;
   label: string;
-  file: string;
 };
 
 export interface EngineState {


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

A project that has an ejected engine with an engine.json without the default scene types then no scene type appears in the scene type selector or be compiled and then the rom will crash immediatly on start.

* **What is the new behavior (if this is a feature change)?**

Default scene types will always be used if not scenes types exist in the engine.json

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
