### PR TITLE
[Fix] Scroll bounds ignored if set to start of scene

### DIFF
--- a/src/lib/compiler/generateGBVMData.ts
+++ b/src/lib/compiler/generateGBVMData.ts
@@ -536,9 +536,16 @@ export const compileParallax = (
 
 export const compileScrollBounds = (
   scrollBounds: SceneBoundsRect | undefined,
+  sceneWidth: number,
+  sceneHeight: number,
 ): { left: number; right: number; top: number; bottom: number } | undefined => {
   if (!scrollBounds) {
-    return undefined;
+    return {
+      left: 0,
+      top: 0,
+      right: tileToPx(sceneWidth - SCREEN_WIDTH),
+      bottom: tileToPx(sceneHeight - SCREEN_HEIGHT),
+    };
   }
   return {
     left: tileToPx(scrollBounds.x),
@@ -583,7 +590,11 @@ export const compileScene = (
       parallax_rows: compileParallax(
         scene.width > SCREEN_WIDTH ? scene.parallax : undefined,
       ),
-      scroll_bounds: compileScrollBounds(scene.scrollBounds),
+      scroll_bounds: compileScrollBounds(
+        scene.scrollBounds,
+        scene.width,
+        scene.height,
+      ),
       palette: toFarPtr(paletteSymbol(bgPalette)),
       sprite_palette: toFarPtr(paletteSymbol(actorsPalette)),
       reserve_tiles: scene.actorsExclusiveLookup["player"] ?? 0,

--- a/test/compiler/generateGBVMData.test.ts
+++ b/test/compiler/generateGBVMData.test.ts
@@ -1,3 +1,4 @@
+import { SCREEN_HEIGHT, SCREEN_WIDTH } from "consts";
 import {
   compileGameGlobalsHeader,
   compileScrollBounds,
@@ -115,7 +116,7 @@ describe("compileScrollBounds", () => {
       height: 20,
     };
 
-    const result = compileScrollBounds(scrollBounds);
+    const result = compileScrollBounds(scrollBounds, 20, 30);
 
     expect(result).toEqual({
       left: 16,
@@ -133,7 +134,7 @@ describe("compileScrollBounds", () => {
       height: 18,
     };
 
-    const result = compileScrollBounds(scrollBounds);
+    const result = compileScrollBounds(scrollBounds, 20, 30);
 
     expect(result).toEqual({
       left: 0,
@@ -151,7 +152,7 @@ describe("compileScrollBounds", () => {
       height: 250,
     };
 
-    const result = compileScrollBounds(scrollBounds);
+    const result = compileScrollBounds(scrollBounds, 20, 30);
 
     expect(result).toEqual({
       left: 40,
@@ -169,7 +170,7 @@ describe("compileScrollBounds", () => {
       height: 12,
     };
 
-    const result = compileScrollBounds(scrollBounds);
+    const result = compileScrollBounds(scrollBounds, 20, 30);
 
     expect(result).toEqual({
       left: 16,
@@ -179,8 +180,13 @@ describe("compileScrollBounds", () => {
     });
   });
 
-  test("should return undefined when scrollBounds is undefined", () => {
-    const result = compileScrollBounds(undefined);
-    expect(result).toBeUndefined();
+  test("should return the given screen size when scrollBounds is undefined", () => {
+    const result = compileScrollBounds(undefined, 20, 30);
+    expect(result).toEqual({
+      left: 0,
+      top: 0,
+      right: (20 - SCREEN_WIDTH) * 8,
+      bottom: (30 - SCREEN_HEIGHT) * 8,
+    });
   });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

If the scroll bounds are set to {0, 20} horizontally or {0, 18} vertically (or both) they'll be ignored in game. This is because when compiling them they're set as 0 width or height. The engine considers those non-set values and instead sets them to the whole width or height of the screen. 

* **What is the new behavior (if this is a feature change)?**

Instead of compiling the bounds to undefined when no scroll bounds are set, compile them to use the whole scene width or height by default. That way the engine won't need to set the values by default. [GBVM PR here](https://github.com/chrismaltby/gbvm/pull/202) will need to update the gbvm module reference when that meres.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
