### PR TITLE
Add support for symlinks in plugin folder

### DIFF
--- a/src/lib/project/loadAvatarData.ts
+++ b/src/lib/project/loadAvatarData.ts
@@ -60,7 +60,7 @@ const loadAllAvatarData = async (
     `${projectRoot}/assets/avatars/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/avatars/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/avatars/**/@(*.png|*.PNG)`
   );
   const imageData = (
     await Promise.all(

--- a/src/lib/project/loadBackgroundData.ts
+++ b/src/lib/project/loadBackgroundData.ts
@@ -66,7 +66,7 @@ const loadAllBackgroundData = async (projectRoot: string) => {
     `${projectRoot}/assets/backgrounds/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/backgrounds/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/backgrounds/**/@(*.png|*.PNG)`
   );
   const imageData = (
     await Promise.all(

--- a/src/lib/project/loadEmoteData.ts
+++ b/src/lib/project/loadEmoteData.ts
@@ -59,7 +59,7 @@ const loadAllEmoteData = async (
     `${projectRoot}/assets/emotes/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/emotes/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/emotes/**/@(*.png|*.PNG)`
   );
   const imageData = (
     await Promise.all(

--- a/src/lib/project/loadFontData.ts
+++ b/src/lib/project/loadFontData.ts
@@ -78,7 +78,7 @@ const loadAllFontData = async (
     `${projectRoot}/assets/fonts/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/fonts/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/fonts/**/@(*.png|*.PNG)`
   );
   const imageData = (
     await Promise.all(

--- a/src/lib/project/loadMusicData.ts
+++ b/src/lib/project/loadMusicData.ts
@@ -38,7 +38,7 @@ const loadAllMusicData = async (projectRoot: string) => {
     `${projectRoot}/assets/music/**/@(*.mod|*.MOD|*.uge|*.UGE)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/music/**/@(*.mod|*.MOD|*.uge|*.UGE)`
+    `${projectRoot}/plugins/*/**/music/**/@(*.mod|*.MOD|*.uge|*.UGE)`
   );
   const musicData = await Promise.all(
     ([] as Promise<MusicResourceAsset>[]).concat(

--- a/src/lib/project/loadScriptEventHandlers.ts
+++ b/src/lib/project/loadScriptEventHandlers.ts
@@ -237,7 +237,7 @@ const loadAllScriptEventHandlers = async (projectRoot: string) => {
   const corePaths = await globAsync(`${eventsRoot}/event*.js`);
 
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/events/event*.js`
+    `${projectRoot}/plugins/*/**/events/event*.js`
   );
 
   const eventHandlers: ScriptEventHandlers = {};

--- a/src/lib/project/loadSoundData.ts
+++ b/src/lib/project/loadSoundData.ts
@@ -59,7 +59,7 @@ const loadAllSoundData = async (projectRoot: string) => {
     `${projectRoot}/assets/sounds/**/@(*.vgm|*.VGM|*.vgz|*.VGZ|*.wav|*.WAV|*.sav|*.SAV)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/sounds/**/@(*.vgm|*.VGM|*.vgz|*.VGZ|*.wav|*.WAV|*.sav|*.SAV)`
+    `${projectRoot}/plugins/*/**/sounds/**/@(*.vgm|*.VGM|*.vgz|*.VGZ|*.wav|*.WAV|*.sav|*.SAV)`
   );
   const soundsData = await Promise.all(
     ([] as Promise<SoundResourceAsset>[]).concat(

--- a/src/lib/project/loadSpriteData.ts
+++ b/src/lib/project/loadSpriteData.ts
@@ -82,7 +82,7 @@ const loadAllSpriteData = async (projectRoot: string) => {
     `${projectRoot}/assets/sprites/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/sprites/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/sprites/**/@(*.png|*.PNG)`
   );
   const spriteData = (
     await Promise.all(

--- a/src/lib/project/loadTilesetData.ts
+++ b/src/lib/project/loadTilesetData.ts
@@ -56,7 +56,7 @@ const loadAllTilesetData = async (projectRoot: string) => {
     `${projectRoot}/assets/tilesets/**/@(*.png|*.PNG)`
   );
   const pluginPaths = await globAsync(
-    `${projectRoot}/plugins/**/tilesets/**/@(*.png|*.PNG)`
+    `${projectRoot}/plugins/*/**/tilesets/**/@(*.png|*.PNG)`
   );
   const imageData = (
     await Promise.all(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix (for a very narrow use case)

* **What is the current behavior?** (You can also link to an open issue here)

When developing plugins I use them on my test project via a symlink to my local plugin repo folder. That way I can develop in the repo but test in a project that doesn't get commited to the remote repo. Currently the glob for the plugins uses `**` and according to the node-glob documentation  it doesn't follow symlinks. 
 


* **What is the new behavior (if this is a feature change)?**

Updates the glob to  `*/**`. This will work because it will follow the first symlink to the local repo and then just use `**` as normal inside it. The only difference is that it'll ignore files in the plugins folder but that's ok since we only care about subfolder at that level.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I could have updated to the latest version of node-glob and use `follow: true` but that seem a bit extreme  and prone to edge case errors for such a small case.