### PR TITLE
Fix: Single 8x8 sprites are weirdly placed in the scene #1779

### DIFF
--- a/src/components/world/SpriteSheetCanvas.tsx
+++ b/src/components/world/SpriteSheetCanvas.tsx
@@ -21,6 +21,7 @@ interface SpriteSheetCanvasProps {
 
 const Wrapper = styled.div`
   position: relative;
+  display: flex;
 `;
 
 const directions: ActorDirection[] = ["right", "left", "up", "down"];


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

Sprites with 8px height displayed with a 4px vertical offset (as reported in #1779)

<img width="1280" height="810" alt="image" src="https://github.com/user-attachments/assets/665127cb-b2ff-4973-a01a-3f22e1c2e317" />

* **What is the new behavior (if this is a feature change)?**

Fixes (somehow) that issue by setting the wrapper for the spritesheet canvas to `flex` (CSS 🤷 )

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think so

* **Other information**:
