### PR TITLE
Add toggle for ROM usage view

### DIFF
--- a/src/components/debugger/DebuggerBuildLog.tsx
+++ b/src/components/debugger/DebuggerBuildLog.tsx
@@ -151,6 +151,9 @@ const DebuggerBuildLog = () => {
   const openBuildFolderOnExport = useAppSelector(
     (state) => getSettings(state).openBuildFolderOnExport,
   );
+  const showRomUsageAfterBuild = useAppSelector(
+    (state) => getSettings(state).showRomUsageAfterBuild,
+  );
 
   const { currentBreakpoint: usageBreakpoint, observe } = useDimensions({
     breakpoints: { SM: 0, MD: 50, LG: 280 },
@@ -224,6 +227,11 @@ const DebuggerBuildLog = () => {
       onChangeSettingProp("openBuildFolderOnExport", !openBuildFolderOnExport),
     [onChangeSettingProp, openBuildFolderOnExport],
   );
+  const onToggleShowRomUsageAfterBuild = useCallback(
+    () =>
+      onChangeSettingProp("showRomUsageAfterBuild", !showRomUsageAfterBuild),
+    [onChangeSettingProp, showRomUsageAfterBuild],
+  );
 
   return (
     <Wrapper>
@@ -287,6 +295,12 @@ const DebuggerBuildLog = () => {
           >
             {l10n("FIELD_OPEN_BUILD_FOLDER_ON_EXPORT")}
           </MenuItem>
+          <MenuItem
+            onClick={onToggleShowRomUsageAfterBuild}
+            icon={showRomUsageAfterBuild ? <CheckIcon /> : <BlankIcon />}
+          >
+            {l10n("FIELD_SHOW_ROM_USAGE_AFTER_BUILD")}
+          </MenuItem>
 
           <MenuDivider />
           <MenuItem onClick={onDeleteCache} icon={<BlankIcon />}>
@@ -294,10 +308,12 @@ const DebuggerBuildLog = () => {
           </MenuItem>
         </DropdownButton>
         <UsageWrapper ref={observe}>
-          <DebuggerUsageData
-            hideLabels={usageBreakpoint !== "LG"}
-            forceZoom={usageBreakpoint === "SM"}
-          ></DebuggerUsageData>
+          {showRomUsageAfterBuild && (
+            <DebuggerUsageData
+              hideLabels={usageBreakpoint !== "LG"}
+              forceZoom={usageBreakpoint === "SM"}
+            ></DebuggerUsageData>
+          )}
         </UsageWrapper>
         <Button onClick={onClear}>{l10n("BUILD_CLEAR")}</Button>
       </ButtonToolbar>

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -92,6 +92,7 @@ const SettingsPage: FC = () => {
     openBuildLogOnWarnings,
     generateDebugFilesEnabled,
     openBuildFolderOnExport,
+    showRomUsageAfterBuild,
     compilerPreset,
     spriteMode,
   } = settings;
@@ -175,6 +176,12 @@ const SettingsPage: FC = () => {
   const onChangeOpenBuildFolderOnExport = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) =>
       onChangeSettingProp("openBuildFolderOnExport", castEventToBool(e)),
+    [onChangeSettingProp],
+  );
+
+  const onChangeShowRomUsageAfterBuild = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      onChangeSettingProp("showRomUsageAfterBuild", castEventToBool(e)),
     [onChangeSettingProp],
   );
 
@@ -800,6 +807,23 @@ const SettingsPage: FC = () => {
                 name="openBuildFolderOnExport"
                 checked={openBuildFolderOnExport}
                 onChange={onChangeOpenBuildFolderOnExport}
+              />
+            </SettingRowInput>
+          </SearchableSettingRow>
+
+          <SearchableSettingRow
+            searchTerm={searchTerm}
+            searchMatches={[l10n("FIELD_SHOW_ROM_USAGE_AFTER_BUILD")]}
+          >
+            <SettingRowLabel>
+              {l10n("FIELD_SHOW_ROM_USAGE_AFTER_BUILD")}
+            </SettingRowLabel>
+            <SettingRowInput>
+              <Checkbox
+                id="showRomUsageAfterBuild"
+                name="showRomUsageAfterBuild"
+                checked={showRomUsageAfterBuild}
+                onChange={onChangeShowRomUsageAfterBuild}
               />
             </SettingRowInput>
           </SearchableSettingRow>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -437,6 +437,7 @@ export const defaultProjectSettings: Settings = {
   runSceneSelectionOnly: false,
   spriteMode: "8x16",
   openBuildFolderOnExport: true,
+  showRomUsageAfterBuild: false,
 };
 
 export const defaultPalettes: Palette[] = [

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1233,6 +1233,7 @@
   "FIELD_SPRITE_MODE_OVERRIDE": "Sprite Mode Override",
   "FIELD_SET_SPRITE_MODE_OVERRIDE": "Set Sprite Mode Override",
   "FIELD_OPEN_BUILD_FOLDER_ON_EXPORT": "Open Build Folder On Export",
+  "FIELD_SHOW_ROM_USAGE_AFTER_BUILD": "Show ROM Usage After Build",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/shared/lib/resources/types.ts
+++ b/src/shared/lib/resources/types.ts
@@ -743,6 +743,7 @@ export const SettingsResource = Type.Object({
   runSceneSelectionOnly: Type.Boolean(),
   spriteMode: SpriteModeSetting,
   openBuildFolderOnExport: Type.Boolean(),
+  showRomUsageAfterBuild: Type.Boolean(),
 });
 
 export type SettingsResource = Static<typeof SettingsResource>;

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -368,6 +368,7 @@ export const dummyProjectData: ProjectData = {
     runSceneSelectionOnly: false,
     spriteMode: "8x16",
     openBuildFolderOnExport: true,
+    showRomUsageAfterBuild: false,
   },
 };
 
@@ -647,6 +648,7 @@ export const dummySettingsResource: SettingsResource = {
   runSceneSelectionOnly: false,
   spriteMode: "8x16",
   openBuildFolderOnExport: true,
+  showRomUsageAfterBuild: false,
 };
 
 export const dummyVariablesResource: VariablesResource = {
@@ -770,6 +772,7 @@ export const dummyProjectResources: ProjectResources = {
     runSceneSelectionOnly: false,
     spriteMode: "8x16",
     openBuildFolderOnExport: true,
+    showRomUsageAfterBuild: false,
   },
 };
 

--- a/test/resources/types.test.ts
+++ b/test/resources/types.test.ts
@@ -640,6 +640,7 @@ describe("TypeBox Schemas", () => {
       runSceneSelectionOnly: false,
       spriteMode: "8x16",
       openBuildFolderOnExport: true,
+      showRomUsageAfterBuild: false,
     };
     const invalidSettings = {
       _resourceType: "settings",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

We always show the ROM usage bar after a build. Some users get unnecessarily stressed by it thinking they'll run out of space soon. 

* **What is the new behavior (if this is a feature change)?**

Implemented a toggle to show/hide the bar (hidden by default) as proposed on Discord [here](https://discord.com/channels/554713715442712616/570925583421276160/1404437430295199835)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. Well, users will have to enable the toggle once for their project if they want to keep seeing the bar.

* **Other information**:

Another suggestion was to show the bar once you're over a certain threshold but I think that'd be more stressful for some users ("why is it appearing now all of a sudden? Am I going to run out of space soon?!")