### PR TITLE
docs: add note about community MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Pull the latest code and run make:cli again, yarn link is only needed for the fi
 
 [GB Studio Documentation](https://www.gbstudio.dev/docs)
 
+## MCP Server (Community Tool)
+
+If you want to automate GB Studio project changes with an AI agent or scripts, I maintain an MCP (Model Context Protocol) server that exposes endpoints for project discovery, validation, inventory, and asset creation. It’s useful for turning prompts into playable prototypes and integrating GB Studio workflows into external tools. You can find it on npm here: [gbstudio-claude-mcp](https://www.npmjs.com/package/gbstudio-claude-mcp).
+
 ## Note For Translators
 
 If you'd like to help contribute new language localisations to GB Studio you can do so by submitting pull requests adding or updating the JSON files found here https://github.com/chrismaltby/gb-studio/tree/develop/src/lang


### PR DESCRIPTION
Mentions gbstudio-claude-mcp on npm for agent automation.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update.

* **What is the current behavior?** (You can also link to an open issue here)
README does not mention the community MCP server for automation.

* **What is the new behavior (if this is a feature change)?**
README includes a short note and npm link for the MCP server.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
[npm package](https://www.npmjs.com/package/gbstudio-claude-mcp)