### PR TITLE
Add compiler optimisation settings

### DIFF
--- a/src/components/app/Preferences.tsx
+++ b/src/components/app/Preferences.tsx
@@ -38,6 +38,8 @@ const Preferences = () => {
   const [musicEditorPath, setMusicEditorPath] = useState<string>("");
   const [zoomLevel, setZoomLevel] = useState<number>(0);
   const [trackerKeyBindings, setTrackerKeyBindings] = useState<number>(0);
+  const [compilerPreset, setCompilerPreset] = useState<number>(3000);
+  const [compilerOptimisation, setCompilerOptimisation] = useState<number>(0);
 
   const currentZoomValue = zoomOptions.find((o) => o.value === zoomLevel);
 
@@ -48,6 +50,8 @@ const Preferences = () => {
       setMusicEditorPath(await API.settings.getString("musicEditorPath", ""));
       setZoomLevel(await API.settings.app.getUIScale());
       setTrackerKeyBindings(await API.settings.app.getTrackerKeyBindings());
+      setCompilerPreset(await API.settings.app.getCompilerPreset());
+      setCompilerOptimisation(await API.settings.app.getCompilerOptimisation());
     }
     fetchData();
   }, []);
@@ -67,6 +71,33 @@ const Preferences = () => {
 
   const currentTrackerKeyBindings = trackerKeyBindingsOptions.find(
     (o) => o.value === trackerKeyBindings
+  );
+
+  const compilerPresetOptions: Options[] = useMemo(
+    () => [
+      { value: 3000,   label: l10n("FIELD_DEFAULT") },
+      { value: 1000,   label: l10n("FIELD_FAST") },
+      { value: 50000,  label: l10n("FIELD_SLOW") },
+      { value: 100000, label: l10n("FIELD_PLACEBO") },
+    ],
+    []
+  );
+
+  const currentCompilerPreset = compilerPresetOptions.find(
+    (o) => o.value === compilerPreset
+  );
+
+  const compilerOptimisationOptions: Options[] = useMemo(
+    () => [
+      { value: 0, label: l10n("FIELD_NONE") },
+      { value: 1, label: l10n("FIELD_SPEED") },
+      { value: 2, label: l10n("FIELD_SIZE") },
+    ],
+    []
+  );
+
+  const currentCompilerOptimisation = compilerOptimisationOptions.find(
+    (o) => o.value === compilerOptimisation
   );
 
   const onChangeTmpPath = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -109,6 +140,16 @@ const Preferences = () => {
     setTmpPath(await API.paths.getTmpPath());
   };
 
+  const onChangeCompilerPreset = (value: number) => {
+    setCompilerPreset(value);
+    API.settings.app.setCompilerPreset(value);
+  };
+
+  const onChangeCompilerOptimisation = (value: number) => {
+    setCompilerOptimisation(value);
+    API.settings.app.setCompilerOptimisation(value);
+  };
+
   return (
     <ThemeProvider>
       <GlobalStyle />
@@ -136,6 +177,26 @@ const Preferences = () => {
         </FormRow>
 
         <FlexGrow />
+        <FormRow>
+          <FormField name="compilerPreset" label={l10n("FIELD_COMPILER_PRESET")}>
+            <Select
+              value={currentCompilerPreset}
+              options={compilerPresetOptions}
+              onChange={(newValue: Options) => {
+                onChangeCompilerPreset(newValue.value);
+              }}
+            />
+          </FormField>
+          <FormField name="compilerOptimisation" label={l10n("FIELD_COMPILER_OPTIMISATION")}>
+            <Select
+              value={currentCompilerOptimisation}
+              options={compilerOptimisationOptions}
+              onChange={(newValue: Options) => {
+                onChangeCompilerOptimisation(newValue.value);
+              }}
+            />
+          </FormField>
+        </FormRow>
 
         <FormRow>
           <FormField

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -206,6 +206,8 @@ export const defaultProjectSettings: SettingsState = {
   previewAsMono: false,
   openBuildLogOnWarnings: true,
   generateDebugFilesEnabled: false,
+  compilerOptimisation: 0,
+  compilerPreset: 3000,
 };
 
 export {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -814,6 +814,12 @@
   "FIELD_SET_CURSOR_POSITION_TO": "Set Cursor Position To",
   "FIELD_MOVE_CURSOR_POSITION_BY": "Move Cursor Position By",
   "FIELD_MOVE_BY": "Move By",
+  "FIELD_OPT_NONE": "No Optimisation",
+  "FIELD_FAST": "Fast",
+  "FIELD_SLOW": "Slow",
+  "FIELD_PLACEBO": "Placebo",
+  "FIELD_COMPILER_PRESET": "Compiler Preset",
+  "FIELD_COMPILER_OPTIMISATION": "Optimise ROM For",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/lib/compiler/buildMakeScript.ts
+++ b/src/lib/compiler/buildMakeScript.ts
@@ -152,6 +152,21 @@ export const getBuildCommands = async (
         `-c`,
       ];
 
+      const settings = require("electron-settings");
+      
+      var compilerPreset = Number(settings.get("compilerPreset") || 3000);
+      buildArgs.push(`-Wf"--max-allocs-per-node ` + compilerPreset + `"`);
+
+      var compilerOptimisation = Number(settings.get("compilerOptimisation") || 0);
+      switch (compilerOptimisation) {
+        case 1:
+          buildArgs.push("-Wf--opt-code-speed");
+          break;
+        case 2:
+          buildArgs.push("-Wf--opt-code-size");
+          break;
+      }
+
       if (colorEnabled) {
         buildArgs.push("-DCGB");
       }

--- a/src/renderer/lib/api/setup.ts
+++ b/src/renderer/lib/api/setup.ts
@@ -153,6 +153,14 @@ const APISetup = {
         ipcRenderer.invoke("set-tracker-keybindings", value),
       getTrackerKeyBindings: () =>
         APISetup.settings.getNumber("trackerKeyBindings", 0),
+      getCompilerPreset: () =>
+        APISetup.settings.getNumber("compilerPreset", 3000),
+      setCompilerPreset: (value: number) =>
+        APISetup.settings.set("compilerPreset", value),
+      getCompilerOptimisation: () =>
+        APISetup.settings.getNumber("compilerOptimisation", 0),
+      setCompilerOptimisation: (value: number) =>
+        APISetup.settings.set("compilerOptimisation", value),
     },
   },
   dialog: {

--- a/src/store/features/settings/settingsState.ts
+++ b/src/store/features/settings/settingsState.ts
@@ -86,6 +86,8 @@ export type SettingsState = {
   previewAsMono: boolean;
   openBuildLogOnWarnings: boolean;
   generateDebugFilesEnabled: boolean;
+  compilerOptimisation: number;
+  compilerPreset: number;
 };
 
 export const initialState: SettingsState = defaultProjectSettings;
@@ -123,6 +125,14 @@ const settingsSlice = createSlice({
 
     setShowNavigator: (state, action: PayloadAction<boolean>) => {
       state.showNavigator = action.payload;
+    },
+
+    setCompilerOptimisation: (state, action: PayloadAction<number>) => {
+      state.compilerOptimisation = action.payload;
+    },
+
+    setCompilerPreset: (state, action: PayloadAction<number>) => {
+      state.compilerPreset = action.payload;
     },
 
     toggleFavoriteEvent: (state, action: PayloadAction<string>) => {

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -280,6 +280,8 @@ export const dummyProjectData: ProjectData = {
     previewAsMono: false,
     openBuildLogOnWarnings: true,
     generateDebugFilesEnabled: false,
+    compilerOptimisation: 0,
+    compilerPreset: 0,
   },
 };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds two options to the "Preferences" screen to control compiler settings. The first, "Compiler Preset", changes the value of "max-allocs-per-node", allowing for the user to select a tradeoff between compiling the ROM faster and compiling the ROM more optimally. The second option, "Optimise ROM For", allows the user to select whether to optimise for faster code ("opt-code-speed"), smaller code ("opt-code-size"), or none.


* **What is the current behavior?** (You can also link to an open issue here)
No current way to set these compiler optimisations.


* **What is the new behavior (if this is a feature change)?**
Compiler optimisations are now selectable if desired.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None that I'm aware of.


* **Other information**:
The code should default to the same settings GB Studio uses right now, so there shouldn't be any change to the ROM output out of the box.