### PR TITLE
Add Instant fade speed to scene pop events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve build cancelling: Stops spawned processes immediately rather than waiting for in progress processes to complete
 - Changing the engine field in a "Store Engine Field In Variable" event no longer resets the variable
 - Build time now shown in seconds when < 60s and minutes+seconds when >= 60s
+- Update Scene Pop events to allow setting Fade Speed as "Instant" [@pau-tomas](https://github.com/pau-tomas)
 
 ### Fixed
 

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -4573,8 +4573,13 @@ extern void __mute_mask_${symbol};
 
   scenePopState = (fadeSpeed = 2) => {
     this._addComment("Pop Scene State");
-    this._setConstMemInt8("fade_frames_per_step", fadeSpeeds[fadeSpeed] ?? 0x3);
-    this._fadeOut(true);
+    if (fadeSpeed > 0) {
+      this._setConstMemInt8(
+        "fade_frames_per_step",
+        fadeSpeeds[fadeSpeed] ?? 0x3
+      );
+      this._fadeOut(true);
+    }
     this._setConstMemInt8("camera_settings", ".CAMERA_LOCK");
     this._scenePop();
     this._addNL();
@@ -4582,8 +4587,14 @@ extern void __mute_mask_${symbol};
 
   scenePopAllState = (fadeSpeed = 2) => {
     this._addComment("Pop All Scene State");
-    this._setConstMemInt8("fade_frames_per_step", fadeSpeeds[fadeSpeed] ?? 0x3);
-    this._fadeOut(true);
+    this._addComment("" + fadeSpeed);
+    if (fadeSpeed > 0) {
+      this._setConstMemInt8(
+        "fade_frames_per_step",
+        fadeSpeeds[fadeSpeed] ?? 0x3
+      );
+      this._fadeOut(true);
+    }
     this._setConstMemInt8("camera_settings", ".CAMERA_LOCK");
     this._scenePopAll();
     this._addNL();

--- a/src/lib/events/eventScenePopAllState.js
+++ b/src/lib/events/eventScenePopAllState.js
@@ -18,6 +18,7 @@ const fields = [
     label: l10n("FIELD_FADE_SPEED"),
     description: l10n("FIELD_SPEED_FADE_DESC"),
     type: "fadeSpeed",
+    allowNone: true,
     defaultValue: "2",
     width: "50%",
   },

--- a/src/lib/events/eventScenePopState.js
+++ b/src/lib/events/eventScenePopState.js
@@ -18,6 +18,7 @@ const fields = [
     label: l10n("FIELD_FADE_SPEED"),
     description: l10n("FIELD_SPEED_FADE_DESC"),
     type: "fadeSpeed",
+    allowNone: true,
     defaultValue: "2",
     width: "50%",
   },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The Restore Previous Scene and Restore First Scene events don't have the option for an instant transition like Scene Change event.

* **What is the new behavior (if this is a feature change)?**

Added the Instant option

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
