### PR TITLE
Add "Wait until finished" flag to Overlay Move To event

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -306,6 +306,7 @@
   "FIELD_EDIT_PALETTES": "Edit Palettes",
   "FIELD_WAIT_UNTIL_FINISHED": "Wait until finished",
   "FIELD_WAIT_UNTIL_FINISHED_SOUND_DESC": "Set if script should pause until sound effect has finished playing.",
+  "FIELD_WAIT_UNTIL_FINISHED_OVERLAY_MOVE_DESC": "Set if script should pause until the overlay has reached its position.",
   "FIELD_ACTOR_TYPE": "Sprite Type",
   "FIELD_OFFSET_X": "Offset X",
   "FIELD_OFFSET_Y": "Offset Y",

--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -4723,14 +4723,16 @@ extern void __mute_mask_${symbol};
     this._addNL();
   };
 
-  overlayMoveTo = (x = 0, y = 18, speed = 0) => {
+  overlayMoveTo = (x = 0, y = 18, speed = 0, wait = true) => {
     this._addComment("Overlay Move To");
     this._overlayMoveTo(
       x,
       y,
       Number(speed) === -3 ? ".OVERLAY_SPEED_INSTANT" : speed,
     );
-    this._overlayWait(true, [".UI_WAIT_WINDOW"]);
+    if (wait) {
+      this._overlayWait(true, [".UI_WAIT_WINDOW"]);
+    }
     this._addNL();
   };
 

--- a/src/lib/events/eventOverlayMoveTo.js
+++ b/src/lib/events/eventOverlayMoveTo.js
@@ -39,11 +39,25 @@ const fields = [
     type: "overlaySpeed",
     defaultValue: -3,
   },
+  {
+    key: "wait",
+    type: "checkbox",
+    label: l10n("FIELD_WAIT_UNTIL_FINISHED"),
+    description: l10n("FIELD_WAIT_UNTIL_FINISHED_OVERLAY_MOVE_DESC"),
+    conditions: [
+      {
+        key: "speed",
+        ne: -3,
+      },
+    ],
+    defaultValue: true,
+    flexBasis: "100%",
+  },
 ];
 
 const compile = (input, helpers) => {
   const { overlayMoveTo } = helpers;
-  overlayMoveTo(input.x, input.y, input.speed);
+  overlayMoveTo(input.x, input.y, input.speed, input.wait ?? true);
 };
 
 module.exports = {

--- a/test/events/eventOverlayMoveTo.test.js
+++ b/test/events/eventOverlayMoveTo.test.js
@@ -8,12 +8,13 @@ test("Should set move overlay to position", () => {
       x: 5,
       y: 9,
       speed: 1,
+      wait: true,
     },
     {
       overlayMoveTo: mockOverlayMoveTo,
     },
   );
-  expect(mockOverlayMoveTo).toBeCalledWith(5, 9, 1);
+  expect(mockOverlayMoveTo).toBeCalledWith(5, 9, 1, true);
 });
 
 test("Should set move overlay to position with instant speed", () => {
@@ -24,10 +25,27 @@ test("Should set move overlay to position with instant speed", () => {
       x: 5,
       y: 9,
       speed: -3,
+      wait: false,
     },
     {
       overlayMoveTo: mockOverlayMoveTo,
     },
   );
-  expect(mockOverlayMoveTo).toBeCalledWith(5, 9, -3);
+  expect(mockOverlayMoveTo).toBeCalledWith(5, 9, -3, false);
+});
+
+test("Should set wait to true by default for legacy events", () => {
+  const mockOverlayMoveTo = jest.fn();
+
+  compile(
+    {
+      x: 5,
+      y: 9,
+      speed: 1,
+    },
+    {
+      overlayMoveTo: mockOverlayMoveTo,
+    },
+  );
+  expect(mockOverlayMoveTo).toBeCalledWith(5, 9, 1, true);
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix for #1855 

* **What is the current behavior?** (You can also link to an open issue here)

Overlay Move To pauses the script until movement finished

* **What is the new behavior (if this is a feature change)?**

Add a checkbox to select if the event should wait or not (default to true)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
