### PR TITLE
Add missing localization for Minimize menu

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1314,6 +1314,7 @@
   "MENU_DELETE": "Delete",
   "MENU_SELECT_ALL": "Select All",
   "MENU_WINDOW": "Window",
+  "MENU_MINIMIZE": "Minimize",
   "MENU_HELP": "Help",
   "MENU_SET_BREAKPOINT": "Set Breakpoint",
   "MENU_DELETE_SONG": "Delete Song",

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -480,7 +480,7 @@ const buildMenu = async (plugins: MenuItemConstructorOptions[] = []) => {
         {
           label: l10n("MENU_MINIMIZE"),
           role: "minimize",
-        }
+        },
       ],
     },
     {
@@ -581,7 +581,7 @@ const buildMenu = async (plugins: MenuItemConstructorOptions[] = []) => {
 
     // Window menu
     template[template.length - 2].submenu = [
-      { role: "minimize" },
+      { label: l10n("MENU_MINIMIZE"), role: "minimize" },
       { role: "zoom" },
       { type: "separator" },
       { role: "front" },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -476,7 +476,12 @@ const buildMenu = async (plugins: MenuItemConstructorOptions[] = []) => {
     {
       role: "window",
       label: l10n("MENU_WINDOW"),
-      submenu: [{ role: "minimize" }],
+      submenu: [
+        {
+          label: l10n("MENU_MINIMIZE"),
+          role: "minimize",
+        }
+      ],
     },
     {
       role: "help",


### PR DESCRIPTION
Add an entry for the minimize menu in the "en" lang file and reference it into the menu.ts code

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Minimize menu is not localized


* **What is the new behavior (if this is a feature change)?**
Minimize menu has in own entry in the lang file


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
