### PR TITLE
Fix checkbox not working on engine fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where changing the dimensions of a sprite png image could cause the sprite editor's tile palette to display incorrectly
 - Fix line numbers in code editor for GBVM scripts with more than 999 lines
 - Fix issue preventing projects being created with the name "project"
+- Fix issue preventing checkbox type working in engine fields [@pau-tomas](https://github.com/pau-tomas)
 
 ## [4.1.3] - 2024-09-16
 

--- a/src/components/settings/EngineFieldsEditor.tsx
+++ b/src/components/settings/EngineFieldsEditor.tsx
@@ -124,14 +124,12 @@ export const EngineFieldInput: FC<EngineFieldInputProps> = ({
     );
   }
   if (field.type === "checkbox") {
-    const theValue =
-      typeof value === "boolean" ? Boolean(value) : Boolean(field.defaultValue);
     return (
       <Checkbox
         id={field.key}
         name={field.key}
-        checked={theValue}
-        onChange={(e) => onChange(e.currentTarget.checked)}
+        checked={value === 1 ? true : false}
+        onChange={(e) => onChange(e.currentTarget.checked === true ? 1 : 0)}
       />
     );
   }

--- a/src/shared/lib/entities/entitiesTypes.ts
+++ b/src/shared/lib/entities/entitiesTypes.ts
@@ -333,7 +333,7 @@ export type CustomEventNormalized = Omit<CustomEvent, "script"> & {
 
 export type EngineFieldValue = {
   id: string;
-  value?: number | string | boolean | undefined;
+  value?: number | string | undefined;
 };
 
 export type MetaspriteTile = {

--- a/src/shared/lib/resources/types.ts
+++ b/src/shared/lib/resources/types.ts
@@ -715,9 +715,7 @@ export type VariablesResource = Static<typeof VariablesResource>;
 
 export const EngineFieldValueData = Type.Object({
   id: Type.String(),
-  value: Type.Optional(
-    Type.Union([Type.String(), Type.Boolean(), Type.Number()])
-  ),
+  value: Type.Optional(Type.Union([Type.String(), Type.Number()])),
 });
 
 export type EngineFieldValueData = Static<typeof EngineFieldValueData>;

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -4171,7 +4171,7 @@ const editEngineFieldValue: CaseReducer<
   EntitiesState,
   PayloadAction<{
     engineFieldId: string;
-    value: string | number | boolean | undefined;
+    value: string | number | undefined;
   }>
 > = (state, action) => {
   engineFieldValuesAdapter.upsertOne(state.engineFieldValues, {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a plugin sets an engine field to type "checkbox" the game will not compile with an `?ASlink-Warning-Undefined Global 'true' referenced by module ''` error.

* **What is the new behavior (if this is a feature change)?**

It allows for checkbox type to be used as engine field.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. People has been using some alternatives for this case (like 0-1 slider on [Belt Scroller](https://github.com/shin-gamedev/gbs-belt-scroller/blob/main/Belt%20Scroller%20Plugin/engine/engine.json#L8) or a Select on [Platformer+](https://github.com/becomingplural/GBS_PlatformerPlus/blob/930ecd3730a7145ef5b2b4ca275a1c507ad1e200/plugins/PlatformerPlus/engine/engine.json#L146))

* **Other information**:

An alternative approach would have been to update `compileBootstrap.ts` and check if the value is a boolean and replace it by a 1 or 0 before generating the`script_engine_init.s` file, but it felt more hacky than just disallow for boolean values for the engine fields.