### PR TITLE
Feat/manage tile alloc

### DIFF
--- a/appData/src/gb/include/gbs_types.h
+++ b/appData/src/gb/include/gbs_types.h
@@ -97,6 +97,7 @@ typedef struct background_t {
     far_ptr_t cgb_tileset;
     far_ptr_t tilemap;              // far pointer to array of bytes with map
     far_ptr_t cgb_tilemap_attr;     // far pointer to array of bytes with CGB attributes (may be NULL)
+	uint8_t allocation_strat;
 } background_t;
 
 typedef struct tileset_t {

--- a/appData/src/gb/src/core/data_manager.c
+++ b/appData/src/gb/src/core/data_manager.c
@@ -16,8 +16,6 @@
 #include "data/spritesheet_none.h"
 #include "data/data_bootstrap.h"
 
-#define ALLOC_BKG_TILES_TOWARDS_SPR
-
 #define EMOTE_SPRITE_SIZE       4
 
 far_ptr_t current_scene;

--- a/appData/src/gb/src/core/data_manager.c
+++ b/appData/src/gb/src/core/data_manager.c
@@ -53,7 +53,7 @@ void load_init(void) BANKED {
     scene_stack_ptr = scene_stack;
 }
 
-void load_bkg_tileset(const tileset_t* tiles, UBYTE bank) BANKED {
+void load_bkg_tileset(const tileset_t* tiles, UBYTE bank, UBYTE allocation_strat) BANKED {
     if ((!bank) || (!tiles)) return;
 
     UWORD n_tiles = ReadBankedUWORD(&(tiles->n_tiles), bank);
@@ -68,26 +68,22 @@ void load_bkg_tileset(const tileset_t* tiles, UBYTE bank) BANKED {
     n_tiles -= 128; data += 128 * 16;
 
     // load second background chunk
-    if (n_tiles < 128) {
-        if (n_tiles < 65) {
-            #ifdef ALLOC_BKG_TILES_TOWARDS_SPR
-                // new allocation style, align to 192-th tile
-                if ((UBYTE)n_tiles) SetBankedBkgData(192 - n_tiles, n_tiles, data, bank);
-            #else
-                // old allocation style, align to 128-th tile
-                if ((UBYTE)n_tiles) SetBankedBkgData(128, n_tiles, data, bank);
-            #endif
-        } else {
-            // if greater than 64 allow overflow into UI, align to 128-th tile
-            if ((UBYTE)n_tiles) SetBankedBkgData(128, n_tiles, data, bank);
-        }
-        return;
-    }
-    SetBankedBkgData(128, 128, data, bank);
-    n_tiles -= 128; data += 128 * 16;
-
-    // if more than 256 - then it's a 360-tile logo, load rest to sprite area
-    if ((UBYTE)n_tiles) SetBankedSpriteData(0, n_tiles, data, bank);
+    if (n_tiles <= 128) {
+        // allocation_strat bit1 : if not set, reverse allocation toward sprites (sprite priorisation)
+		// allocation_strat bit2: if not set, align to reserved ui tile offset
+        if (allocation_strat & 1){
+			if ((UBYTE)n_tiles) SetBankedBkgData(128, ((allocation_strat >> 1) & 1)? n_tiles: MIN(n_tiles, 64), data, bank);
+		} else {	
+            if ((UBYTE)n_tiles) SetBankedBkgData((((allocation_strat >> 1) & 1) ? 256: 192) - n_tiles, n_tiles, data, bank);
+		}
+    } 
+	else 
+	{
+		// if more than 256 - then it's a 360-tile logo, load rest to sprite area
+		SetBankedBkgData(128, 128, data, bank);
+		n_tiles -= 128; data += 128 * 16;
+		SetBankedSpriteData(0, n_tiles, data, bank);
+	}
 }
 
 void load_background(const background_t* background, UBYTE bank) BANKED {
@@ -107,11 +103,11 @@ void load_background(const background_t* background, UBYTE bank) BANKED {
     image_height = image_tile_height * 8;
     scroll_y_max = image_height - ((UINT16)SCREENHEIGHT);
 
-    load_bkg_tileset(bkg.tileset.ptr, bkg.tileset.bank);
+    load_bkg_tileset(bkg.tileset.ptr, bkg.tileset.bank, bkg.allocation_strat);
 #ifdef CGB
     if ((_is_CGB) && (bkg.cgb_tileset.ptr)) {
         VBK_REG = 1;
-        load_bkg_tileset(bkg.cgb_tileset.ptr, bkg.cgb_tileset.bank);
+        load_bkg_tileset(bkg.cgb_tileset.ptr, bkg.cgb_tileset.bank, bkg.allocation_strat);
         VBK_REG = 0;
     }
 #endif

--- a/src/components/forms/BackgroundSelectButton.tsx
+++ b/src/components/forms/BackgroundSelectButton.tsx
@@ -12,7 +12,7 @@ import { RelativePortal } from "ui/layout/RelativePortal";
 import { BackgroundSelect } from "./BackgroundSelect";
 import { assetURLStyleProp } from "shared/lib/helpers/assets";
 import { useAppDispatch, useAppSelector } from "store/hooks";
-import { MAX_BACKGROUND_TILES, MAX_BACKGROUND_TILES_CGB } from "consts";
+import { MAX_BACKGROUND_TILES, MAX_BACKGROUND_TILES_CGB, UI_TILE_LENGTH } from "consts";
 import { monoOverrideForFilename } from "shared/lib/assets/backgrounds";
 import { FlexGrow } from "ui/spacing/Spacing";
 
@@ -21,6 +21,7 @@ interface BackgroundSelectProps {
   value?: string;
   is360: boolean;
   tilesetId: string;
+  allocationStrat: number;
   includeInfo?: boolean;
   onChange?: (newId: string) => void;
 }
@@ -166,6 +167,7 @@ export const BackgroundSelectButton: FC<BackgroundSelectProps> = ({
   onChange,
   is360,
   tilesetId,
+  allocationStrat,
   includeInfo,
 }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -193,10 +195,11 @@ export const BackgroundSelectButton: FC<BackgroundSelectProps> = ({
           backgroundId: value,
           tilesetId,
           is360,
+		  allocationStrat,
         })
       );
     }
-  }, [dispatch, value, is360, tilesetId]);
+  }, [dispatch, value, is360, tilesetId, allocationStrat]);
 
   useEffect(() => {
     if (buttonFocus) {
@@ -308,8 +311,8 @@ export const BackgroundSelectButton: FC<BackgroundSelectProps> = ({
               </SpriteInfoRow>
               <SpriteInfoRow
                 error={
-                  (numTiles > MAX_BACKGROUND_TILES_CGB ||
-                    (!isCGBOnly && numTiles > MAX_BACKGROUND_TILES)) &&
+                  (numTiles > (MAX_BACKGROUND_TILES_CGB - (((allocationStrat >> 1) & 1)? 0: (UI_TILE_LENGTH * 2))) ||
+                    (!isCGBOnly && numTiles > (MAX_BACKGROUND_TILES - (((allocationStrat >> 1) & 1)? 0: (UI_TILE_LENGTH))))) &&
                   !is360
                 }
               >

--- a/src/components/world/SceneInfo.tsx
+++ b/src/components/world/SceneInfo.tsx
@@ -119,6 +119,9 @@ const SceneInfo = () => {
   const backgroundNumTiles = useAppSelector(
     (state) => state.assets.backgrounds[scene?.backgroundId || ""]?.numTiles
   );
+  const backgroundAllocationStrat = useAppSelector(
+    (state) => state.assets.backgrounds[scene?.backgroundId || ""]?.allocationStrat
+  );
   const isCGBOnly = useAppSelector(
     (state) => state.project.present.settings.colorMode === "color"
   );
@@ -399,7 +402,7 @@ const SceneInfo = () => {
   const triggerCount = scene.triggers.length;
   const maxSpriteTiles =
     scene.type !== "LOGO"
-      ? maxSpriteTilesForBackgroundTilesLength(backgroundNumTiles, isCGBOnly)
+      ? maxSpriteTilesForBackgroundTilesLength(backgroundNumTiles, isCGBOnly, backgroundAllocationStrat)
       : MAX_LOGO_SPRITE_TILES;
 
   return (

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -30,8 +30,8 @@ const MAX_TRIGGERS = 30;
 const MAX_FRAMES = 25;
 const MAX_SPRITE_TILES = 64;
 
-export const MAX_BACKGROUND_TILES = 16 * 12;
-export const MAX_BACKGROUND_TILES_CGB = 16 * 12 * 2;
+export const MAX_BACKGROUND_TILES = 16 * 16;
+export const MAX_BACKGROUND_TILES_CGB = 16 * 16 * 2;
 
 const SCREEN_WIDTH = 20;
 const SCREEN_HEIGHT = 18;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -30,8 +30,9 @@ const MAX_TRIGGERS = 30;
 const MAX_FRAMES = 25;
 const MAX_SPRITE_TILES = 64;
 
-export const MAX_BACKGROUND_TILES = 16 * 16;
-export const MAX_BACKGROUND_TILES_CGB = 16 * 16 * 2;
+export const MAX_BACKGROUND_TILES = 256;
+export const MAX_BACKGROUND_TILES_CGB = 512;
+export const UI_TILE_LENGTH = 64;
 
 const SCREEN_WIDTH = 20;
 const SCREEN_HEIGHT = 18;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -802,6 +802,8 @@
   "FIELD_COPY_VALUE": "Copy Value",
   "FIELD_PASTE_VALUE": "Paste Value",
   "FIELD_STACK": "Stack",
+  "FIELD_PRIORITIZE_SPRITE_ALLOC": "Prioritize Sprite Allocation",
+  "FIELD_RESERVE_UI_TILES": "Reserve UI Tiles",
   "FIELD_COMMON_TILESET": "Common Tileset",
   "FIELD_COMMON_TILESET_DESC": "Setting a common tileset for a scene will cause the selected tileset tiles to always be loaded in the same order. Careful use of this on two scenes will allow you to seamlessly switch between the scenes with no transition and no tile glitching.",
   "FIELD_AUTO_COLOR": "Auto Color",

--- a/src/lib/compiler/compileData.ts
+++ b/src/lib/compiler/compileData.ts
@@ -124,12 +124,12 @@ import compileTilesets from "lib/compiler/compileTilesets";
 type CompiledTilemapData = {
   symbol: string;
   data: number[] | Uint8Array;
-  is360: boolean;
+  is360: boolean;  
 };
 
 type CompiledTilesetData = {
   symbol: string;
-  data: number[] | Uint8Array;
+  data: number[] | Uint8Array;  
 };
 
 export type SceneMapData = {
@@ -288,11 +288,20 @@ export const precompileBackgrounds = async (
       )
     )
     .map((background) => background.id);
+	
+  const allocationStratLookup = scenes.reduce((memo, scene) => {
+  	if (!scene.backgroundId || !scene.allocationStrat){
+		return memo;
+	}
+	memo[scene.backgroundId] = scene.allocationStrat;
+    return memo;  
+  }, {} as Record<string, number>);
 
   const backgroundsData = await compileImages(
     usedBackgrounds,
     commonTilesetsLookup,
     generate360Ids,
+	allocationStratLookup,
     colorMode,
     projectRoot,
     {
@@ -315,7 +324,7 @@ export const precompileBackgrounds = async (
         tileset1Index = usedTilesets.length;
         usedTilesets.push({
           symbol: `${background.symbol}_tileset`,
-          data: background.vramData[0],
+          data: background.vramData[0],		  
         });
       }
 
@@ -344,7 +353,7 @@ export const precompileBackgrounds = async (
         usedTilemapAttrs.push({
           symbol: `${background.symbol}_tilemap_attr`,
           data: background.attr,
-          is360: generate360Ids.includes(background.id),
+          is360: generate360Ids.includes(background.id),		  
         });
       }
 
@@ -354,6 +363,7 @@ export const precompileBackgrounds = async (
         cgbTileset: usedTilesets[tileset2Index],
         tilemap: usedTilemaps[tilemapIndex],
         tilemapAttr: usedTilemapAttrs[tilemapAttrIndex],
+		allocationStrat: (generate360Ids.includes(background.id))? 3: (allocationStratLookup[background.id] ?? 0),
       };
     }
   );

--- a/src/lib/compiler/compileImages.ts
+++ b/src/lib/compiler/compileImages.ts
@@ -27,6 +27,7 @@ import { monoOverrideForFilename } from "shared/lib/assets/backgrounds";
 
 const TILE_FIRST_CHUNK_SIZE = 128;
 const TILE_BANK_SIZE = 256;
+const TILE_UI_OFFSET = 192;
 
 type PrecompiledBackgroundData = BackgroundData & {
   commonTilesetId?: string;
@@ -136,6 +137,7 @@ const compileImage = async (
   img: BackgroundData,
   commonTileset: TilesetData | undefined,
   is360: boolean,
+  allocationStrat: number,
   colorMode: ColorModeSetting,
   projectPath: string,
   { warnings }: CompileImageOptions
@@ -228,6 +230,7 @@ const compileImage = async (
     img,
     undefined,
     false,
+	allocationStrat,
     cgbOnly,
     projectPath,
     uniqueTiles.length
@@ -257,15 +260,23 @@ const compileImage = async (
         img
       );
       // Reallocate tilemap based on strategy
-      if (tileIndex < TILE_FIRST_CHUNK_SIZE) {
-        tilemap[index] = tileIndex;
-      } else {
-        // tile index > 128 is allocated with an unused tile offset
-        // to allow as much tiles as possible for sprite data
-        const bankSize = vramData[inVRAM2 ? 1 : 0].length / 16;
-        const offset = TILE_BANK_SIZE - bankSize;
-        tilemap[index] = tileIndex + offset;
-      }
+	  // first bit of allocationStrat specify if reverse the tile order past 128 toward sprite tiles (sprite tile priority) (default true)
+	  const reverseTile = ((allocationStrat) & 1)? false: true;
+	   // second bit of allocationStrat specify if we reserve the default ui tiles (default 192)
+	  const reservedOffset = ((allocationStrat >> 1) & 1)? TILE_BANK_SIZE: TILE_UI_OFFSET;
+	  if (reverseTile){
+		if (tileIndex < TILE_FIRST_CHUNK_SIZE) {
+			tilemap[index] = tileIndex;
+		} else {
+			// tile index > 128 is allocated with an unused tile offset
+			// to allow as much tiles as possible for sprite data
+			const bankSize = vramData[inVRAM2 ? 1 : 0].length / 16;
+			const offset = reservedOffset - bankSize;
+			tilemap[index] = tileIndex + offset;
+		}
+	  } else {
+		tilemap[index] = tileIndex;
+	  }
       if (inVRAM2) {
         return attr | FLAG_VRAM_BANK_1;
       }
@@ -290,6 +301,7 @@ const compileImages = async (
   imgs: BackgroundData[],
   commonTilesetsLookup: Record<string, TilesetData[]>,
   generate360Ids: string[],
+  allocationStratLookup: Record<string, number>,
   colorMode: ColorModeSetting,
   projectPath: string,
   { warnings }: CompileImageOptions
@@ -305,6 +317,7 @@ const compileImages = async (
               img,
               undefined,
               generate360Ids.includes(img.id),
+			  allocationStratLookup[img.id] ?? 0,
               colorMode,
               projectPath,
               { warnings }
@@ -315,6 +328,7 @@ const compileImages = async (
                 img,
                 commonTileset,
                 generate360Ids.includes(img.id),
+				allocationStratLookup[img.id] ?? 0,
                 colorMode,
                 projectPath,
                 { warnings }

--- a/src/lib/compiler/compileImages.ts
+++ b/src/lib/compiler/compileImages.ts
@@ -26,7 +26,7 @@ import l10n from "shared/lib/lang/l10n";
 import { monoOverrideForFilename } from "shared/lib/assets/backgrounds";
 
 const TILE_FIRST_CHUNK_SIZE = 128;
-const TILE_BANK_SIZE = 192;
+const TILE_BANK_SIZE = 256;
 
 type PrecompiledBackgroundData = BackgroundData & {
   commonTilesetId?: string;

--- a/src/lib/compiler/generateGBVMData.ts
+++ b/src/lib/compiler/generateGBVMData.ts
@@ -26,6 +26,7 @@ export interface PrecompiledBackground {
   tilemap: PrecompiledTileData;
   tilemapAttr: PrecompiledTileData;
   autoPalettes?: Palette[];
+  allocationStrat: number,
 }
 
 export interface ProjectileData {
@@ -70,7 +71,7 @@ export interface PrecompiledTileData {
 export interface PrecompiledTilemapData {
   symbol: string;
   data: number[] | Uint8Array;
-  is360: boolean;
+  is360: boolean;  
 }
 
 interface Entity {
@@ -922,6 +923,7 @@ export const compileBackground = (
       cgb_tilemap_attr: color
         ? toFarPtr(background.tilemapAttr.symbol)
         : "{ NULL, NULL }",
+	  allocation_strat: background.allocationStrat,
     },
     ([] as string[]).concat(
       background.tileset?.symbol ?? [],

--- a/src/lib/helpers/validation.ts
+++ b/src/lib/helpers/validation.ts
@@ -10,7 +10,7 @@ import {
 } from "shared/lib/tiles/tileData";
 import { assetFilename } from "shared/lib/helpers/assets";
 import { readFileToTilesDataArray } from "lib/tiles/readFileToTiles";
-import { MAX_BACKGROUND_TILES, MAX_BACKGROUND_TILES_CGB } from "consts";
+import { MAX_BACKGROUND_TILES, MAX_BACKGROUND_TILES_CGB, UI_TILE_LENGTH } from "consts";
 
 const MAX_IMAGE_WIDTH = 2040;
 const MAX_IMAGE_HEIGHT = 2040;
@@ -39,6 +39,7 @@ export const getBackgroundInfo = async (
   background: BackgroundData,
   commonTileset: Tileset | undefined,
   is360: boolean,
+  allocationStrat: number,
   isCGBOnly: boolean,
   projectPath: string,
   precalculatedTilesetLength?: number
@@ -95,20 +96,21 @@ export const getBackgroundInfo = async (
   ) {
     warnings.push(l10n("WARNING_BACKGROUND_NOT_MULTIPLE_OF_8"));
   }
-  if (tilesetLength > MAX_BACKGROUND_TILES && !is360 && !isCGBOnly) {
+  let max_bg_tiles = (MAX_BACKGROUND_TILES - (((allocationStrat >> 1) & 1)? 0: (UI_TILE_LENGTH)));
+  if (tilesetLength > max_bg_tiles && !is360 && !isCGBOnly) {
     warnings.push(
       l10n("WARNING_BACKGROUND_TOO_MANY_TILES", {
         tilesetLength,
-        maxTilesetLength: MAX_BACKGROUND_TILES,
+        maxTilesetLength: max_bg_tiles,
       })
     );
   }
-
-  if (tilesetLength > MAX_BACKGROUND_TILES_CGB && !is360 && isCGBOnly) {
+  max_bg_tiles = (MAX_BACKGROUND_TILES_CGB - (((allocationStrat >> 1) & 1)? 0: (UI_TILE_LENGTH * 2)));
+  if (tilesetLength > max_bg_tiles && !is360 && isCGBOnly) {
     warnings.push(
       l10n("WARNING_BACKGROUND_TOO_MANY_TILES", {
         tilesetLength,
-        maxTilesetLength: MAX_BACKGROUND_TILES_CGB,
+        maxTilesetLength: max_bg_tiles,
       })
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1444,10 +1444,11 @@ ipcMain.handle(
     background: Background,
     tileset: Tileset | undefined,
     is360: boolean,
+	allocationStrat: number,
     cgbOnly: boolean
   ) => {
     const projectRoot = Path.dirname(projectPath);
-    return getBackgroundInfo(background, tileset, is360, cgbOnly, projectRoot);
+    return getBackgroundInfo(background, tileset, is360, allocationStrat, cgbOnly, projectRoot);
   }
 );
 

--- a/src/renderer/lib/api/setup.ts
+++ b/src/renderer/lib/api/setup.ts
@@ -221,6 +221,7 @@ const APISetup = {
       background: Background,
       tileset: Tileset | undefined,
       is360: boolean,
+	  allocationStrat: number,
       cgbOnly: boolean
     ): Promise<BackgroundInfo> =>
       ipcRenderer.invoke(
@@ -228,6 +229,7 @@ const APISetup = {
         background,
         tileset,
         is360,
+		allocationStrat,
         cgbOnly
       ),
     addFile: (filename: string): Promise<void> =>

--- a/src/shared/lib/entities/entitiesTypes.ts
+++ b/src/shared/lib/entities/entitiesTypes.ts
@@ -388,6 +388,7 @@ export type Scene = {
   height: number;
   backgroundId: string;
   tilesetId: string;
+  allocationStrat: number;
   paletteIds: string[];
   spritePaletteIds: string[];
   collisions: number[];

--- a/src/shared/lib/helpers/sprites.ts
+++ b/src/shared/lib/helpers/sprites.ts
@@ -4,18 +4,18 @@ export const maxSpriteTilesForBackgroundTilesLength = (
 ) => {
   if (isCGBOnly) {
     if (backgroundTilesLength <= 256) {
-      return 192;
+      return 256;
     }
-    if (backgroundTilesLength * 0.5 < 192) {
-      return 192 - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
+    if (backgroundTilesLength * 0.5 < 256) {
+      return 256 - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
     }
     return 128;
   }
   if (backgroundTilesLength <= 128) {
-    return 96;
+    return 128;
   }
-  if (backgroundTilesLength < 192) {
-    return 96 - Math.ceil((backgroundTilesLength - 128) / 2);
+  if (backgroundTilesLength < 256) {
+    return 128 - Math.ceil((backgroundTilesLength - 128) / 2);
   }
   return 64;
 };

--- a/src/shared/lib/helpers/sprites.ts
+++ b/src/shared/lib/helpers/sprites.ts
@@ -1,21 +1,23 @@
 export const maxSpriteTilesForBackgroundTilesLength = (
   backgroundTilesLength: number,
-  isCGBOnly: boolean
+  isCGBOnly: boolean,
+  backgroundAllocationStrat: number,
 ) => {
+  const reserveUITiles = !((backgroundAllocationStrat >> 1) & 1);
   if (isCGBOnly) {
     if (backgroundTilesLength <= 256) {
-      return 256;
+      return ((reserveUITiles)? 192: 256);
     }
-    if (backgroundTilesLength * 0.5 < 256) {
-      return 256 - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
+    if (backgroundTilesLength * 0.5 < ((reserveUITiles)? 192: 256)) {
+      return ((reserveUITiles)? 192: 256) - Math.ceil((backgroundTilesLength / 2 - 128) / 2) * 2;
     }
     return 128;
   }
   if (backgroundTilesLength <= 128) {
-    return 128;
+    return ((reserveUITiles)? 96: 128);
   }
-  if (backgroundTilesLength < 256) {
-    return 128 - Math.ceil((backgroundTilesLength - 128) / 2);
+  if (backgroundTilesLength < ((reserveUITiles)? 192: 256)) {
+    return ((reserveUITiles)? 96: 128) - Math.ceil((backgroundTilesLength - 128) / 2);
   }
   return 64;
 };

--- a/src/store/features/assets/assetsMiddleware.ts
+++ b/src/store/features/assets/assetsMiddleware.ts
@@ -30,6 +30,7 @@ const assetsMiddleware: Middleware<Dispatch, RootState> =
           !cachedWarnings ||
           cachedWarnings.timestamp < background._v ||
           cachedWarnings.is360 !== action.payload.is360 ||
+		  cachedWarnings.allocationStrat !== action.payload.allocationStrat || 
           cachedWarnings.isCGBOnly !== isCGBOnly ||
           cachedWarnings.tilesetId !== tilesetId
         ) {
@@ -38,6 +39,7 @@ const assetsMiddleware: Middleware<Dispatch, RootState> =
               background,
               tileset,
               action.payload.is360,
+			  action.payload.allocationStrat,
               isCGBOnly
             )
             .then((info) => {
@@ -45,6 +47,7 @@ const assetsMiddleware: Middleware<Dispatch, RootState> =
                 actions.setBackgroundAssetInfo({
                   id: action.payload.backgroundId,
                   is360: action.payload.is360,
+				  allocationStrat: action.payload.allocationStrat,
                   tilesetId,
                   warnings: info.warnings,
                   numTiles: info.numTiles,

--- a/src/store/features/assets/assetsState.ts
+++ b/src/store/features/assets/assetsState.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 type BackgroundAsset = {
   id: string;
   is360: boolean;
+  allocationStrat: number;
   isCGBOnly: boolean;
   tilesetId?: string;
   warnings: string[];
@@ -31,6 +32,7 @@ const assetsSlice = createSlice({
         backgroundId: string;
         tilesetId?: string;
         is360: boolean;
+		allocationStrat: number;
       }>
     ) => {
       state.backgroundsLoading = true;
@@ -40,6 +42,7 @@ const assetsSlice = createSlice({
       action: PayloadAction<{
         id: string;
         is360: boolean;
+		allocationStrat: number;
         tilesetId?: string;
         isCGBOnly: boolean;
         warnings: string[];
@@ -51,6 +54,7 @@ const assetsSlice = createSlice({
       state.backgrounds[action.payload.id] = {
         id: action.payload.id,
         is360: action.payload.is360,
+		allocationStrat: action.payload.allocationStrat,
         tilesetId: action.payload.tilesetId,
         isCGBOnly: action.payload.isCGBOnly,
         warnings: action.payload.warnings,

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -740,6 +740,7 @@ const addScene: CaseReducer<
     name: defaultLocalisedSceneName(scenesTotal),
     backgroundId,
     tilesetId: "",
+	allocationStrat: 0,
     width: Math.max(MIN_SCENE_WIDTH, background?.width || 0),
     height: Math.max(MIN_SCENE_HEIGHT, background?.height || 0),
     type: "TOPDOWN",

--- a/test/data/compiler/compileImages.test.ts
+++ b/test/data/compiler/compileImages.test.ts
@@ -17,6 +17,7 @@ test("should compile images", async () => {
     backgroundData,
     {},
     [],
+	{},
     "mixed",
     `${__dirname}/_files/`,
     { warnings: () => {} }
@@ -36,6 +37,7 @@ test("should compile split large images into two tilesets for CGB mode", async (
     backgroundData,
     {},
     [],
+	{},
     "color",
     `${__dirname}/_files/`,
     { warnings: () => {} }
@@ -56,6 +58,7 @@ test("should compile large images into one overflowing bank when not in color on
     backgroundData,
     {},
     [],
+	{},
     "mixed",
     `${__dirname}/_files/`,
     { warnings: () => {} }
@@ -75,6 +78,7 @@ test("should split tiles into two banks when in color only mode, filling first 1
     backgroundData,
     {},
     [],
+	{},
     "color",
     `${__dirname}/_files/`,
     { warnings: () => {} }

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -43,6 +43,7 @@ export const dummySceneNormalized: SceneNormalized = {
   symbol: "scene_0",
   backgroundId: "",
   tilesetId: "",
+  allocationStrat: 0,
   x: 0,
   y: 0,
   width: 20,
@@ -122,6 +123,7 @@ export const dummyPrecompiledBackground: PrecompiledBackground = {
     symbol: "ta_1",
     data: new Uint8Array(),
   },
+  allocationStrat: 0,
 };
 
 export const dummyBackground: Background = {

--- a/test/store/features/assets/assetsMiddleware.test.ts
+++ b/test/store/features/assets/assetsMiddleware.test.ts
@@ -58,6 +58,7 @@ test("Should trigger call to check background assets", async () => {
   const action = actions.loadBackgroundAssetInfo({
     backgroundId: "bg1",
     is360: false,
+	allocationStrat: 0,
   });
 
   middleware(store)(next)(action);
@@ -70,6 +71,7 @@ test("Should trigger call to check background assets", async () => {
       id: "bg1",
       numTiles: 10,
       is360: false,
+	  allocationStrat: 0,
       isCGBOnly: false,
       warnings: ["Warning 1"],
       lookup: [],
@@ -96,6 +98,7 @@ test("Should not trigger call to check background assets if already cached asset
             id: "bg1",
             assets: ["Warning 2"],
             is360: false,
+			allocationStrat: 0,
             isCGBOnly: false,
             timestamp: 100,
           },
@@ -131,6 +134,7 @@ test("Should not trigger call to check background assets if already cached asset
   const action = actions.loadBackgroundAssetInfo({
     backgroundId: "bg1",
     is360: false,
+	allocationStrat: 0,
   });
 
   middleware(store)(next)(action);
@@ -193,6 +197,7 @@ test("Should trigger call to check background assets if cache has expired", asyn
   const action = actions.loadBackgroundAssetInfo({
     backgroundId: "bg1",
     is360: false,
+	allocationStrat: 0,
   });
 
   middleware(store)(next)(action);
@@ -205,6 +210,7 @@ test("Should trigger call to check background assets if cache has expired", asyn
       id: "bg1",
       numTiles: 10,
       is360: false,
+	  allocationStrat: 0,
       isCGBOnly: false,
       warnings: ["Warning 1"],
       lookup: [],

--- a/test/store/features/assets/assetsState.test.ts
+++ b/test/store/features/assets/assetsState.test.ts
@@ -12,6 +12,7 @@ test("Should set loading flag while fetching background warnings", () => {
   const action = actions.loadBackgroundAssetInfo({
     backgroundId: "bg1",
     is360: false,
+	allocationStrat: 0,
   });
   const newState = reducer(state, action);
   expect(newState.backgroundsLoading).toBe(true);
@@ -28,6 +29,7 @@ test("Should be able to set background warnings", () => {
     warnings: ["warning 1", "warning 2"],
     numTiles: 10,
     is360: false,
+	allocationStrat: 0,
     isCGBOnly: false,
     lookup: [],
   });
@@ -53,6 +55,7 @@ test("Should replace existing warnings", () => {
         warnings: ["warning 1", "warning 2"],
         numTiles: 10,
         is360: false,
+		allocationStrat: 0,
         isCGBOnly: false,
         timestamp: 0,
         lookup: [],
@@ -64,6 +67,7 @@ test("Should replace existing warnings", () => {
     warnings: ["warning 3"],
     numTiles: 15,
     is360: false,
+	allocationStrat: 0,
     isCGBOnly: false,
     lookup: [],
   });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: Allows the user to specify the tile allocation style for a background.

By default both options are checked and is the same behaviour as GBS 4 which reserve tiles for its default ui and allocate BG tiles upwards in the shared tileset VRAM to prioritise sprite tile overflowing in it.

Unchecking both options "Prioritize Sprite Allocation" and "Reserve UI Tiles" will have the same behaviour as GBS 3.


* **What is the current behavior?** (You can also link to an open issue here)
Current behavior forces a certain tile allocation, making it hard to have control over the tileset VRAM


* **What is the new behavior (if this is a feature change)?**
2 checkboxes are added under the background selection in a scene allowing to change tile allocation behavior.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes should occur as the tile allocation will be the same as GBS 4 was by default.


* **Other information**:
Some screenshots
![image](https://github.com/user-attachments/assets/f7eec94a-e623-4202-8f12-db0c0f11f130)
![image](https://github.com/user-attachments/assets/4cb25799-0944-43a8-927d-c67a8b083ea3)
