### PR TITLE
Minor engine field UI enhancement

### DIFF
--- a/src/components/ui/form/SettingRow.tsx
+++ b/src/components/ui/form/SettingRow.tsx
@@ -33,6 +33,7 @@ export const SettingRowLabel = styled.label<SettingRowLabelProps>`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  text-decoration: underline;
   font-size: ${(props) => props.theme.typography.fontSize};
   ${(props) =>
     props.$sectionHeading
@@ -46,6 +47,10 @@ export const SettingRowLabel = styled.label<SettingRowLabelProps>`
           padding-left: ${props.$indent * 20}px;
         `
       : ""}
+
+  &:hover {
+    color: ${(props) => props.theme.colors.highlight};
+  }
 `;
 
 export const SettingRowInput = styled.div`


### PR DESCRIPTION
This is PR is related to the issue #1863 

I've added underlining and a color change when hovering on any field to imply that the fields have descriptions. Additionally, I've vertically centred input fields within engine fields.

* **What is the new behavior (if this is a feature change)?**

<img width="297" height="417" alt="Screenshot 2025-11-21 at 12 46 41 AM" src="https://github.com/user-attachments/assets/3bf8bd71-1771-417a-a494-4835bd755d6d" />

<img width="297" height="417" alt="image" src="https://github.com/user-attachments/assets/86b6f967-b630-402b-88ff-19a6acd7eb3b" />