### PR TITLE
Update pl.json 2052 - open build folder on export

### DIFF
--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -2,7 +2,7 @@
   "RTL": false,
 
   "GBSTUDIO_DESCRIPTION": "Visual retro game maker\nPolish translation by: Reptile (reptile@o2.pl)",
-  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2047250801",
+  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2052250805",
 
   "// 1": "UI -------------------------------------------------------",
   "ACTOR": "Aktor",
@@ -1232,6 +1232,7 @@
   "FIELD_DEFAULT_SPRITE_MODE": "Domyślny tryb grafiki",
   "FIELD_SPRITE_MODE_OVERRIDE": "Nadpisanie trybu grafiki",
   "FIELD_SET_SPRITE_MODE_OVERRIDE": "Ustaw nadpisanie trybu grafiki",
+  "FIELD_OPEN_BUILD_FOLDER_ON_EXPORT": "Otwórz folder kompilacji po eksporcie",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Szukaj",


### PR DESCRIPTION
Added line for open build folder on export.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update for pl.json


* **What is the current behavior?** (You can also link to an open issue here)
Missing one line for "Open build folder on export"


* **What is the new behavior (if this is a feature change)?**
Added missing line


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.


* **Other information**:
Merge ASAP, as always - Thank you!