### PR TITLE
WIP: Optimize weapon cooldown script, by waiting an additional frame after each VM_RPN

### DIFF
--- a/src/lib/compiler/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder.ts
@@ -5391,7 +5391,8 @@ extern void __mute_mask_${symbol};
       .operator(".LT")
       .stop();
     this._ifConst(".EQ", ".ARG0", 1, endLabel, 1);
-
+    // Wait 1 extra frame
+    this._idle();
     // Set next call time to sys_time + delay
     const localsLookup = this._performFetchOperations(fetchOps);
     const rpn = this._rpn();
@@ -5401,6 +5402,8 @@ extern void __mute_mask_${symbol};
       .operator(".ADD")
       .refSetVariable(timerVariable)
       .stop();
+    // Wait 1 extra frame
+    this._idle();
 
     this._compilePath(truePath);
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Optimizes the rateLimit script generation to not do multiple expensive VM_RPN calls.

* **What is the current behavior?** (You can also link to an open issue here)

Current behaviour uses one VM_RPN to calculate result for if condition, and then another VM_RPN if if condition succeeded (to set next frame where "weapon cooldown" has completed). 

Current behaviour causes bad performance spikes in shooter section of example project.

* **What is the new behavior (if this is a feature change)?**

New behaviour is that two VM_IDLE instructions are added:
- One VM_IDLE directly after the if statement (if successful)
- One VM_IDLE after the VM_RPN which calculates next "cooldown" frame

New behaviour avoids the performance spikes in the shooter section.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes. There will now be a 2-frame delay for firing projectiles.

* **Other information**:
