### PR TITLE
Use the color compatible compile flag for mono+color games

### DIFF
--- a/src/lib/compiler/buildMakeScript.ts
+++ b/src/lib/compiler/buildMakeScript.ts
@@ -200,7 +200,7 @@ export const buildLinkFlags = (
       `-Wm-yn"${validName}"`,
     ],
     // Color
-    color ? ["-Wm-yC"] : [],
+    colorOnly ? ["-Wm-yC"] : color ? ["-Wm-yc"] : [],
     // SGB
     sgb ? ["-Wm-ys"] : [],
     // Pocket


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes #1808 

* **What is the current behavior?** (You can also link to an open issue here)

We always set the Color Only flag for Monochrome + Color games

* **What is the new behavior (if this is a feature change)?**

The right flag is used at compile time

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. All Color functionalities we use in hybrid games (extra VRAM for text, double CPU speed...) should still work when running the game in a Color device.

* **Other information**:

N/A
