### PR TITLE
Update pl.json 2086 - add missing FIELD_ADVENTURE_STATE

### DIFF
--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -2,7 +2,7 @@
   "RTL": false,
 
   "GBSTUDIO_DESCRIPTION": "Visual retro game maker\nPolish translation by: Reptile (reptile@o2.pl)",
-  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2084251026",
+  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2086251028",
 
   "// 1": "UI -------------------------------------------------------",
   "ACTOR": "Aktor",
@@ -1255,6 +1255,8 @@
   "FIELD_PUSH_STATE": "Popychanie",
   "FIELD_PUSH_START": "Początek stanu: popychanie",
   "FIELD_PUSH_END": "Koniec stanu: popychanie",
+  "FIELD_ADVENTURE_STATE": "Stan przygodowy",
+  "FIELD_ADVENTURE_STATE_DESC": "Aktualny wewnętrzny stan sceny przygodowej",
   
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Szukaj",


### PR DESCRIPTION
Added the missing FIELD_ADVENTURE_STATE

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update for the pl.json


* **What is the current behavior?** (You can also link to an open issue here)
Missing lines (FIELD_ADVENTURE_STATE)


* **What is the new behavior (if this is a feature change)?**
Added missing lines


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Do not think so.


* **Other information**:
As alwasy, merge ASAP, thanks!