### PR TITLE
Feature: Allow setting the horizontal/vertical flip attributes of a tile in color mode

### DIFF
--- a/src/components/ui/icons/Icons.tsx
+++ b/src/components/ui/icons/Icons.tsx
@@ -99,6 +99,21 @@ export const AutoColorIcon = () => (
   </svg>
 );
 
+export const AutoFlipIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 16 16">
+    <path fill="#444" d="M0 15l6-5-6-4.9z"></path>
+	<path fill="#444" d="M9 10.1l6 4.9v-10l-6 5.1zM14 12.9l-3.4-2.8 3.4-3v5.8z"></path>
+	<path fill="#444" d="M7 5h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 3h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 7h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 9h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 11h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 13h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7 15h1v1h-1v-1z"></path>
+	<path fill="#444" d="M7.5 1v0c1.3 0 2.6 0.7 3.6 1.9l-1.1 1.1h3v-3l-1.2 1.2c-1.2-1.4-2.7-2.2-4.3-2.2 0 0 0 0 0 0-1.9 0-3.6 1-4.9 2.9l0.8 0.6c1.1-1.6 2.5-2.5 4.1-2.5z"></path>
+  </svg>
+);
+
 export const FlipHorizontalIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24">
     <g
@@ -539,16 +554,6 @@ export const FlipVerticalTileIcon = () => (
     <path d="M9 10H13V11L8 16L3 11L3 10H7L6.99999 6L3 6L3 5L8 0L13 5V6L9 6L9 10Z" />
   </svg>
 );
-
-/*
-<svg width="800px" height="800px" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6 9L6 13L5 13L-3.15903e-06 8L5 3L6 3L6 7L10 7L10 3L11 3L16 8L11 13L10 13L10 9L6 9Z" fill="#000000"/>
-</svg>
-
-<svg width="800px" height="800px" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 10H13V11L8 16L3 11L3 10H7L6.99999 6L3 6L3 5L8 0L13 5V6L9 6L9 10Z" fill="#000000"/>
-</svg>
-*/
 
 export const EraserIcon = () => (
   <svg

--- a/src/components/ui/icons/Icons.tsx
+++ b/src/components/ui/icons/Icons.tsx
@@ -528,6 +528,28 @@ export const PriorityTileIcon = () => (
   </svg>
 );
 
+export const FlipHorizontalTileIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 16 16">
+    <path d="M6 9L6 13L5 13L-3.15903e-06 8L5 3L6 3L6 7L10 7L10 3L11 3L16 8L11 13L10 13L10 9L6 9Z" />
+  </svg>
+);
+
+export const FlipVerticalTileIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 16 16">
+    <path d="M9 10H13V11L8 16L3 11L3 10H7L6.99999 6L3 6L3 5L8 0L13 5V6L9 6L9 10Z" />
+  </svg>
+);
+
+/*
+<svg width="800px" height="800px" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 9L6 13L5 13L-3.15903e-06 8L5 3L6 3L6 7L10 7L10 3L11 3L16 8L11 13L10 13L10 9L6 9Z" fill="#000000"/>
+</svg>
+
+<svg width="800px" height="800px" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 10H13V11L8 16L3 11L3 10H7L6.99999 6L3 6L3 5L8 0L13 5V6L9 6L9 10Z" fill="#000000"/>
+</svg>
+*/
+
 export const EraserIcon = () => (
   <svg
     width="24"

--- a/src/components/world/BrushToolbar.tsx
+++ b/src/components/world/BrushToolbar.tsx
@@ -15,6 +15,8 @@ import {
   EyeOpenIcon,
   EyeClosedIcon,
   PriorityTileIcon,
+  FlipVerticalTileIcon,
+  FlipHorizontalTileIcon,
   SlopeIcon,
   AutoColorIcon,
   CheckIcon,
@@ -31,6 +33,8 @@ import {
   BRUSH_MAGIC,
   DMG_PALETTE,
   TILE_COLOR_PROP_PRIORITY,
+  TILE_COLOR_PROP_FLIP_HORIZONTAL,
+  TILE_COLOR_PROP_FLIP_VERTICAL,
   BRUSH_SLOPE,
   defaultCollisionTileDefs,
   defaultProjectSettings,
@@ -553,6 +557,34 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
               title={l10n("TOOL_TILE_PRIORITY")}
             >
               <PriorityTileIcon />
+            </Button>
+          )}
+		  {showPalettes && (
+            <Button
+              variant="transparent"
+              onClick={
+                TILE_COLOR_PROP_FLIP_HORIZONTAL !== selectedPalette
+                  ? setSelectedPalette(TILE_COLOR_PROP_FLIP_HORIZONTAL)
+                  : setSelectedPalette(0)
+              }
+              active={TILE_COLOR_PROP_FLIP_HORIZONTAL === selectedPalette}
+              title={l10n("TOOL_TILE_FLIP_HORIZONTAL")}
+            >
+              <FlipHorizontalTileIcon />
+            </Button>
+          )}
+		  {showPalettes && (
+            <Button
+              variant="transparent"
+              onClick={
+                TILE_COLOR_PROP_FLIP_VERTICAL !== selectedPalette
+                  ? setSelectedPalette(TILE_COLOR_PROP_FLIP_VERTICAL)
+                  : setSelectedPalette(0)
+              }
+              active={TILE_COLOR_PROP_FLIP_VERTICAL === selectedPalette}
+              title={l10n("TOOL_TILE_FLIP_VERTICAL")}
+            >
+              <FlipVerticalTileIcon />
             </Button>
           )}
           {selectedBrush !== BRUSH_SLOPE && showTileTypes && (

--- a/src/components/world/BrushToolbar.tsx
+++ b/src/components/world/BrushToolbar.tsx
@@ -19,6 +19,7 @@ import {
   FlipHorizontalTileIcon,
   SlopeIcon,
   AutoColorIcon,
+  AutoFlipIcon,
   CheckIcon,
   BlankIcon,
   TileValueIcon,
@@ -410,6 +411,16 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
         })
       );
   }, [dispatch, scene?.backgroundId, background]);
+  
+  const onToggleAutoFlip = useCallback(() => {
+    scene?.backgroundId &&
+      dispatch(
+        entitiesActions.editBackgroundAutoFlip({
+          backgroundId: scene.backgroundId,
+          autoFlip: !background?.autoFlip,
+        })
+      );
+  }, [dispatch, scene?.backgroundId, background]);
 
   const onMouseUp = () => {
     if (timerRef.current) {
@@ -559,7 +570,7 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
               <PriorityTileIcon />
             </Button>
           )}
-		  {showPalettes && (
+		  {showPalettes && !background?.autoFlip && (
             <Button
               variant="transparent"
               onClick={
@@ -573,7 +584,7 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
               <FlipHorizontalTileIcon />
             </Button>
           )}
-		  {showPalettes && (
+		  {showPalettes && !background?.autoFlip && (
             <Button
               variant="transparent"
               onClick={
@@ -585,6 +596,16 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
               title={l10n("TOOL_TILE_FLIP_VERTICAL")}
             >
               <FlipVerticalTileIcon />
+            </Button>
+          )}
+		  {showPalettes && background && (
+            <Button
+              variant="transparent"
+              onClick={onToggleAutoFlip}
+              active={background.autoFlip}
+              title={l10n("FIELD_AUTO_FLIP")}
+            >
+              <AutoFlipIcon />
             </Button>
           )}
           {selectedBrush !== BRUSH_SLOPE && showTileTypes && (

--- a/src/components/world/ColorizedImage.worker.ts
+++ b/src/components/world/ColorizedImage.worker.ts
@@ -87,26 +87,22 @@ workerCtx.onmessage = async (evt) => {
 
   const imageData = ctx.getImageData(0, 0, width, height);
   const data = imageData.data;
-  const data_copy = [...data];
   for (let t = 0; t < tilesLength; t++) {
     const tX = t % tileWidth;
     const tY = Math.floor(t / tileWidth);
     const palette =
       palettesRGB[tiles[t] & TILE_COLOR_PALETTE] || palettesRGB[0];
-	const flipH = (tiles[t] & TILE_COLOR_PROP_FLIP_HORIZONTAL) == TILE_COLOR_PROP_FLIP_HORIZONTAL;
-	const flipV = (tiles[t] & TILE_COLOR_PROP_FLIP_VERTICAL) == TILE_COLOR_PROP_FLIP_VERTICAL;
     const p1X = tX * 8;
     const p2X = p1X + 8;
     const p1Y = tY * 8;
     const p2Y = p1Y + 8;
     for (let pX = p1X; pX < p2X; pX++) {
       for (let pY = p1Y; pY < p2Y; pY++) {
-        let index = (pX + pY * width) * 4;
-        const colorIndex = indexColour(data_copy[index + 1]);
+        const index = (pX + pY * width) * 4;
+        const colorIndex = indexColour(data[index + 1]);
         const color = previewAsMono
           ? dmgPalette[colorIndex]
           : palette[colorIndex];
-		index = (((flipH)?(p1X + (p2X - (pX + 1))):pX) + (((flipV)?(p1Y + (p2Y - (pY + 1))):pY) * width)) * 4;
         data[index] = color.r;
         data[index + 1] = color.g;
         data[index + 2] = color.b;

--- a/src/components/world/ColorizedImage.worker.ts
+++ b/src/components/world/ColorizedImage.worker.ts
@@ -1,4 +1,4 @@
-import { DMG_PALETTE } from "consts";
+import { DMG_PALETTE, TILE_COLOR_PROP_FLIP_HORIZONTAL, TILE_COLOR_PROP_FLIP_VERTICAL } from "consts";
 import { hex2GBCrgb } from "shared/lib/helpers/color";
 
 // eslint-disable-next-line no-restricted-globals
@@ -87,23 +87,26 @@ workerCtx.onmessage = async (evt) => {
 
   const imageData = ctx.getImageData(0, 0, width, height);
   const data = imageData.data;
-
+  const data_copy = [...data];
   for (let t = 0; t < tilesLength; t++) {
     const tX = t % tileWidth;
     const tY = Math.floor(t / tileWidth);
     const palette =
       palettesRGB[tiles[t] & TILE_COLOR_PALETTE] || palettesRGB[0];
+	const flipH = (tiles[t] & TILE_COLOR_PROP_FLIP_HORIZONTAL) == TILE_COLOR_PROP_FLIP_HORIZONTAL;
+	const flipV = (tiles[t] & TILE_COLOR_PROP_FLIP_VERTICAL) == TILE_COLOR_PROP_FLIP_VERTICAL;
     const p1X = tX * 8;
     const p2X = p1X + 8;
     const p1Y = tY * 8;
     const p2Y = p1Y + 8;
     for (let pX = p1X; pX < p2X; pX++) {
       for (let pY = p1Y; pY < p2Y; pY++) {
-        const index = (pX + pY * width) * 4;
-        const colorIndex = indexColour(data[index + 1]);
+        let index = (pX + pY * width) * 4;
+        const colorIndex = indexColour(data_copy[index + 1]);
         const color = previewAsMono
           ? dmgPalette[colorIndex]
           : palette[colorIndex];
+		index = (((flipH)?(p1X + (p2X - (pX + 1))):pX) + (((flipV)?(p1Y + (p2Y - (pY + 1))):pY) * width)) * 4;
         data[index] = color.r;
         data[index + 1] = color.g;
         data[index + 2] = color.b;

--- a/src/components/world/SceneCursor.tsx
+++ b/src/components/world/SceneCursor.tsx
@@ -814,13 +814,9 @@ const SceneCursor = ({ sceneId, enabled, sceneFiltered }: SceneCursorProps) => {
       // paint tileColors rather than remove them
       if (selectedPalette & TILE_COLOR_PROPS) {
         // If drawing props replace but keep tileColors
-        const tileProp = selectedPalette & TILE_COLOR_PROPS;
-        const currentProp = hoverPalette & TILE_COLOR_PROPS;
-        if (currentProp !== tileProp) {
-          data.current.drawTile = tileProp;
-        } else {
-          data.current.drawTile = hoverPalette & TILE_COLOR_PALETTE;
-        }
+        let tileProp = selectedPalette & TILE_COLOR_PROPS;
+		const currentProp = hoverPalette & TILE_COLOR_PROPS;
+		data.current.drawTile = currentProp ^ tileProp;
       } else {
         data.current.drawTile = selectedPalette;
       }

--- a/src/components/world/ScenePriorityMap.tsx
+++ b/src/components/world/ScenePriorityMap.tsx
@@ -7,12 +7,14 @@ interface ScenePriorityMapProps {
   width: number;
   height: number;
   tileColors: number[];
+  selectedPalette: number;
 }
 
 const ScenePriorityMap = ({
   width,
   height,
   tileColors,
+  selectedPalette,
 }: ScenePriorityMapProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
 
@@ -28,7 +30,7 @@ const ScenePriorityMap = ({
         for (let xi = 0; xi < width; xi++) {
           const tileIndex = width * yi + xi;
           const tile = tileColors[tileIndex];
-          if ((tile & TILE_COLOR_PROP_PRIORITY) === TILE_COLOR_PROP_PRIORITY) {
+          if ((tile & selectedPalette) === selectedPalette) {
             ctx.fillStyle = "rgba(40,250,40,0.3)";
           } else {
             ctx.fillStyle = "rgba(40,40,40,0.6)";
@@ -37,7 +39,7 @@ const ScenePriorityMap = ({
         }
       }
     }
-  }, [tileColors, height, width]);
+  }, [selectedPalette, tileColors, height, width]);
 
   return (
     <canvas

--- a/src/components/world/SceneView.tsx
+++ b/src/components/world/SceneView.tsx
@@ -18,6 +18,7 @@ import {
   DMG_PALETTE,
   MIDDLE_MOUSE,
   TILE_COLOR_PROP_PRIORITY,
+  TILE_COLOR_PROPS,
   TOOL_SELECT,
 } from "consts";
 import SceneInfo from "./SceneInfo";
@@ -254,6 +255,7 @@ const SceneView = memo(({ id, index, editable }: SceneViewProps) => {
 
   const tool = useAppSelector((state) => state.editor.tool);
   const showLayers = useAppSelector((state) => state.editor.showLayers);
+  const selectedPalette = useAppSelector((state) => state.editor.selectedPalette);
 
   const showEntities =
     (tool !== TOOL_COLORS &&
@@ -269,7 +271,7 @@ const SceneView = memo(({ id, index, editable }: SceneViewProps) => {
   const showPriorityMap = useAppSelector(
     (state) =>
       tool === TOOL_COLORS &&
-      state.editor.selectedPalette === TILE_COLOR_PROP_PRIORITY
+      state.editor.selectedPalette & TILE_COLOR_PROPS
   );
 
   const zoom = useAppSelector((state) => state.editor.zoom);
@@ -711,6 +713,7 @@ const SceneView = memo(({ id, index, editable }: SceneViewProps) => {
               width={scene.width}
               height={scene.height}
               tileColors={tileColors}
+			  selectedPalette={selectedPalette}
             />
           </SceneOverlay>
         )}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -119,6 +119,8 @@ export const COLLISION_SLOPE_VALUES = [
 // Colors
 export const TILE_COLOR_PALETTE = 0x7;
 export const TILE_COLOR_PROPS = 0xf8;
+export const TILE_COLOR_PROP_FLIP_HORIZONTAL = 0x20;
+export const TILE_COLOR_PROP_FLIP_VERTICAL = 0x40;
 export const TILE_COLOR_PROP_PRIORITY = 0x80;
 export const DMG_PALETTE = {
   id: "dmg",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -62,6 +62,8 @@
   "TOOL_ADD_SONG_LABEL": "Add new song",
   "TOOL_SYNC_INSTRUMENT_NAVIGATOR": "Use selected instrument when adding notes",
   "TOOL_TILE_PRIORITY": "Tile Priority",
+  "TOOL_TILE_FLIP_HORIZONTAL": "Horizontal Flip",
+  "TOOL_TILE_FLIP_VERTICAL": "Vertical Flip",
   "TOOL_MAGIC": "Magic Brush",
   "TOOL_SLOPE": "Slope Brush",
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -821,6 +821,7 @@
   "FIELD_COMMON_TILESET": "Common Tileset",
   "FIELD_COMMON_TILESET_DESC": "Setting a common tileset for a scene will cause the selected tileset tiles to always be loaded in the same order. Careful use of this on two scenes will allow you to seamlessly switch between the scenes with no transition and no tile glitching.",
   "FIELD_AUTO_COLOR": "Auto Color",
+  "FIELD_AUTO_FLIP": "Auto Flip",
   "FIELD_MANUAL": "Manual",
   "FIELD_PREVIEW_AS_MONO": "Preview as Monochrome",
   "FIELD_MONO_OVERRIDE_DESC": "This image is using automatic palettes with a monochrome override defined at \"{tilesFilename}\" which will determine the tile data used, while \"{filename}\" will determine the colors",

--- a/src/lib/compiler/compileData.ts
+++ b/src/lib/compiler/compileData.ts
@@ -723,6 +723,7 @@ export const precompileTilesets = async (
   tilesets: TilesetData[],
   scenes: Scene[],
   customEventsLookup: Record<string, CustomEvent>,
+  scriptEventHandlers: ScriptEventHandlers,
   projectRoot: string,
   {
     warnings,
@@ -750,9 +751,15 @@ export const precompileTilesets = async (
         maxDepth: MAX_NESTED_SCRIPT_DEPTH,
       },
     },
-    (cmd) => {
-      if (cmd.args && cmd.args.tilesetId) {
-        addTileset(ensureString(cmd.args.tilesetId, ""));
+    (cmd) => {		
+      if (cmd.args) {
+        for (const key in cmd.args) {
+          const value = cmd.args[key];
+          const fieldType = scriptEventHandlers[cmd.command]?.fieldsLookup[key]?.type;
+          if (fieldType == "tileset") {
+            addTileset(ensureString(value, ""));
+          }
+        }
       }
       if (eventHasArg(cmd, "references")) {
         const referencedIds = ensureReferenceArray(cmd.args?.references, [])
@@ -1175,6 +1182,7 @@ const precompile = async (
     projectData.tilesets,
     projectData.scenes,
     customEventsLookup,
+	scriptEventHandlers,
     projectRoot,
     { warnings }
   );

--- a/src/lib/compiler/precompile/determineUsedAssets.ts
+++ b/src/lib/compiler/precompile/determineUsedAssets.ts
@@ -289,7 +289,9 @@ export const determineUsedAssets = ({
                 addFontsFromString(row);
               }
             }
-          }
+          } else if (fieldType == "tileset"){
+		     console.log(cmd);
+		  }
         }
       }
     }

--- a/src/shared/lib/entities/entitiesTypes.ts
+++ b/src/shared/lib/entities/entitiesTypes.ts
@@ -198,6 +198,7 @@ export type Background = {
   tileColors: number[];
   monoOverrideId?: string;
   autoColor?: boolean;
+  autoFlip?: boolean;
   plugin?: string;
   inode: string;
   _v: number;

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -2213,6 +2213,24 @@ const editBackgroundAutoColor: CaseReducer<
   }
 };
 
+const editBackgroundAutoFlip: CaseReducer<
+  EntitiesState,
+  PayloadAction<{ backgroundId: string; autoFlip: boolean }>
+> = (state, action) => {
+  const background = localBackgroundSelectById(
+    state,
+    action.payload.backgroundId
+  );
+  if (background) {
+    backgroundsAdapter.updateOne(state.backgrounds, {
+      id: background.id,
+      changes: {
+        autoFlip: action.payload.autoFlip,
+      },
+    });
+  }
+};
+
 const updateMonoOverrideIds = (state: EntitiesState) => {
   const backgrounds = localBackgroundSelectAll(state);
   const getKey = (b: Background) => `${b.plugin ?? ""}_${b.filename}`;
@@ -4412,6 +4430,7 @@ const entitiesSlice = createSlice({
 
     setBackgroundSymbol,
     editBackgroundAutoColor,
+	editBackgroundAutoFlip,
 
     /**************************************************************************
      * Sprites

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -3227,7 +3227,7 @@ const paintColor: CaseReducer<
 
   const getValue = (x: number, y: number) => {
     const tileColorIndex = background.width * y + x;
-    return tileColors[tileColorIndex];
+	return tileColors[tileColorIndex];
   };
 
   const setValue = (x: number, y: number, value: number) => {
@@ -3235,15 +3235,21 @@ const paintColor: CaseReducer<
     let newValue = value;
     if (isTileProp) {
       // If is prop keep previous color value
-      newValue =
-        (tileColors[tileColorIndex] & TILE_COLOR_PALETTE) +
-        (value & TILE_COLOR_PROPS);
+	  if (value !== 0){
+	    newValue =
+          (tileColors[tileColorIndex] & TILE_COLOR_PALETTE) +
+          (value & TILE_COLOR_PROPS);
+	  } else {
+	    newValue = (tileColors[tileColorIndex] & TILE_COLOR_PALETTE)
+	  }      
     } else if (value !== 0) {
       // If is color keep prop unless erasing
       newValue =
         (value & TILE_COLOR_PALETTE) +
         (tileColors[tileColorIndex] & TILE_COLOR_PROPS);
-    }
+    } else {
+	  newValue = (tileColors[tileColorIndex] & TILE_COLOR_PROPS)
+	}
     tileColors[tileColorIndex] = newValue;
   };
 


### PR DESCRIPTION
Added in the color toolbar the posibility to mark background tiles as flipped horizontaly and or verticaly in color mode.
Also added the option to automaticaly detect which tiles are flippables.



https://github.com/user-attachments/assets/bd0384c0-db8d-4a65-b4fd-99f7b6fd67a9

