### PR TITLE
Fix remaining unlocalized string from issue #1433

### DIFF
--- a/src/shared/lib/entities/entitiesHelpers.ts
+++ b/src/shared/lib/entities/entitiesHelpers.ts
@@ -414,6 +414,11 @@ export const paletteName = (palette: Palette, paletteIndex: number) => {
       case "default-ui":
         return l10n("FIELD_PALETTE_DEFAULT_UI");
     }
+  } else {
+    switch (palette.id) {
+      case "dmg":
+        return l10n("FIELD_PALETTE_DEFAULT_DMG");
+    }
   }
   // Otherwise, use the auto-generated or user specified name
   return palette.name || defaultLocalisedPaletteName(paletteIndex);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes one remaining issue from #1433 where "DMG (GB Default)" string was still showing up in English.


* **What is the current behavior?** (You can also link to an open issue here)
"DMG (GB Default)" string shows up in the tooltip (title) in the brush tool bar.


* **What is the new behavior (if this is a feature change)?**
String is localized.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
None

QA results after fix:

Source:
<img width="360" alt="1433_fix_source_qa_results" src="https://github.com/chrismaltby/gb-studio/assets/3715832/aa58e5be-8237-45e2-871d-908f532238ef">

Target:
<img width="368" alt="1433_fix_target_qa_results" src="https://github.com/chrismaltby/gb-studio/assets/3715832/6d904a96-e644-4a10-a580-a8dedf3ae98c">

