### PR TITLE
Set icon for deb and rpm packages

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -22,11 +22,19 @@ module.exports = async () => {
       new MakerAppImage({}),
       {
         name: "@electron-forge/maker-deb",
-        config: {},
+        config: {
+          options: {
+            icon: 'src/assets/app/icon/app_icon.png'
+          }
+        },
       },
       {
         name: "@electron-forge/maker-rpm",
-        config: {},
+        config: {
+          options: {
+            icon: 'src/assets/app/icon/app_icon.png'
+          }
+        },
       },
     ],
     packagerConfig: {


### PR DESCRIPTION
Linux packages require additional configuration in order for the desktop icon to be correctly set[^1].

Fixes #936

[^1]: https://www.electronforge.io/guides/create-and-add-icons#linux