### PR TITLE
Fix bug with out-of-bounds memory writes on 8-bit values in init script

### DIFF
--- a/src/lib/compiler/compileBootstrap.ts
+++ b/src/lib/compiler/compileBootstrap.ts
@@ -93,7 +93,10 @@ ${usedEngineFields
       engineValue && engineValue.value !== undefined
         ? engineValue.value
         : engineField.defaultValue;
-    return `        VM_SET_CONST_INT16      _${engineField.key}, ${value}`;
+    if(engineField.cType === "WORD" || engineField.cType === "UWORD")
+        return `        VM_SET_CONST_INT16      _${engineField.key}, ${value}`;
+    else
+        return `        VM_SET_CONST_INT8       _${engineField.key}, ${value}`;
   })
   .join("\n")}
 


### PR DESCRIPTION
* Make generated script_engine_init code check engineField data type and generate VM_SET_CONST_INT8 instead of VM_SET_CONST_INT16 for 8-bit data types

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This changes the compileBootstrap.ts script generating the script_engine_init routine to use the appropriate VM_SET_CONST instruction for 16-bit / 8-bit variables instead of always assuming they are 16-bit.

* **What is the current behavior?** (You can also link to an open issue here)

Current behaviour is that VM_SET_CONST_INT_16 is used to initialize all the variables in usedEngineFields, ignoring their data size.

This causes an out-of-bounds memory write for those engine fields that happen to be 8-bit. And it appears to have gone mostly unnoticed in GB Studio builds - perhaps because incorrectly overwritten data did not cause any visible bugs.

However, for my NES fork BB Studio (https://github.com/michel-iwaniec/bb-studio) this was causing a serious crash, as one of the 8-bit engine fields was placed just before an ISR trampoline in RAM.

* **What is the new behavior (if this is a feature change)?**

The new behavior is that script_engine_init generates the appropriate VM_SET_CONST instruction depending on the cType member for the engineField:

- VM_SET_CONST_INT16 when cType is "WORD"
- VM_SET_CONST_INT16 when cType is "UWORD"
- VM_SET_CONST_INT8 otherwise

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes as far as I'm aware.

* **Other information**:
