### PR TITLE
Fix issue #1452

### DIFF
--- a/appData/src/gb/src/core/vm.c
+++ b/appData/src/gb/src/core/vm.c
@@ -190,8 +190,10 @@ void vm_if(SCRIPT_CTX * THIS, UBYTE condition, INT16 idxA, INT16 idxB, UBYTE * p
         case VM_OP_GE: res = (A >= B); break;
         case VM_OP_NE: res = (A != B); break;
     }
-    if (res) THIS->PC = pc;
-    if (n) THIS->stack_ptr -= n;
+    if (res){
+        THIS->PC = pc;
+        if (n) THIS->stack_ptr -= n;
+    }
 }
 // if condition; compares argument on VM stack with an immediate value
 // idxA point to arguments to compare, B is a value
@@ -208,8 +210,10 @@ void vm_if_const(SCRIPT_CTX * THIS, UBYTE condition, INT16 idxA, INT16 B, UBYTE 
         case VM_OP_GE: res = (A >= B); break;
         case VM_OP_NE: res = (A != B); break;
     }
-    if (res) THIS->PC = pc;
-    if (n) THIS->stack_ptr -= n;
+    if (res){
+        THIS->PC = pc;
+        if (n) THIS->stack_ptr -= n;
+    }
 }
 // pushes value from VM stack onto VM stack
 // if idx >= 0 then idx is absolute, else idx is relative to VM stack pointer


### PR DESCRIPTION
This is a bug fix for https://github.com/chrismaltby/gb-studio/issues/1452 making sure that VM_IF and VM_IF_CONST align with documentation

Users who rely on the fact that VM_IF and VM_IF_CONST pop values from the stack regardless of the result will have to add ways to clean the stack if the result is false.
