### PR TITLE
Add camera properties to Value Selects

### DIFF
--- a/src/components/script/hooks/useScriptEventTitle.tsx
+++ b/src/components/script/hooks/useScriptEventTitle.tsx
@@ -108,6 +108,9 @@ export const useScriptEventTitle = (
     async function fetchAutoLabel() {
       if (scriptEventDefs[command]?.hasAutoLabel) {
         const actorNameForId = (value: unknown) => {
+          if (value === "camera") {
+            return l10n("FIELD_CAMERA");
+          }
           if (context.type === "script" && customEvent) {
             return (
               customEvent.actors[value as string]?.name ||

--- a/src/components/ui/icons/Icons.tsx
+++ b/src/components/ui/icons/Icons.tsx
@@ -897,6 +897,12 @@ export const SettingsIcon = () => (
   </svg>
 );
 
+export const CameraIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24">
+    <path d="M16 16c0 1.104-.896 2-2 2h-12c-1.104 0-2-.896-2-2v-8c0-1.104.896-2 2-2h12c1.104 0 2 .896 2 2v8zm8-10l-6 4.223v3.554l6 4.223v-12z" />
+  </svg>
+);
+
 export const SadIcon = () => (
   <svg width="1096" height="974" viewBox="0 0 1096 974" version="1.1">
     <defs>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -989,6 +989,9 @@
   "FIELD_SHOW_TILE_VALUES": "Show Tile Values",
   "FIELD_SUBMIT_PLUGIN": "Submit Plugin",
   "FIELD_WAIT_UNTIL_BUTTON_PRESSED": "Wait Until Button Pressed",
+  "FIELD_CAMERA": "Camera",
+  "FIELD_DEADZONE_X": "Deadzone X",
+  "FIELD_DEADZONE_Y": "Deadzone Y",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/shared/lib/entities/entitiesHelpers.ts
+++ b/src/shared/lib/entities/entitiesHelpers.ts
@@ -992,7 +992,7 @@ export const updateCustomEventArgs = (
         };
         const addPropertyActor = (property: string) => {
           const actor = property && property.replace(/:.*/, "");
-          if (actor !== "player" && actor !== "$self$") {
+          if (actor !== "player" && actor !== "$self$" && actor !== "camera") {
             const letter = String.fromCharCode(
               "A".charCodeAt(0) + parseInt(actor)
             );

--- a/src/shared/lib/scriptValue/types.ts
+++ b/src/shared/lib/scriptValue/types.ts
@@ -166,6 +166,10 @@ const validProperties = [
   "pypos",
   "direction",
   "frame",
+  "xdeadzone",
+  "ydeadzone",
+  "xoffset",
+  "yoffset",
 ];
 
 export const isScriptValue = (value: unknown): value is ScriptValue => {

--- a/src/shared/lib/scripts/autoLabel.ts
+++ b/src/shared/lib/scripts/autoLabel.ts
@@ -81,6 +81,18 @@ export const getAutoLabel = (
       if (value === "frame") {
         return l10n("FIELD_ANIMATION_FRAME").replace(/ /g, "");
       }
+      if (value === "xdeadzone") {
+        return l10n("FIELD_DEADZONE_X").replace(/ /g, "");
+      }
+      if (value === "ydeadzone") {
+        return l10n("FIELD_DEADZONE_Y").replace(/ /g, "");
+      }
+      if (value === "xoffset") {
+        return l10n("FIELD_OFFSET_X").replace(/ /g, "");
+      }
+      if (value === "yoffset") {
+        return l10n("FIELD_OFFSET_Y").replace(/ /g, "");
+      }
       return value;
     };
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Camera properties (like position, deadzone or offset) can be set to values but can't be read with any native event. 

* **What is the new behavior (if this is a feature change)?**

Adds Camera position (tile and pixels), Deadzone and Offset to the list that can be selected as properties in the Value fields.

<img width="594" alt="image" src="https://github.com/user-attachments/assets/e4185006-1bce-495c-9a79-02dd0d7caa6a" />

This acts as a replacement for the [Store Camera Field in Variable](https://github.com/pau-tomas/gb-studio-plugins/tree/main?tab=readme-ov-file#store-camera-field-in-variable) plugin with the exception of the scroll fields.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
