### PR TITLE
Fix: Pressing "E" doesn't work on Wave editor field

### DIFF
--- a/src/components/music/WaveEditorInput.tsx
+++ b/src/components/music/WaveEditorInput.tsx
@@ -25,6 +25,7 @@ const validKeys = [
   "B",
   "C",
   "D",
+  "E",
   "F",
 ];
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

Pressing "e" doesn't work on the Wave editor field 

* **What is the new behavior (if this is a feature change)?**

"e" works

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

🤦 
