### PR TITLE
Document direction encoding

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1122,7 +1122,7 @@
   "EVENT_ACTOR_GET_POSITION": "Store Actor Position In Variables",
   "EVENT_ACTOR_GET_POSITION_DESC": "Store the current position of an actor within two variables, one to store the horizontal position and another to store the vertical position.",
   "EVENT_ACTOR_GET_DIRECTION": "Store Actor Direction In Variable",
-  "EVENT_ACTOR_GET_DIRECTION_DESC": "Store the current direction of an actor within a variable.",
+  "EVENT_ACTOR_GET_DIRECTION_DESC": "Store the current direction of an actor within a variable.\nDown: 0\nRight: 1\nUp: 2\nLeft: 3",
   "EVENT_ACTOR_SET_POSITION_TO_VALUE": "Set Actor Position Using Variables",
   "EVENT_ACTOR_MOVE_TO": "Actor Move To",
   "EVENT_ACTOR_MOVE_TO_DESC": "Move an actor to a new position.",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
Currently the documentation states [what the Event block does](https://www.gbstudio.dev/docs/scripting/script-glossary/actor/#store-actor-direction-in-variable) without explaining how it does it.  [Users have requested that more details be added.](https://discord.com/channels/554713715442712616/749492438292496475/1362197586769084598)


* **What is the new behavior?**
I have added text to explaining what values correspond to what directions:
  - Down: 0
  - Right: 1
  - Up: 2
  - Left: 3

* **Does this PR introduce a breaking change?**
No.
Although I should note that after this change the docs would need to be updated whenever these values are altered, which might be undesired.


* **Other information**:
Let me know if I have not altered the text in the correct location.
