### PR TITLE
Update pl.json 2130 - support lines for monochrome palettes

### DIFF
--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -2,7 +2,7 @@
   "RTL": false,
 
   "GBSTUDIO_DESCRIPTION": "Visual retro game maker\nPolish translation by: Reptile (reptile@o2.pl)",
-  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2126251210",
+  "GBSTUDIO_COPYRIGHT": "Distributed under MIT license.\n Translation: 2130251213",
 
   "// 1": "UI -------------------------------------------------------",
   "ACTOR": "Aktor",
@@ -546,6 +546,8 @@
   "FIELD_FLIP_HORIZONTAL": "Przerzuć w poziomie",
   "FIELD_FLIP_VERTICAL": "Przerzuć w pionie",
   "FIELD_MONOCHROME_PALETTE": "Paleta monochromatyczna",
+  "FIELD_MONOCHROME_PALETTES": "Palety monochromatyczne",
+  "FIELD_DEFAULT_MONOCHROME_PALETTES": "Domyślne palety monochromatyczne",
   "FIELD_COLOR_PALETTE": "Paleta koloru",
   "FIELD_EDIT_IMAGE": "Edytuj obraz",
   "FIELD_UNIQUE": "Wyjątek",
@@ -1286,6 +1288,8 @@
   "FIELD_AUTO_TILE_FLIP_SUPPORT_DESC": "Dotyczy wyłącznie scen typu 'Tylko kolor'.",
   "FIELD_SET_AUTO_TILE_FLIP_OVERRIDE": "Ustaw nadpisanie automatycznego odbicia tafli",
   "FIELD_DISABLED": "Wyłączone",
+  "FIELD_MONOCHROME_BGP_NOTE": "Paleta BGP jest używana dla tła oraz warstw nakładki.",
+  "FIELD_MONOCHROME_OBP_NOTE": "Palety OBP są używane dla spritów.",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Szukaj",


### PR DESCRIPTION
Update for the pl.json - 
Add support for setting global and per scene monochrome palettes, added missing lines.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update for the pl.json


* **What is the current behavior?** (You can also link to an open issue here)
Missing lines

* **What is the new behavior (if this is a feature change)?**
Added missing lines


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Merge ASAP, as always, thanks!