### PR TITLE
Add ROM usage visualization to build log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add event "Set Actor Collision Bounding Box" to modify collision shape
 - Add event "Set Text Sound Effect" to set a sound effect to play as each dialogue text character is displayed
 - When deleting scripts, you are now given the option to also delete all "Call Script" events that reference the script
+- Add ROM usage monitor to Build Log showing how much free space is available before the next ROM size increase [@pau-tomas](https://github.com/pau-tomas)
 
 ### Changed
 

--- a/src/app/project/initProject.ts
+++ b/src/app/project/initProject.ts
@@ -446,3 +446,7 @@ API.events.debugger.disconnected.subscribe(() => {
 API.events.project.saveProgress.subscribe((_, completed, total) => {
   store.dispatch(projectActions.setSaveWriteProgress({ completed, total }));
 });
+
+API.events.debugger.romusage.subscribe((_, usageData) => {
+  store.dispatch(debuggerActions.setUsageData(usageData));
+});

--- a/src/components/debugger/DebuggerBuildLog.tsx
+++ b/src/components/debugger/DebuggerBuildLog.tsx
@@ -14,6 +14,7 @@ import {
   getSettings,
 } from "store/features/settings/settingsState";
 import settingsActions from "store/features/settings/settingsActions";
+import DebuggerUsageData from "components/debugger/DebuggerUsageData";
 
 const PIN_TO_BOTTOM_RANGE = 100;
 
@@ -191,6 +192,8 @@ const DebuggerBuildLog = () => {
             {l10n("BUILD_EMPTY_BUILD_CACHE")}
           </MenuItem>
         </DropdownButton>
+        <FlexGrow />
+        <DebuggerUsageData></DebuggerUsageData>
         <FlexGrow />
         <Button onClick={onClear}>{l10n("BUILD_CLEAR")}</Button>
       </ButtonToolbar>

--- a/src/components/debugger/DebuggerUsageData.tsx
+++ b/src/components/debugger/DebuggerUsageData.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from "react";
+import l10n from "shared/lib/lang/l10n";
+import { useAppSelector } from "store/hooks";
+import styled from "styled-components";
+import { TooltipWrapper } from "ui/tooltips/Tooltip";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  white-space: nowrap;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  gap: 6px;
+  flex-grow: 2;
+`;
+
+const Total = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  background-color: black;
+  height: 20px;
+  border-radius: ${(props) => props.theme.borderRadius}px;
+  border: 1px solid ${(props) => props.theme.colors.input.border};
+  overflow: hidden;
+`;
+
+const Used = styled.div`
+  display: inline-block;
+  position: absolute;
+  left: 0;
+  background-color: ${(props) => props.theme.colors.highlight};
+  height: inherit;
+  transition: width 0.3s ease-in-out;
+  pointer-events: none;
+`;
+
+const SizeStep = styled.div`
+  position: relative;
+  display: inline-block;
+  height: inherit;
+  border-right: 1px solid ${(props) => props.theme.colors.input.border};
+  transition: width 0.3s ease-in-out;
+
+  :hover {
+    background-color: #191919;
+  }
+`;
+
+const TooltipChild = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+`;
+
+const sizes = [
+  { bytes: 128 * 1024 }, // 128 KiB
+  { bytes: 256 * 1024 }, // 256 KiB
+  { bytes: 512 * 1024 }, // 512 KiB
+  { bytes: 1 * 1024 * 1024 }, // 1 MiB
+  { bytes: 2 * 1024 * 1024 }, // 2 MiB
+  { bytes: 4 * 1024 * 1024 }, // 4 MiB
+];
+
+const renderSize = (bytes: number) => {
+  if (bytes < 1024) {
+    return `${bytes} bytes`;
+  } else if (bytes < 1024 * 1024) {
+    const kb = bytes / 1024;
+    return `${parseFloat(kb.toFixed(2))} KiB`;
+  } else {
+    const mb = bytes / (1024 * 1024);
+    return `${parseFloat(mb.toFixed(2))} MiB`;
+  }
+};
+
+const DebuggerUsageData = () => {
+  const usageData = useAppSelector((state) => state.debug.usageData);
+  const status = useAppSelector((state) => state.console.status);
+
+  const [zoom, setZoom] = useState(sizes.length - 1);
+
+  let totalUsage = 0;
+  let fullSize = 0;
+  let romSizeIndex = 0;
+  if (usageData) {
+    usageData.banks.forEach((bank) => (totalUsage += Number(bank.used)));
+    usageData.banks.forEach((bank) => (fullSize += Number(bank.size)));
+    for (let i = 0; i < sizes.length; i++) {
+      if (totalUsage <= sizes[i].bytes) {
+        romSizeIndex = i;
+        break;
+      }
+    }
+  }
+
+  const toggleZoom = (newZoom: number) => {
+    if (zoom === newZoom) {
+      setZoom(sizes.length - 1);
+    } else {
+      setZoom(newZoom);
+    }
+  };
+
+  const maxSize = sizes[zoom].bytes;
+  const usedPercent = (totalUsage * 100) / maxSize;
+
+  return (
+    <Wrapper>
+      {!usageData ? (
+        <div>
+          {status === "running"
+            ? l10n("FIELD_BUILDING")
+            : l10n("FIELD_RUN_A_BUILD_USAGE_DESC")}
+        </div>
+      ) : (
+        <>
+          <div>ROM:</div>
+          <Total onClick={() => toggleZoom(romSizeIndex)}>
+            {sizes.map((s, i) => {
+              const byteStep =
+                s.bytes - (sizes[i - 1] ? sizes[i - 1].bytes : 0);
+              return (
+                <SizeStep style={{ width: `${(byteStep * 100) / maxSize}%` }}>
+                  <TooltipWrapper
+                    tooltip={
+                      i <= romSizeIndex ? (
+                        <>
+                          <strong>
+                            {renderSize(sizes[romSizeIndex].bytes)}
+                          </strong>
+                          <div>
+                            {l10n("FIELD_CURRENT_ROM_SIZE_TOOLTIP", {
+                              freeSpace: renderSize(
+                                sizes[romSizeIndex].bytes - totalUsage
+                              ),
+                            })}
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <strong>{renderSize(sizes[i].bytes)}</strong>
+                          <div>
+                            {l10n("FIELD_NEXT_ROM_SIZE_TOOLTIP", {
+                              freeSpace: renderSize(
+                                sizes[i - 1].bytes - totalUsage
+                              ),
+                            })}
+                          </div>
+                        </>
+                      )
+                    }
+                  >
+                    <TooltipChild />
+                  </TooltipWrapper>
+                </SizeStep>
+              );
+            })}
+            <Used style={{ width: `${usedPercent}%` }}></Used>
+          </Total>
+          <div>
+            {l10n("FIELD_ROM_USAGE_LABEL", {
+              totalUsage: renderSize(totalUsage),
+              romSize: renderSize(sizes[romSizeIndex].bytes),
+            })}
+          </div>
+        </>
+      )}
+    </Wrapper>
+  );
+};
+
+export default DebuggerUsageData;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -322,7 +322,7 @@
   "FIELD_COLLIDE_WITH_DESC": "The groups of actors that will be checked for collisions. e.g. If it should pass through any actors but the player set this field to just 'Player'.",
   "FIELD_COLLISION_GROUP_N": "Group {n}",
   "FIELD_PLAYER": "Player",
-  "FIELD_ACTOR": "Actor",  
+  "FIELD_ACTOR": "Actor",
   "FIELD_IS_ABOVE": "Is Above",
   "FIELD_IS_BELOW": "Is Below",
   "FIELD_IS_LEFT_OF": "Is Left of",
@@ -766,7 +766,7 @@
   "FIELD_COLOR_MODE_COLOR_ONLY": "Color Only",
   "FIELD_COLOR_MODE_MONO_INFO": "GB, GB Color, Pocket",
   "FIELD_COLOR_MODE_COLOR_MONO_INFO": "GB, GB Color, Pocket",
-  "FIELD_COLOR_MODE_COLOR_ONLY_INFO": "GB Color, Pocket",  
+  "FIELD_COLOR_MODE_COLOR_ONLY_INFO": "GB Color, Pocket",
   "FIELD_SUPPORTED_PLATFORMS": "Supported Platforms",
   "FIELD_MONOCHROME_ONLY": "Monochrome only",
   "FIELD_SGB_UNAVAILABLE": "Super GB Mode is not supported for 'Color Only' games",
@@ -844,6 +844,10 @@
   "FIELD_APPLY_CHANGES": "Apply Changes",
   "FIELD_REVERT_CHANGES": "Revert Changes",
   "FIELD_PIN_TO_SCREEN": "Pin To Screen",
+  "FIELD_RUN_A_BUILD_USAGE_DESC": "Run a build to calculate ROM usage",
+  "FIELD_CURRENT_ROM_SIZE_TOOLTIP": "Your ROM needs to grow {freeSpace} to fill this size.",
+  "FIELD_NEXT_ROM_SIZE_TOOLTIP": "Your ROM needs to grow {freeSpace} to get to this size.",
+  "FIELD_ROM_USAGE_LABEL": "{totalUsage} of {romSize} used",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",
@@ -1342,7 +1346,7 @@
   "MENU_DELETE_SOUND_EFFECT": "Delete Sound Effect",
   "MENU_DELETE_PALETTE": "Delete Palette",
   "MENU_SPELLING": "Spelling and Grammar",
-  "MENU_CHECK_SPELLING_WHILE_TYPING" : "Check Spelling While Typing",
+  "MENU_CHECK_SPELLING_WHILE_TYPING": "Check Spelling While Typing",
   "MENU_DELETE_PREFAB": "Delete Prefab",
   "MENU_EDIT_PREFAB": "Edit Prefab",
 
@@ -1524,6 +1528,7 @@
   "COMPILER_COMPILING": "Compiling",
   "COMPILER_LINKING": "Linking",
   "COMPILER_PACKING": "Packing Data",
+  "COMPILER_ROMUSAGE": "Calculating ROM usage",
 
   "// 21": "Messages -----------------------------------------------------",
 

--- a/src/lib/compiler/romUsage.ts
+++ b/src/lib/compiler/romUsage.ts
@@ -1,0 +1,85 @@
+import fs from "fs-extra";
+import ensureBuildTools from "lib/compiler/ensureBuildTools";
+import spawn from "lib/helpers/cli/spawn";
+import l10n from "shared/lib/lang/l10n";
+
+type RomUsageOptions = {
+  buildRoot: string;
+  tmpPath: string;
+  progress: (msg: string) => void;
+  warnings: (msg: string) => void;
+};
+
+export type UsageData = {
+  banks: Array<{
+    name: string;
+    type: string;
+    baseBankNum: string;
+    isBanked: string;
+    isMergedBank: string;
+    rangeStart: string;
+    rangeEnd: string;
+    size: string;
+    used: string;
+    free: string;
+    usedPercent: string;
+    freePercent: string;
+    miniGraph: string;
+  }>;
+};
+
+const romUsage = async ({
+  buildRoot = "/tmp",
+  tmpPath = "/tmp",
+  warnings = (_msg) => {},
+  progress = (_msg) => {},
+}: RomUsageOptions) => {
+  const env = Object.create(process.env);
+
+  const buildToolsPath = await ensureBuildTools(tmpPath);
+  const buildToolsVersion = await fs.readFile(
+    `${buildToolsPath}/tools_version`,
+    "utf8"
+  );
+
+  env.PATH = [`${buildToolsPath}/gbdk/bin`, env.PATH].join(":");
+  env.GBDKDIR = `${buildToolsPath}/gbdk/`;
+  env.GBS_TOOLS_VERSION = buildToolsVersion;
+
+  const options = {
+    cwd: buildRoot,
+    env,
+    shell: true,
+  };
+
+  const romusageCommand =
+    process.platform === "win32"
+      ? `..\\_gbstools\\gbdk\\bin\\romusage.exe`
+      : `../_gbstools/gbdk/bin/romusage`;
+  const romusageArgs = [`${buildRoot}/build/rom/game.map`, `-g`, `-sH`, `-sJ`];
+
+  let output = "";
+  progress(`${l10n("COMPILER_ROMUSAGE")}...`);
+  const { completed: romusageCompleted } = spawn(
+    romusageCommand,
+    romusageArgs,
+    options,
+    {
+      onLog: (msg) => {
+        output += msg;
+      },
+      onError: (msg) => {
+        if (msg.indexOf("Romusage") > -1) {
+          return;
+        }
+        warnings(msg);
+      },
+    }
+  );
+
+  await romusageCompleted;
+
+  return JSON.parse(output) as UsageData;
+};
+
+export default romUsage;

--- a/src/renderer/lib/api/setup.ts
+++ b/src/renderer/lib/api/setup.ts
@@ -39,6 +39,7 @@ import type { ScriptEventDefs } from "shared/lib/scripts/scriptDefHelpers";
 import type { MenuZoomType } from "menu";
 import type { DebuggerDataPacket } from "shared/lib/debugger/types";
 import type { SceneMapData, VariableMapData } from "lib/compiler/compileData";
+import type { UsageData } from "lib/compiler/romUsage";
 import type { TilesetAssetData } from "lib/project/loadTilesetData";
 import type { Asset, AssetType } from "shared/lib/helpers/assets";
 import type { Patrons } from "scripts/fetchPatrons";
@@ -426,6 +427,10 @@ const APISetup = {
       disconnected: createSubscribeAPI<(event: IpcRendererEvent) => void>(
         "debugger:disconnected"
       ),
+      romusage:
+        createSubscribeAPI<(event: IpcRendererEvent, data: UsageData) => void>(
+          "debugger:romusage"
+        ),
     },
     project: {
       saveProgress: createSubscribeAPI<

--- a/src/store/features/buildGame/buildGameMiddleware.ts
+++ b/src/store/features/buildGame/buildGameMiddleware.ts
@@ -83,14 +83,6 @@ const buildGameMiddleware: Middleware<Dispatch, RootState> =
       }
 
       dispatch(consoleActions.completeConsole());
-    } else if (consoleActions.stdErr.match(action)) {
-      const state = store.getState();
-      const dispatch = store.dispatch.bind(store);
-      if (state.project.present.settings.openBuildLogOnWarnings) {
-        dispatch(settingsActions.editSettings({ debuggerEnabled: true }));
-        dispatch(navigationActions.setSection("world"));
-        dispatch(debuggerActions.setIsLogOpen(true));
-      }
     }
 
     return next(action);

--- a/src/store/features/debugger/debuggerState.ts
+++ b/src/store/features/debugger/debuggerState.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { SceneMapData, VariableMapData } from "lib/compiler/compileData";
+import type { UsageData } from "lib/compiler/romUsage";
 import isEqual from "lodash/isEqual";
 import type { DebuggerScriptContext } from "shared/lib/debugger/types";
 
@@ -15,6 +16,7 @@ export interface DebuggerState {
   currentSceneSymbol: string;
   isPaused: boolean;
   isLogOpen: boolean;
+  usageData: UsageData | null;
 }
 
 export const initialState: DebuggerState = {
@@ -29,6 +31,7 @@ export const initialState: DebuggerState = {
   currentSceneSymbol: "",
   isPaused: true,
   isLogOpen: false,
+  usageData: null,
 };
 
 const debuggerSlice = createSlice({
@@ -79,6 +82,9 @@ const debuggerSlice = createSlice({
     },
     setIsLogOpen: (state, action: PayloadAction<boolean>) => {
       state.isLogOpen = action.payload;
+    },
+    setUsageData: (state, action: PayloadAction<UsageData>) => {
+      state.usageData = action.payload;
     },
   },
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

Other than looking at the size of the compiled rom for the game there's no way to know the size of the it. Additionally since the rom size grows in "steps" there has been confusion about the real size of the game and when it'll grow to the next rom size.

* **What is the new behavior (if this is a feature change)?**

This change adds a rom usage visualization to the build log panel. The visualization appears and gets updated after each build of the game and includes a way to see the different steps (128 KiB, 256 KiB, 1 MiB, 2MiB and 4MiB) and how much the rom needs to grow to get to the next step size.

<img width="901" alt="image" src="https://github.com/user-attachments/assets/53bbca2d-a342-4591-b416-f8fcf9021136">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
