### PR TITLE
Fix launching projectiles in actor direction

### DIFF
--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -4011,7 +4011,7 @@ extern void __mute_mask_${symbol};
     rpn
       .int16(0) // Save space for direction
       .stop();
-    this._actorGetAngle(actorRef, ".ARG1");
+    this._actorGetAngle(actorRef, ".ARG0");
     this._projectileLaunch(projectileIndex, ".ARG2");
     this._stackPop(3);
     this._addNL();
@@ -4029,8 +4029,8 @@ extern void __mute_mask_${symbol};
     rpn
       .int16(0) // Save space for direction
       .stop();
-    this.setActorId(".ARG1", actorId);
-    this._actorGetAngle(".ARG1", ".ARG1");
+    this.setActorId(".ARG0", actorId);
+    this._actorGetAngle(".ARG0", ".ARG0");
     this._projectileLaunch(projectileIndex, ".ARG2");
     this._stackPop(3);
     this._addNL();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix; fixes issue #1639.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, when launching projectiles in an actor's direction, the projectile launches upward at the topmost tile of the screen as seen in the issue listed above.


* **What is the new behavior (if this is a feature change)?**
The issue is now fixed and the projectiles now are able to fire in the correct position and direction.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I'm aware of.


* **Other information**:
