### PR TITLE
Removing the hard reserving tile for the default ui system.

### DIFF
--- a/appData/src/gb/src/core/data_manager.c
+++ b/appData/src/gb/src/core/data_manager.c
@@ -16,8 +16,6 @@
 #include "data/spritesheet_none.h"
 #include "data/data_bootstrap.h"
 
-#define ALLOC_BKG_TILES_TOWARDS_SPR
-
 #define EMOTE_SPRITE_SIZE       4
 
 far_ptr_t current_scene;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -30,8 +30,8 @@ const MAX_TRIGGERS = 30;
 const MAX_FRAMES = 25;
 const MAX_SPRITE_TILES = 64;
 
-export const MAX_BACKGROUND_TILES = 16 * 12;
-export const MAX_BACKGROUND_TILES_CGB = 16 * 12 * 2;
+export const MAX_BACKGROUND_TILES = 16 * 16;
+export const MAX_BACKGROUND_TILES_CGB = 16 * 16 * 2;
 
 const SCREEN_WIDTH = 20;
 const SCREEN_HEIGHT = 18;

--- a/src/lib/compiler/compileImages.ts
+++ b/src/lib/compiler/compileImages.ts
@@ -26,7 +26,7 @@ import l10n from "shared/lib/lang/l10n";
 import { monoOverrideForFilename } from "shared/lib/assets/backgrounds";
 
 const TILE_FIRST_CHUNK_SIZE = 128;
-const TILE_BANK_SIZE = 192;
+const TILE_BANK_SIZE = 256;
 
 type PrecompiledBackgroundData = BackgroundData & {
   commonTilesetId?: string;

--- a/src/shared/lib/helpers/sprites.ts
+++ b/src/shared/lib/helpers/sprites.ts
@@ -4,18 +4,18 @@ export const maxSpriteTilesForBackgroundTilesLength = (
 ) => {
   if (isCGBOnly) {
     if (backgroundTilesLength <= 256) {
-      return 192;
+      return 256;
     }
-    if (backgroundTilesLength * 0.5 < 192) {
-      return 192 - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
+    if (backgroundTilesLength * 0.5 < 256) {
+      return 256 - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
     }
     return 128;
   }
   if (backgroundTilesLength <= 128) {
-    return 96;
+    return 128;
   }
-  if (backgroundTilesLength < 192) {
-    return 96 - Math.ceil((backgroundTilesLength - 128) / 2);
+  if (backgroundTilesLength < 256) {
+    return 128 - Math.ceil((backgroundTilesLength - 128) / 2);
   }
   return 64;
 };


### PR DESCRIPTION
For people who have some scenes that have more than 192 unique tiles (up to 256 in normal mode and up to 512 in color-only mode) and dont use the default ui system. issues fixed:
- The background image compiler would cap at 192 unique tile, not allowing any way to have more tiles even with a plugin fix
- Removed ALLOC_BKG_TILES_TOWARDS_SPR definition in the engine as the new allocation hard caps at 192 tiles
This fixes a breaking change that was introduced in GBS 4 by adding this hard cap.
