### PR TITLE
add "linux" to maker-zip target for building generic linux binaries

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -17,7 +17,7 @@ module.exports = async () => {
       },
       {
         name: "@electron-forge/maker-zip",
-        platforms: ["darwin", "win32"],
+        platforms: ["darwin", "win32", "linux"],
       },
       new MakerAppImage({}),
       {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features) No official tests needed, this just allows for building for generic linux.
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds "linux" to the maker-zip target so it will allow building on generic Linux.


* **What is the current behavior?** (You can also link to an open issue here)
It refuses to build maker-zip on Linux, hence my hacky fix in the [gb-studio-git](https://aur.archlinux.org/packages/gb-studio-git) package.
