### PR TITLE
Changed the hardcoded way to mask collision tile data upon drawing to scene

### DIFF
--- a/src/components/world/BrushToolbar.tsx
+++ b/src/components/world/BrushToolbar.tsx
@@ -170,7 +170,7 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
   const dispatch = useAppDispatch();
 
   const sceneId = useAppSelector((state) => state.editor.scene);
-  const { selectedPalette, selectedTileType, selectedBrush, showLayers } =
+  const { selectedPalette, selectedTileType, selectedTileMask, selectedBrush, showLayers } =
     useAppSelector((state) => state.editor);
   const scene = useAppSelector((state) =>
     sceneSelectors.selectById(state, sceneId),
@@ -252,11 +252,10 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
         }
 
         let newValue = selectedTile.flag;
-
+		const mask = selectedTile.mask ?? 0xff;
         if (e.shiftKey) {
           if (selectedTile.multi) {
-            // If multi selectable tile toggle on/off when shift clicking
-            const mask = selectedTile.mask ?? 0xff;
+            // If multi selectable tile toggle on/off when shift clicking            
             if (
               selectedTileType !== selectedTile.flag &&
               selectedTileType & selectedTile.flag
@@ -276,6 +275,7 @@ const BrushToolbar = ({ hasFocusForKeyboardShortcuts }: BrushToolbarProps) => {
         dispatch(
           editorActions.setSelectedTileType({
             tileType: newValue,
+			tileMask: mask,
           }),
         );
       }

--- a/src/components/world/SceneCollisions.tsx
+++ b/src/components/world/SceneCollisions.tsx
@@ -95,7 +95,7 @@ const SceneCollisions = ({
 
       ctx.font = "8px Public Pixel";
       ctx.imageSmoothingEnabled = false;
-
+/*
       const sortedTileDefs = collisionTileDefs.map((t) => t);
       sortedTileDefs.sort((a, b) => {
         if (a.mask) {
@@ -111,14 +111,14 @@ const SceneCollisions = ({
         const bCount = b.flag.toString(2).split("1").length - 1;
         return bCount - aCount;
       });
-
+*/
       for (let yi = 0; yi < height; yi++) {
         for (let xi = 0; xi < width; xi++) {
           const collisionIndex = width * yi + xi;
           const tile = collisions[collisionIndex] ?? 0;
           let unknownTile = tile !== 0;
 
-          for (const tileDef of sortedTileDefs) {
+          for (const tileDef of collisionTileDefs) {
             if (isCollisionTileActive(tile, tileDef)) {
               ctx.fillStyle = tileDef.color;
               drawCollisionTile(tileDef, ctx, xi, yi);

--- a/src/store/features/editor/editorState.ts
+++ b/src/store/features/editor/editorState.ts
@@ -123,6 +123,7 @@ export interface EditorState {
   worldViewHeight: number;
   selectedPalette: number;
   selectedTileType: number;
+  selectedTileMask: number;
   selectedBrush: Brush;
   showLayers: boolean;
   lastScriptTab: string;
@@ -194,6 +195,7 @@ export const initialState: EditorState = {
   worldViewHeight: 0,
   selectedPalette: 0,
   selectedTileType: COLLISION_ALL,
+  selectedTileMask: 0xff,
   selectedBrush: BRUSH_8PX,
   showLayers: true,
   lastScriptTab: "",
@@ -324,9 +326,10 @@ const editorSlice = createSlice({
 
     setSelectedTileType: (
       state,
-      action: PayloadAction<{ tileType: number }>,
+      action: PayloadAction<{ tileType: number, tileMask: number }>,
     ) => {
       state.selectedTileType = action.payload.tileType;
+	  state.selectedTileMask = action.payload.tileMask;
     },
 
     setShowLayers: (state, action: PayloadAction<{ showLayers: boolean }>) => {

--- a/src/store/features/entities/entitiesState.ts
+++ b/src/store/features/entities/entitiesState.ts
@@ -2946,7 +2946,7 @@ const paintCollision: CaseReducer<
       y: number;
       value: number;
       brush: Brush;
-      isTileProp: boolean;
+      tileMask: number;
     } & ({ drawLine?: false } | { drawLine: true; endX: number; endY: number })
   >
 > = (state, action) => {
@@ -2959,7 +2959,7 @@ const paintCollision: CaseReducer<
     return;
   }
 
-  const isTileProp = action.payload.isTileProp;
+  const tileMask = action.payload.tileMask;
   const brush = action.payload.brush;
   const drawSize = brush === "16px" ? 2 : 1;
   const collisionsSize = Math.ceil(background.width * background.height);
@@ -2979,8 +2979,11 @@ const paintCollision: CaseReducer<
 
   const setValue = (x: number, y: number, value: number) => {
     const tileIndex = background.width * y + x;
+	const currentCollision = collisions[tileIndex];
     let newValue = value;
-    if (isTileProp) {
+    if (tileMask) {
+	  newValue = (currentCollision & (0xff ^ tileMask)) | value;
+	  /*
       if (value & 0x0f) {
         // If is prop and one way, overwrite both
         newValue = value;
@@ -2992,6 +2995,7 @@ const paintCollision: CaseReducer<
     } else if (value !== 0 && !isSlope(newValue)) {
       // If is collision keep prop unless erasing
       newValue = (value & COLLISION_ALL) + (collisions[tileIndex] & TILE_PROPS);
+	  */
     }
     collisions[tileIndex] = newValue;
   };
@@ -3201,7 +3205,7 @@ const paintColor: CaseReducer<
       y: number;
       paletteIndex: number;
       brush: Brush;
-      isTileProp: boolean;
+      tileMask: number;
     } & ({ drawLine?: false } | { drawLine: true; endX: number; endY: number })
   >
 > = (state, action) => {
@@ -3213,7 +3217,7 @@ const paintColor: CaseReducer<
     return;
   }
 
-  const isTileProp = action.payload.isTileProp;
+  const tileMask = action.payload.tileMask;
   const brush = action.payload.brush;
   const drawSize = brush === "16px" ? 2 : 1;
   const tileColorsSize = Math.ceil(background.width * background.height);
@@ -3232,8 +3236,11 @@ const paintColor: CaseReducer<
 
   const setValue = (x: number, y: number, value: number) => {
     const tileColorIndex = background.width * y + x;
+	const currentColor = tileColors[tileColorIndex];
     let newValue = value;
-    if (isTileProp) {
+    if (tileMask) {
+		newValue = (currentColor & (0xff ^ tileMask)) | value;
+		/*
       // If is prop keep previous color value
       newValue =
         (tileColors[tileColorIndex] & TILE_COLOR_PALETTE) +
@@ -3243,6 +3250,7 @@ const paintColor: CaseReducer<
       newValue =
         (value & TILE_COLOR_PALETTE) +
         (tileColors[tileColorIndex] & TILE_COLOR_PROPS);
+		*/
     }
     tileColors[tileColorIndex] = newValue;
   };

--- a/test/store/features/editor/editorState.test.ts
+++ b/test/store/features/editor/editorState.test.ts
@@ -76,7 +76,7 @@ test("Should be able to set selected tile type", () => {
     ...initialState,
     selectedTileType: 0,
   };
-  const action = actions.setSelectedTileType({ tileType: 5 });
+  const action = actions.setSelectedTileType({ tileType: 5, tileMask: 0x0f });
   const newState = reducer(state, action);
   expect(newState.selectedTileType).toBe(5);
 });
@@ -645,7 +645,7 @@ describe("editor reducer", () => {
 
   describe("setSelectedTileType", () => {
     test("should set selectedTileType", () => {
-      const action = actions.setSelectedTileType({ tileType: 1 });
+      const action = actions.setSelectedTileType({ tileType: 1, tileMask: 0x0f });
       const newState = reducer(state, action);
       expect(newState.selectedTileType).toBe(1);
     });

--- a/test/store/features/entities/entitiesState.test.ts
+++ b/test/store/features/entities/entitiesState.test.ts
@@ -632,7 +632,7 @@ test("Should be able to flood fill collisions", () => {
     y: 0,
     value: 2,
     brush: "fill",
-    isTileProp: false,
+    tileMask: 0x0f,
     drawLine: false,
     tileLookup: [],
   });
@@ -681,7 +681,7 @@ test("Should be able to paint collisions", () => {
     y: 0,
     value: 2,
     brush: "8px",
-    isTileProp: false,
+    tileMask: 0x0f,
     drawLine: false,
     tileLookup: [],
   });
@@ -737,7 +737,7 @@ test("Should be able to paint collision line", () => {
     endY: 5,
     value: 2,
     brush: "8px",
-    isTileProp: false,
+    tileMask: 0x0f,
     drawLine: true,
     tileLookup: [],
   });


### PR DESCRIPTION
Changed the hardcoded way to mask collision tile data upon drawing to scene and instead use the mask values specified in the tile definition in the engine.json for the specified scene type. (useful if you create custom collision tile definition for a scene and specify masks that dont fit the default's COLLISION_ALL (0x0f) and TILE_PROPS (0xf0) masks)

Example, in this case, I made a custom scene type that contains 3 collision types and 16 directions, the 16 directions could not fit in either of the default masks so it couldn't overlap the separate custom mask correctly: 
![image](https://github.com/user-attachments/assets/71ad0754-48e6-4d05-b6c8-d501ed8c713c)
![image](https://github.com/user-attachments/assets/47719488-1525-4a2c-9f10-4a41c54c7dac)
