### PR TITLE
[Fix]  8x8 mode spritesheets in color only mode leaving extra gaps in tileset

### DIFF
--- a/src/lib/compiler/compileSprites.ts
+++ b/src/lib/compiler/compileSprites.ts
@@ -27,7 +27,7 @@ const S_VRAM2 = 0x8;
 type SpriteTileAllocationStrategy = (
   tileIndex: number,
   numTiles: number,
-  sprite: SpriteSheetData,
+  spriteMode: SpriteModeSetting,
 ) => { tileIndex: number; inVRAM2: boolean };
 
 interface AnimationOffset {
@@ -77,8 +77,9 @@ const spriteTileAllocationDefault: SpriteTileAllocationStrategy = (
 const spriteTileAllocationColorOnly: SpriteTileAllocationStrategy = (
   tileIndex,
   numTiles,
+  spriteMode,
 ) => {
-  const bank1NumTiles = Math.ceil(numTiles / 4) * 2;
+  const bank1NumTiles = (spriteMode === "8x16")? Math.ceil(numTiles / 4) * 2: Math.ceil(numTiles / 2);
   const inVRAM2 = tileIndex >= bank1NumTiles;
   return {
     tileIndex: inVRAM2 ? tileIndex - bank1NumTiles : tileIndex,
@@ -178,7 +179,7 @@ export const compileSprite = async (
                   const { tileIndex, inVRAM2 } = tileAllocationStrategy(
                     optimisedTile.tile,
                     tiles.length,
-                    spriteSheet,
+                    spriteMode,
                   );
                   if (flip) {
                     const data: SpriteTileData = {
@@ -257,7 +258,7 @@ export const compileSprite = async (
 
   // Split tiles into VRAM banks based on allocation strategy
   tiles.map(indexedImageTo2bppSpriteData).forEach((tile, i) => {
-    const { inVRAM2 } = tileAllocationStrategy(i, tiles.length, spriteSheet);
+    const { inVRAM2 } = tileAllocationStrategy(i, tiles.length, spriteMode);
     vramData[inVRAM2 ? 1 : 0].push(...tile);
   });
 


### PR DESCRIPTION
Spritesheets compiled in 8x8 mode and color only mode will split tiles as if in 8x16 mode, leaving 2 tiles gaps instead of 1 tile gap in the compiled sprite tilesets when the split is uneven. (it was also leaving a 2 tile gap even if the split is even if each side had an odd tile count ex: 5-5)

example without the fix (notice the two empty tile gaps separating the two loaded spritesheets)
<img width="266" height="230" alt="image" src="https://github.com/user-attachments/assets/7f4c33d6-3ce5-44fa-90d8-9948f0d78195" />

example with the fix:
<img width="269" height="235" alt="image" src="https://github.com/user-attachments/assets/c24fef6c-d11f-4018-a252-4e055ecc4dd8" />
