### PR TITLE
Fix GitHub Issue 1577 - Incorrectly displayed Noise-Sounds

### DIFF
--- a/src/components/music/helpers/notePreview.ts
+++ b/src/components/music/helpers/notePreview.ts
@@ -204,6 +204,7 @@ function previewWaveInstrument(
 }
 
 function previewNoiseInstrument(note: number, instrument: NoiseInstrument) {
+
   const regs = {
     NR41:
       "00" +
@@ -218,7 +219,7 @@ function previewNoiseInstrument(note: number, instrument: NoiseInstrument) {
         3,
       ),
     NR43: bitpack(
-      note2noise(note + (instrument.noise_macro ?? [])[0]) +
+      note2noise(note + ((instrument.noise_macro && instrument.noise_macro[0]) ?? 0)) +
         (instrument.bit_count === 7 ? 8 : 0),
       8,
     ),
@@ -238,7 +239,7 @@ function previewNoiseInstrument(note: number, instrument: NoiseInstrument) {
     console.log("noise macro step = " + noiseStep);
     emulator.writeMem(
       NR43,
-      note2noise(note + (instrument.noise_macro ?? [])[noiseStep]) +
+      note2noise(note + ((instrument.noise_macro && instrument.noise_macro[0]) ?? 0)) +
         (instrument.bit_count === 7 ? 8 : 0),
     );
     noiseStep++;
@@ -278,3 +279,4 @@ const note2noise = (note: number) => {
   const pitch = 64 > note ? 63 - note : 192 + note;
   return pitch > 7 ? (((pitch - 4) >> 2) << 4) + (pitch & 3) + 4 : pitch;
 };
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix of Issue 1577

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/chrismaltby/gb-studio/issues/1577

* **What is the new behavior (if this is a feature change)?**

Noise-Preview-Sound matches the sound which displays when pressing play.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
