### PR TITLE
Use number for flag field on if flag set event

### DIFF
--- a/src/components/forms/FlagSelect.tsx
+++ b/src/components/forms/FlagSelect.tsx
@@ -6,10 +6,10 @@ import { Select, SelectCommonProps } from "ui/form/Select";
 
 interface FlagSelectProps extends SelectCommonProps {
   name: string;
-  value?: string;
+  value?: number;
   variableId: string;
   entityId: string;
-  onChange?: (newId: string) => void;
+  onChange?: (newFlag: number) => void;
 }
 
 export const FlagSelect: FC<FlagSelectProps> = ({
@@ -38,7 +38,7 @@ export const FlagSelect: FC<FlagSelectProps> = ({
       }
       return {
         label: namedLabel,
-        value: `${i}`,
+        value: i,
       };
     });
 
@@ -46,7 +46,7 @@ export const FlagSelect: FC<FlagSelectProps> = ({
     flagOptions.find((o) => (value ? o.value === value : o.value === value)) ||
     flagOptions[0];
 
-  const onFieldChange = (newOption: { value: string }) => {
+  const onFieldChange = (newOption: { value: number }) => {
     if (onChange) {
       onChange(newOption.value);
     }

--- a/src/components/script/ScriptEventFormInput.tsx
+++ b/src/components/script/ScriptEventFormInput.tsx
@@ -299,7 +299,7 @@ const ScriptEventFormInput = ({
         name={id}
         variableId={argValue(args.variable) as string}
         entityId={entityId}
-        value={String(value ?? defaultValue)}
+        value={Number(value ?? defaultValue)}
         onChange={onChangeField}
       ></FlagSelect>
     );

--- a/src/lib/project/migrateProject.ts
+++ b/src/lib/project/migrateProject.ts
@@ -55,7 +55,7 @@ import { ensureNumber } from "shared/types";
 const indexById = <T>(arr: T[]) => keyBy(arr, "id");
 
 export const LATEST_PROJECT_VERSION = "4.0.0";
-export const LATEST_PROJECT_MINOR_VERSION = "3";
+export const LATEST_PROJECT_MINOR_VERSION = "4";
 
 const ensureProjectAssetSync = (
   relativePath: string,
@@ -2521,6 +2521,26 @@ export const migrateFrom400r2To400r3Event = (
   return event;
 };
 
+/* Version 4.0.0 r4 updates EVENT_IF_FLAGS_COMPARE to use a number 
+for flags instead of a string. 
+ */
+export const migrateFrom400r3To400r4Event = (
+  event: ScriptEvent
+): ScriptEvent => {
+  const migrateMeta = generateMigrateMeta(event);
+
+  if (event.args && event.command === "EVENT_IF_FLAGS_COMPARE") {
+    return migrateMeta({
+      ...event,
+      args: {
+        ...event.args,
+        flag: Number(event.args.flag),
+      },
+    });
+  }
+  return event;
+};
+
 const migrateProject = (
   project: ProjectData,
   projectRoot: string,
@@ -2721,6 +2741,10 @@ const migrateProject = (
     if (release === "2") {
       data = applyEventsMigration(data, migrateFrom400r2To400r3Event);
       release = "3";
+    }
+    if (release === "3") {
+      data = applyEventsMigration(data, migrateFrom400r3To400r4Event);
+      release = "4";
     }
   }
 

--- a/test/migrate/migrate400releases.test.js
+++ b/test/migrate/migrate400releases.test.js
@@ -1,6 +1,7 @@
 import {
   migrateFrom400r1To400r2Event,
   migrateFrom400r2To400r3Event,
+  migrateFrom400r3To400r4Event,
 } from "../../src/lib/project/migrateProject";
 import initElectronL10N from "../../src/lib/lang/initElectronL10N";
 
@@ -258,6 +259,56 @@ test("should migrate x/y coordinate values as 0 in replace tile event if invalid
         type: "number",
         value: 1,
       },
+    },
+  });
+});
+
+test("should migrate flag values to number if string", () => {
+  const oldEvent = {
+    command: "EVENT_IF_FLAGS_COMPARE",
+    args: {
+      variable: "L0",
+      flag: "10",
+    },
+    children: {
+      true: [{ command: "MOCK_TRUE" }],
+      false: [{ command: "MOCK_FALSE" }],
+    },
+  };
+  expect(migrateFrom400r3To400r4Event(oldEvent)).toMatchObject({
+    command: "EVENT_IF_FLAGS_COMPARE",
+    args: {
+      variable: "L0",
+      flag: 10,
+    },
+    children: {
+      true: [{ command: "MOCK_TRUE" }],
+      false: [{ command: "MOCK_FALSE" }],
+    },
+  });
+});
+
+test("should keep the flag value as a number if number", () => {
+  const oldEvent = {
+    command: "EVENT_IF_FLAGS_COMPARE",
+    args: {
+      variable: "L0",
+      flag: 10,
+    },
+    children: {
+      true: [{ command: "MOCK_TRUE" }],
+      false: [{ command: "MOCK_FALSE" }],
+    },
+  };
+  expect(migrateFrom400r3To400r4Event(oldEvent)).toMatchObject({
+    command: "EVENT_IF_FLAGS_COMPARE",
+    args: {
+      variable: "L0",
+      flag: 10,
+    },
+    children: {
+      true: [{ command: "MOCK_TRUE" }],
+      false: [{ command: "MOCK_FALSE" }],
     },
   });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix for #1407

* **What is the current behavior?** (You can also link to an open issue here)

The new flag select field in 4.0 returns a string instead of a number which is what the If Flag Set event expects. This meant that the comparison was always failing.

* **What is the new behavior (if this is a feature change)?**

Make the flag select return a number and migrate any flag value that has been set to a string.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
