### PR TITLE
Fix IME confirmation issue for non-English text

### DIFF
--- a/src/components/forms/AddReferenceMenu.tsx
+++ b/src/components/forms/AddReferenceMenu.tsx
@@ -359,6 +359,11 @@ const AddReferenceMenu = ({ onBlur, onAdd }: AddReferenceMenuProps) => {
     (state) => state.project.present.settings.musicDriver
   );
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   useEffect(() => {
     const allOptions = ([] as (EventOptGroup | EventOption)[]).concat([
       {
@@ -550,7 +555,14 @@ const AddReferenceMenu = ({ onBlur, onAdd }: AddReferenceMenuProps) => {
         setSelectedIndex(Math.max(selectedIndex - 1, 0));
         scrollIntoViewIfNeeded(selectedIndex - 1);
       } else if (e.key === "Enter") {
-        onSelectOption(selectedIndex);
+        if (!isComposing || isFocusOut) {
+          onSelectOption(selectedIndex);
+          isFocusOut = false;
+        } else if (isComposing) {
+          // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+          // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+          isFocusOut = true;
+        }
       }
     },
     [
@@ -605,6 +617,8 @@ const AddReferenceMenu = ({ onBlur, onAdd }: AddReferenceMenuProps) => {
             placeholder={l10n("TOOLBAR_SEARCH")}
             onKeyDown={onKeyDown}
             onChange={onChangeSearchTerm}
+            onCompositionStart={onRenameCompositionStart}
+            onCompositionEnd={onRenameCompositionEnd}
           />
         </SelectMenuSearchWrapper>
         <SelectMenuOptionsWrapper

--- a/src/components/forms/AnimationStateSelect.tsx
+++ b/src/components/forms/AnimationStateSelect.tsx
@@ -126,6 +126,11 @@ const AnimationStateSelect = ({
     spriteStateSelectors.selectAll(state)
   );
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const onRenameStart = () => {
     if (currentValue) {
       setEditValue(currentValue.label);
@@ -144,7 +149,14 @@ const AnimationStateSelect = ({
 
   const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onRenameFinish();
+      if (!isComposing || isFocusOut) {
+        onRenameFinish();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     } else if (e.key === "Escape") {
       setRenameVisible(false);
     }
@@ -198,6 +210,8 @@ const AnimationStateSelect = ({
           onKeyDown={onRenameKeyDown}
           onFocus={onRenameFocus}
           onBlur={onRenameFinish}
+          onCompositionStart={onRenameCompositionStart}
+          onCompositionEnd={onRenameCompositionEnd}
           autoFocus
         />
       ) : (

--- a/src/components/forms/ReferencesSelect.tsx
+++ b/src/components/forms/ReferencesSelect.tsx
@@ -539,6 +539,11 @@ export const AssetReference = <
   const [renameVisible, setRenameVisible] = useState(false);
   const [customSymbol, setCustomSymbol] = useState("");
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const onCopy = useCallback(
     (symbol: string) => {
       dispatch(clipboardActions.copyText(copyTransform(symbol)));
@@ -557,7 +562,14 @@ export const AssetReference = <
 
   const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onRenameFinish();
+      if (!isComposing || isFocusOut) {
+        onRenameFinish();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     } else if (e.key === "Escape") {
       setRenameVisible(false);
     }
@@ -593,6 +605,8 @@ export const AssetReference = <
               onKeyDown={onRenameKeyDown}
               onFocus={onRenameFocus}
               onBlur={onRenameFinish}
+              onCompositionStart={onRenameCompositionStart}
+              onCompositionEnd={onRenameCompositionEnd}
               autoFocus
             />
             <RenameCompleteButton
@@ -661,6 +675,11 @@ export const VariableReference = ({ id, onRemove }: ReferenceProps) => {
   const [renameVisible, setRenameVisible] = useState(false);
   const [customSymbol, setCustomSymbol] = useState("");
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const onCopy = useCallback(
     (symbol: string) => {
       dispatch(clipboardActions.copyText(symbol));
@@ -679,7 +698,14 @@ export const VariableReference = ({ id, onRemove }: ReferenceProps) => {
 
   const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onRenameFinish();
+      if (!isComposing || isFocusOut) {
+        onRenameFinish();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     } else if (e.key === "Escape") {
       setRenameVisible(false);
     }
@@ -709,6 +735,8 @@ export const VariableReference = ({ id, onRemove }: ReferenceProps) => {
               onKeyDown={onRenameKeyDown}
               onFocus={onRenameFocus}
               onBlur={onRenameFinish}
+              onCompositionStart={onRenameCompositionStart}
+              onCompositionEnd={onRenameCompositionEnd}
               autoFocus
             />
             <RenameCompleteButton

--- a/src/components/forms/VariableSelect.tsx
+++ b/src/components/forms/VariableSelect.tsx
@@ -165,6 +165,11 @@ export const VariableSelect: FC<VariableSelectProps> = ({
   const canRename =
     allowRename && !valueIsTemp && context.entityType !== "customEvent";
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   useEffect(() => {
     const variables = namedVariablesByContext(
       context,
@@ -217,7 +222,14 @@ export const VariableSelect: FC<VariableSelectProps> = ({
 
   const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onRenameFinish();
+      if (!isComposing || isFocusOut) {
+        onRenameFinish();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     } else if (e.key === "Escape") {
       setRenameVisible(false);
     }
@@ -269,6 +281,8 @@ export const VariableSelect: FC<VariableSelectProps> = ({
           onKeyDown={onRenameKeyDown}
           onFocus={onRenameFocus}
           onBlur={onRenameFinish}
+          onCompositionStart={onRenameCompositionStart}
+          onCompositionEnd={onRenameCompositionEnd}
           autoFocus
         />
       ) : (

--- a/src/components/pages/PalettePage.tsx
+++ b/src/components/pages/PalettePage.tsx
@@ -87,6 +87,11 @@ const PalettePage = () => {
   const minCenterPaneWidth = 0;
   const [edit, setEdit] = useState(false);
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const allPalettes = useAppSelector((state) =>
     paletteSelectors.selectAll(state)
   );
@@ -175,7 +180,14 @@ const PalettePage = () => {
 
   const checkForFinishEdit = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onFinishEdit();
+      if (!isComposing || isFocusOut) {
+        onFinishEdit();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     }
   };
 
@@ -221,6 +233,8 @@ const PalettePage = () => {
                     onChange={onEditName}
                     onKeyDown={checkForFinishEdit}
                     onBlur={onFinishEdit}
+                    onCompositionStart={onRenameCompositionStart}
+                    onCompositionEnd={onRenameCompositionEnd}
                     autoFocus
                   />
                 ) : (

--- a/src/components/script/AddScriptEventMenu.tsx
+++ b/src/components/script/AddScriptEventMenu.tsx
@@ -500,6 +500,11 @@ const AddScriptEventMenu = ({
   const childOptionsRef = useRef<HTMLDivElement>(null);
   const fuseRef = useRef<Fuse<EventOption> | null>(null);
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const lastSceneId = useAppSelector((state) => {
     const ids = sceneSelectors.selectIds(state);
     return ids[ids.length - 1];
@@ -807,7 +812,14 @@ const AddScriptEventMenu = ({
         setSelectedIndex(Math.max(selectedIndex - 1, 0));
         scrollIntoViewIfNeeded(selectedIndex - 1);
       } else if (e.key === "Enter") {
-        onSelectOption(selectedIndex);
+        if (!isComposing || isFocusOut) {
+          onSelectOption(selectedIndex);
+          isFocusOut = false;
+        } else if (isComposing) {
+          // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+          // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+          isFocusOut = true;
+        }
       } else if (e.key === "Tab") {
         e.preventDefault();
         onToggleFavoriteOption(selectedIndex);
@@ -875,6 +887,8 @@ const AddScriptEventMenu = ({
             placeholder={l10n("TOOLBAR_SEARCH")}
             onKeyDown={onKeyDown}
             onChange={onChangeSearchTerm}
+            onCompositionStart={onRenameCompositionStart}
+            onCompositionEnd={onRenameCompositionEnd}
           />
         </SelectMenuSearchWrapper>
         <SelectMenuOptionsWrapper

--- a/src/components/script/ScriptEditorEvent.tsx
+++ b/src/components/script/ScriptEditorEvent.tsx
@@ -91,6 +91,11 @@ const ScriptEditorEvent = React.memo(
     const [insertBefore, setInsertBefore] = useState(false);
     const [showSymbols, setShowSymbols] = useState(false);
 
+    const [isComposing, setComposition] = useState(false);
+    const onRenameCompositionStart = () => setComposition(true);
+    const onRenameCompositionEnd = () => setComposition(false);
+    var isFocusOut = false;
+
     const clipboardFormat = useAppSelector(
       (state) => state.clipboard.data?.format
     );
@@ -244,9 +249,16 @@ const ScriptEditorEvent = React.memo(
 
     const onDetectRenameComplete = useCallback((e) => {
       if (e.key === "Enter") {
-        setRename(false);
+        if (!isComposing || isFocusOut) {
+          setRename(false);
+          isFocusOut = false;
+        } else if (isComposing) {
+          // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+          // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+          isFocusOut = true;
+        }
       }
-    }, []);
+    }, [isComposing]);
 
     drag(dragRef);
     drop(dropRef);
@@ -475,6 +487,8 @@ const ScriptEditorEvent = React.memo(
                           onBlur={onRenameComplete}
                           onKeyDown={onDetectRenameComplete}
                           placeholder={l10n("FIELD_RENAME")}
+                          onCompositionStart={onRenameCompositionStart}
+                          onCompositionEnd={onRenameCompositionEnd}
                         />
                         <ScriptEventRenameInputCompleteButton
                           onClick={onRenameComplete}

--- a/src/components/ui/form/FlagField.tsx
+++ b/src/components/ui/form/FlagField.tsx
@@ -129,6 +129,11 @@ export const FlagField: FC<FlagFieldFieldProps> = ({
   const variableIsTemp = variableId && variableId.startsWith("T");
   const variableIsParam = variableId && variableId.startsWith("V");
 
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
+
   const namedVariable = useAppSelector((state) => {
     let id = variableId;
     if (variableIsLocal) {
@@ -162,7 +167,14 @@ export const FlagField: FC<FlagFieldFieldProps> = ({
 
   const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      onRenameFinish();
+      if (!isComposing || isFocusOut) {
+        onRenameFinish();
+        isFocusOut = false;
+      } else if (isComposing) {
+        // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+        // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+        isFocusOut = true;
+      }
     } else if (e.key === "Escape") {
       setRenameVisible(false);
     }
@@ -206,6 +218,8 @@ export const FlagField: FC<FlagFieldFieldProps> = ({
           onKeyDown={onRenameKeyDown}
           onFocus={onRenameFocus}
           onBlur={onRenameFinish}
+          onCompositionStart={onRenameCompositionStart}
+          onCompositionEnd={onRenameCompositionEnd}
           autoFocus
         />
       ) : (

--- a/src/components/ui/form/RenameInput.tsx
+++ b/src/components/ui/form/RenameInput.tsx
@@ -63,6 +63,10 @@ export const RenameInput = ({
   onRenameCancel,
 }: RenameInputProps) => {
   const [name, setName] = useState(value ?? "");
+  const [isComposing, setComposition] = useState(false);
+  const onRenameCompositionStart = () => setComposition(true);
+  const onRenameCompositionEnd = () => setComposition(false);
+  var isFocusOut = false;
 
   const onRenameChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -77,7 +81,14 @@ export const RenameInput = ({
         onRenameCancel();
         setName(value ?? "");
       } else if (e.key === "Enter") {
-        onRenameComplete(name);
+        if (!isComposing || isFocusOut) {
+          onRenameComplete(name);
+          isFocusOut = false;
+        } else if (isComposing) {
+          // We cannot set isComposing to false as state here as it will trigger back to true again when the Enter key is pressed
+          // So instead, we set a flag to immediately focus out when user is not composing in IME mode and Enter key is entered
+          isFocusOut = true;
+        }
       }
     },
     [name, onRenameCancel, onRenameComplete, value]
@@ -99,6 +110,8 @@ export const RenameInput = ({
         onChange={onRenameChange}
         onKeyDown={onRenameKeyDown}
         onBlur={onRenameBlur}
+        onCompositionStart={onRenameCompositionStart}
+        onCompositionEnd={onRenameCompositionEnd}
       />
       <CompleteButton onClick={onRenameBlur} title={l10n("FIELD_RENAME")}>
         <CheckIcon />


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes IME confirmation issues while typing in non-English text in input fields.

* **What is the current behavior?** (You can also link to an open issue here)

![GBS_IME_issue1](https://github.com/user-attachments/assets/2cb88e65-b051-4b0c-b210-229892276665)
![GBS_IME_issue2](https://github.com/user-attachments/assets/19a84d89-7a64-40a6-8353-921a75b0de3f)


When we input text using IME (i.e. Writing out Japanese, Chinese, Korean characters), we tend to hit the Enter key to accept the character conversion whilst typing a sentence. However, GBS will treats the Enter key presses as form input acceptance, which cancels out the IME input and looses focus from the input field. As a consequence, we cannot continue typing until the end of sentence.

This issue seems like it is present on Chrome running on a Mac (confirmed on both Intel based and M1). Windows 11 (confirmed on a Surface Laptop) does not seem to have this issue.
Hence, on a macOS, we need a way to distinguish the Enter key pressed specifically for IME input and other Enter key presses.




* **What is the new behavior (if this is a feature change)?**

A workaround to this issue is to detect if user is composing text using IME or not and dismiss the Enter key press event when typing something with IME.

This PR fix will distinguish between the Enter key pressed specifically for IME input and other Enter key presses.

As far as I know, this issue occurs during renaming and inserting search text with:

[RenameInput.tsx]
- Custom script renaming
- Scene name renaming
- Global variable renaming
- Background image name renaming
- Tileset name renaming
- Music name renaming
- Instrument name renaming
- Sound effects name renaming

[AnimationStateSelect.tsx]
- Sprite state renaming

[PalettePage.tsx]
- Palette name renaming (both in navigation pane and in the editor)

[FlagField.tsx]
- Flag name renaming

[ScriptEditorEvent.tsx]
- Renaming event labels

[VariableSelect.tsx]
- Variable name renaming in event editor components

[AddScriptEventMenu.tsx]
- When searching event components with IME ON

[AddReferenceMenu.tsx]
- When searching references with IME ON

[ReferencesSelect.tsx]
- When renaming references to both asset & variables


(Basically, any input field that accepts the Enter key as form-input acceptance has the issue)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

This fix should work with Japanese, Chinese, Korean, or any other languages that uses IME.