### PR TITLE
Add Animation States To Global Header File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to right click a scene to "Run From Here" allowing quick preview of a specific scene. Optionally can only include the selected scenes for faster build previews in large projects.
 - Add events "Load Projectile Into Slot" and "Launch Projectile In Slot" to allow more advanced control over setup and launch of projectiles and changing the loaded projectiles at run time
 - Add ability to hover over tiles in debugger VRAM preview to see tile memory address information [@pau-tomas](https://github.com/pau-tomas)
+- Add animation states to generated `game_globals.h` allowing use from engine code [@Mico27](https://github.com/Mico27)
 
 ### Changed
 

--- a/src/lib/compiler/compileData.ts
+++ b/src/lib/compiler/compileData.ts
@@ -2101,7 +2101,8 @@ const compile = async (
 
   output["game_globals.h"] = compileGameGlobalsHeader(
     variableAliasLookup,
-    projectData.variables.constants
+    projectData.variables.constants,
+	precompiled.stateReferences
   );
 
   const variableMap = keyBy(Object.values(variableAliasLookup), "symbol");

--- a/src/lib/compiler/generateGBVMData.ts
+++ b/src/lib/compiler/generateGBVMData.ts
@@ -1252,7 +1252,8 @@ export const compileGameGlobalsInclude = (
 
 export const compileGameGlobalsHeader = (
   variableAliasLookup: Record<string, VariableMapData>,
-  constants: Constant[]
+  constants: Constant[],
+  stateReferences: string[]
 ) => {
   return (
     `#ifndef GAME_GLOBALS_H\n#define GAME_GLOBALS_H\n\n` +
@@ -1269,6 +1270,11 @@ export const compileGameGlobalsHeader = (
         return `#define ${constant.symbol.toLocaleUpperCase()} ${
           constant.value
         }\n`;
+	  })
+      .join("") +
+	stateReferences
+      .map((string, stringIndex) => {
+        return `#define ${string} ${stringIndex}\n`;
       })
       .join("") +
     `\n` +

--- a/test/compiler/generateGBVMData.test.ts
+++ b/test/compiler/generateGBVMData.test.ts
@@ -1,0 +1,51 @@
+import { compileGameGlobalsHeader } from "lib/compiler/generateGBVMData";
+
+describe("compileGameGlobalsHeader", () => {
+  test("should include variables, constants and state references in global header", () => {
+    const output = compileGameGlobalsHeader(
+      {
+        var1: {
+          id: "var1",
+          name: "Variable 1",
+          symbol: "VAR_1",
+          isLocal: false,
+          entityType: "scene",
+          entityId: "",
+          sceneId: "",
+        },
+        var2: {
+          id: "var2",
+          name: "Variable 2",
+          symbol: "VAR_2",
+          isLocal: false,
+          entityType: "scene",
+          entityId: "",
+          sceneId: "",
+        },
+      },
+      [
+        {
+          symbol: "CONST_0",
+          id: "const0",
+          name: "Constant 0",
+          value: 0,
+        },
+        {
+          symbol: "CONST_1",
+          id: "const1",
+          name: "Constant 1",
+          value: 64,
+        },
+      ],
+      ["STATE_DEFAULT", "STATE_EXPLODE", "STATE_OPEN"]
+    );
+    expect(output).toInclude("VAR_1 0");
+    expect(output).toInclude("VAR_2 1");
+    expect(output).toInclude("MAX_GLOBAL_VARS 2");
+    expect(output).toInclude("CONST_0 0");
+    expect(output).toInclude("CONST_1 64");
+    expect(output).toInclude("STATE_DEFAULT 0");
+    expect(output).toInclude("STATE_EXPLODE 1");
+    expect(output).toInclude("STATE_OPEN 2");
+  });
+});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add animation states to the game_globals.h file (not just the game_globals.i file) so that they can be referenced in engine code.


* **What is the current behavior?** (You can also link to an open issue here)
Animation states are currently only in game_globals.i file, so to be able to refer to them in engine code you have to manually create the defines. However using this method, somtimes the animation states values change and you have to recreate the defines by copy pasting from the game_globals.i file everytime that happens.


* **What is the new behavior (if this is a feature change)?**
This will add the animations state includes in the game_globals.h file which can be referenced in engine code without having to define them manually.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I'm aware of


* **Other information**:
