### PR TITLE
Fix empty title in Script navigator sidebar

### DIFF
--- a/src/lib/project/migrateProject.ts
+++ b/src/lib/project/migrateProject.ts
@@ -41,6 +41,7 @@ import {
   SpriteSheetData,
 } from "shared/lib/entities/entitiesTypes";
 import {
+  customEventName,
   isUnionValue,
   isUnionVariableValue,
 } from "shared/lib/entities/entitiesHelpers";
@@ -53,7 +54,7 @@ import {
 const indexById = <T>(arr: T[]) => keyBy(arr, "id");
 
 export const LATEST_PROJECT_VERSION = "3.3.0";
-export const LATEST_PROJECT_MINOR_VERSION = "5";
+export const LATEST_PROJECT_MINOR_VERSION = "6";
 
 const ensureProjectAssetSync = (
   relativePath: string,
@@ -2372,6 +2373,18 @@ const migrateFrom330r4To330r5Events = (data: ProjectData): ProjectData => {
   };
 };
 
+const migrateFrom330r5To330r6Events = (data: ProjectData): ProjectData => {
+  return {
+    ...data,
+    customEvents: (data.customEvents || []).map((customEvent, index) => {
+      return {
+        ...customEvent,
+        name: customEvent.name ? customEvent.name : `Script ${index + 1}`,
+      };
+    }),
+  };
+};
+
 const migrateProject = (
   project: ProjectData,
   projectRoot: string,
@@ -2549,6 +2562,10 @@ const migrateProject = (
     if (release === "4") {
       data = migrateFrom330r4To330r5Events(data);
       release = "5";
+    }
+    if (release === "5") {
+      data = migrateFrom330r5To330r6Events(data);
+      release = "6";
     }
   }
 

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -2485,7 +2485,7 @@ const addCustomEvent: CaseReducer<
   const customEventsTotal = localCustomEventSelectors.selectTotal(state);
   const newCustomEvent: CustomEventNormalized = {
     id: action.payload.customEventId,
-    name: "",
+    name: `Script ${customEventsTotal + 1}`,
     description: "",
     variables: {},
     actors: {},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

New scripts are created with empty name. This used to be replaced with a default name (`Script n`) in the navigation sidebar, but now they're appearing as empty.

* **What is the new behavior (if this is a feature change)?**

Scripts are now created with a default name, and old scripts with empty name are migrated to have a name instead of empty string.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Opted by creating the scripts with default name moving forward (instead of an empty string). The other option was map the custom event list in the navigator component and use `entitiesHelper.customEventName` to generate a default name dynamically.