### PR TITLE
Fix app freezing when selecting effect field in music tracker

### DIFF
--- a/src/components/music/SongTracker.tsx
+++ b/src/components/music/SongTracker.tsx
@@ -158,15 +158,21 @@ export const SongTracker = ({
   const [activeField, setActiveField] = useState<number | undefined>();
   const channelId = useAppSelector((state) => state.tracker.selectedChannel);
 
-  if (activeField !== undefined) {
-    const newChannelId = Math.floor((activeField % ROW_SIZE) / CHANNEL_FIELDS);
-    dispatch(trackerActions.setSelectedChannel(newChannelId));
-    if (activeField % CHANNEL_FIELDS >= 2) {
-      dispatch(
-        trackerActions.setSelectedEffectCell(Math.floor(activeField / ROW_SIZE))
+  useEffect(() => {
+    if (activeField !== undefined) {
+      const newChannelId = Math.floor(
+        (activeField % ROW_SIZE) / CHANNEL_FIELDS
       );
+      dispatch(trackerActions.setSelectedChannel(newChannelId));
+      if (activeField % CHANNEL_FIELDS >= 2) {
+        dispatch(
+          trackerActions.setSelectedEffectCell(
+            Math.floor(activeField / ROW_SIZE)
+          )
+        );
+      }
     }
-  }
+  }, [activeField, dispatch]);
 
   const playingRowRef = useRef<HTMLSpanElement>(null);
   if (playingRowRef && playingRowRef.current) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for #1409

* **What is the current behavior?** (You can also link to an open issue here)

App freezes when selecting the effect column in the tracker due to an infinite rerender of MusicUgePage.

* **What is the new behavior (if this is a feature change)?**

The side effects of selecting a new field setting the selected channel and showing the effect editor if the column is one of the effects ones are now wrapped on a useEffect hook to avoid the rerendering.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

The issue was introduce with the changes in https://github.com/chrismaltby/gb-studio/commit/16d252d1704b62b82f5e033aecda7fbad52fc001, not sure why it wasn't happening until then tho, since I removed the useEffect a while ago 🤔 