### PR TITLE
Update the engine to support rumble for mbc5 carts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix "Add Flags" event tooltips localisation.
 - Fix issue where some sidebar inputs would appear above script tabs when scrolled
+- Fix rumble support when using MBC5 cartridge [@pau-tomas](https://github.com/pau-tomas)
 
 ## [4.0.0-beta2]
 

--- a/appData/src/gb/include/vm_gameboy.h
+++ b/appData/src/gb/include/vm_gameboy.h
@@ -35,7 +35,9 @@ void vm_poll(SCRIPT_CTX * THIS, INT16 idx, INT16 res, UBYTE event_mask) OLDCALL 
 void vm_set_sprite_mode(SCRIPT_CTX * THIS, UBYTE mode) OLDCALL BANKED;
 void vm_replace_tile_xy(SCRIPT_CTX * THIS, UBYTE x, UBYTE y, UBYTE tileset_bank, const tileset_t * tileset, INT16 idx_start_tile) OLDCALL BANKED;
 
+#ifndef RUMBLE_ENABLE
 #define RUMBLE_ENABLE 0x20u
+#endif 
 void vm_rumble(SCRIPT_CTX * THIS, UBYTE enable) OLDCALL BANKED;
 
 void vm_load_tileset(SCRIPT_CTX * THIS, INT16 idx, UBYTE bank, const background_t * background) OLDCALL BANKED;

--- a/src/lib/compiler/buildMakeScript.ts
+++ b/src/lib/compiler/buildMakeScript.ts
@@ -14,6 +14,7 @@ type BuildOptions = {
   platform: string;
   batteryless: boolean;
   targetPlatform: "gb" | "pocket";
+  cartType: "mbc3" | "mbc5";
 };
 
 const buildMakeScript = async (
@@ -26,6 +27,7 @@ const buildMakeScript = async (
     platform,
     batteryless,
     targetPlatform,
+    cartType,
   }: BuildOptions
 ) => {
   const cmds = platform === "win32" ? [""] : ["#!/bin/bash", "set -e"];
@@ -54,6 +56,9 @@ const buildMakeScript = async (
   if (batteryless) {
     CFLAGS += " -DBATTERYLESS";
   }
+
+  const rumbleBit = cartType === "mbc3" ? "0x20u" : "0x08u";
+  CFLAGS += `-DRUMBLE_ENABLE=${rumbleBit}`;
 
   if (debug) {
     CFLAGS += " -Wf--debug -Wl-y";
@@ -113,6 +118,7 @@ export const getBuildCommands = async (
     platform,
     batteryless,
     targetPlatform,
+    cartType,
   }: BuildOptions
 ) => {
   const srcRoot = `${buildRoot}/src/**/*.@(c|s)`;
@@ -163,6 +169,9 @@ export const getBuildCommands = async (
       if (batteryless) {
         buildArgs.push("-DBATTERYLESS");
       }
+
+      const rumbleBit = cartType === "mbc3" ? "0x20u" : "0x08u";
+      buildArgs.push(`-DRUMBLE_ENABLE=${rumbleBit}`);
 
       if (debug) {
         buildArgs.push("-Wf--fverbose-asm");
@@ -266,7 +275,7 @@ export const buildLinkFlags = (
     .toUpperCase()
     .replace(/[^A-Z]*/g, "")
     .substring(0, 15);
-  const cart = cartType === "mbc3" ? "0x10" : "0x1B";
+  const cart = cartType === "mbc3" ? "0x10" : "0x1E";
   return ([] as Array<string>).concat(
     // General
     [

--- a/src/lib/compiler/makeBuild.ts
+++ b/src/lib/compiler/makeBuild.ts
@@ -72,6 +72,11 @@ const makeBuild = async ({
   } else {
     env.MUSIC_DRIVER = "GBT_PLAYER";
   }
+  if (settings.cartType === "mbc3") {
+    env.RUMBLE_ENABLE = 0x20;
+  } else {
+    env.RUMBLE_ENABLE = 0x08;
+  }
 
   // Populate /obj with cached data
   await fetchCachedObjData(buildRoot, tmpPath, env);
@@ -85,6 +90,7 @@ const makeBuild = async ({
     debug,
     platform: process.platform,
     targetPlatform,
+    cartType: settings.cartType,
   });
 
   const options = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix / Feature

* **What is the current behavior?** (You can also link to an open issue here)

The VM_RUMBLE command works only with the insidegadgets MBC3 carts with rumble ([they’re out of stock](<https://shop.insidegadgets.com/product/gameboy-4mb-32kb-fram-mbc3-with-rtcrumble-plus-2x-2mb-mode-flash-cart-build-it-yourself/>)). Because those carts also had RTC they operated slightly different than the “official” rumble carts like Pokémon Pinball.

This is what the IG page says about those carts ```How to use the rumble motor
You need to write the byte 0x20 to 0x4000-0x5FFF. Usually games write 0x08 but that would conflict with the RTC so you need to patch games to use 0x20 instead. ```. 

`0x20` is what the `RUMBLE_ENABLE` flag is set to in our `vm_gameboy.h`. This means that emulators that expect the “official” way to do rumble (using `0x08`) won't work. For example, the recenlty released Sameboy for iOS. 

On top of that, even if you ejected the engine to update `RUMBLE_ENABLE` to `0x08` it won't work because we're always setting the cart header for mbc5 to `0x1B    MBC5+RAM+BATTERY` instead of `0x1E    MBC5+RUMBLE+RAM+BATTERY`.

* **What is the new behavior (if this is a feature change)?**

When MBC5 is selected, then set the cart header to `0x1E` and set `RUMBLE_ENABLE`  to `0x08`. That way both methods (the MBC3 IG cart and the official MBC5 cart) will work depending on the type of cart selected.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

This could mean that we can add a Rumble event officially, but given that the feature is kind of niche and can't be easily tested (binjgb doesn't support rumble) I think it might be better to release it as a plugin.
