### PR TITLE
Add font selection input to events and adds a set font event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for creating Notes that can be positioned and resized in the World view with multiple color options
+- Add "Set Font" event to change the current default font from scripts [@Mico27](https://github.com/Mico27)
 
 ## [4.2.2] - 2026-02-24
 

--- a/src/components/script/AddScriptEventMenu.tsx
+++ b/src/components/script/AddScriptEventMenu.tsx
@@ -30,6 +30,7 @@ import {
   sceneSelectors,
   spriteSheetSelectors,
   tilesetSelectors,
+  fontSelectors,
 } from "store/features/entities/entitiesState";
 import { useDebounce } from "ui/hooks/use-debounce";
 import { ScriptEditorContext } from "./ScriptEditorContext";
@@ -88,6 +89,7 @@ interface InstanciateOptions {
   defaultSpriteId: string;
   defaultEmoteId: string;
   defaultTilesetId: string;
+  defaultFontId: string;
   defaultEngineFieldId: string;
   defaultArgs?: Record<string, unknown>;
 }
@@ -107,6 +109,7 @@ const instanciateScriptEvent = (
     defaultSpriteId,
     defaultEmoteId,
     defaultTilesetId,
+    defaultFontId,
     defaultEngineFieldId,
     defaultArgs,
   }: InstanciateOptions,
@@ -167,6 +170,8 @@ const instanciateScriptEvent = (
           replaceValue = defaultEmoteId;
         } else if (defaultValue === "LAST_TILESET") {
           replaceValue = defaultTilesetId;
+        } else if (defaultValue === "LAST_FONT") {
+          replaceValue = defaultFontId;
         } else if (defaultValue === "LAST_ACTOR") {
           replaceValue = defaultActorId;
         } else if (defaultValue === "LAST_ENGINE_FIELD") {
@@ -576,6 +581,9 @@ const AddScriptEventMenu = ({
   const lastTilesetId = useAppSelector(
     (state) => tilesetSelectors.selectIds(state)[0],
   );
+  const lastFontId = useAppSelector(
+    (state) => fontSelectors.selectIds(state)[0],
+  );
   const lastEngineFieldId = useAppSelector(
     (state) => state.engine.defaultEngineFieldId,
   );
@@ -839,6 +847,7 @@ const AddScriptEventMenu = ({
               defaultSpriteId: String(lastSpriteId),
               defaultEmoteId: String(lastEmoteId),
               defaultTilesetId: String(lastTilesetId),
+              defaultFontId: String(lastFontId),
               defaultEngineFieldId: String(lastEngineFieldId),
               defaultArgs: {
                 ...defaultArgs,
@@ -867,6 +876,7 @@ const AddScriptEventMenu = ({
       lastSpriteId,
       lastEmoteId,
       lastTilesetId,
+      lastFontId,
       lastEngineFieldId,
       onBlur,
     ],

--- a/src/components/script/ScriptEventFormInput.tsx
+++ b/src/components/script/ScriptEventFormInput.tsx
@@ -25,6 +25,7 @@ import { SceneSelect } from "components/forms/SceneSelect";
 import { SoundEffectSelect } from "components/forms/SoundEffectSelect";
 import { SpriteSheetSelect } from "components/forms/SpriteSheetSelect";
 import { VariableSelect } from "components/forms/VariableSelect";
+import { FontSelect } from "components/forms/FontSelect";
 import {
   castEventToBool,
   castEventToFloat,
@@ -755,6 +756,16 @@ const ScriptEventFormInput = ({
             (args[field.unitsField || ""] || field.unitsDefault) as UnitType
           }
           filters={field.filters}
+        />
+      </OffscreenSkeletonInput>
+    );
+  } else if (type === "font") {
+    return (
+      <OffscreenSkeletonInput>
+        <FontSelect
+          name={id}
+          value={String(value ?? "")}
+          onChange={onChangeField}
         />
       </OffscreenSkeletonInput>
     );

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1311,6 +1311,7 @@
   "FIELD_EVERY_FRAME_WITH_WARN": "Every Frame (Most Precise, Slowest)",
   "FIELD_TOUCHING_WALL": "Is Touching Wall",
   "FIELD_PLATFORM_TOUCHING_WALL_DESC": "Whether the player is currently pressing against a wall in the platformer scene.",
+  "FIELD_FONT_DESC": "The font to use for drawing text.",
 
   "// 7": "Asset Viewer ---------------------------------------------",
   "ASSET_SEARCH": "Search...",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1470,6 +1470,8 @@
   "EVENT_OVERLAY_HIDE_DESC": "Hides the screen overlay.",
   "EVENT_OVERLAY_MOVE_TO": "Overlay Move To",
   "EVENT_OVERLAY_MOVE_TO_DESC": "Moves the overlay to a new position on the screen.",
+  "EVENT_SET_FONT": "Set Font",
+  "EVENT_SET_FONT_DESC": "Set the currently used font for text",
   "EVENT_AWAIT_INPUT": "Pause Script Until Button Pressed",
   "EVENT_AWAIT_INPUT_DESC": "Pauses the script until one of the specified joypad buttons are pressed.",
   "EVENT_MUSIC_PLAY": "Play Music Track",

--- a/src/lib/compiler/precompile/determineUsedAssets.ts
+++ b/src/lib/compiler/precompile/determineUsedAssets.ts
@@ -316,6 +316,8 @@ export const determineUsedAssets = ({
             }
           } else if (fieldType === "tileset" && typeof value === "string") {
             addTilesetById(value);
+          } else if (fieldType === "font" && typeof value === "string") {
+            addFontById(value);
           } else if (fieldType === "soundEffect" && typeof value === "string") {
             // Sounds
             addSoundById(value);

--- a/src/lib/compiler/scriptBuilder/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder/scriptBuilder.ts
@@ -1519,10 +1519,10 @@ class ScriptBuilder extends ScriptBuilderBase {
     this._setConstMemUInt8("overlay_cut_scanline", LYC_SYNC_VALUE);
     this._addNL();
   };
-  
-  setFont = (fontIndex = 0) => {
-    this._addComment("Set font");
-    this._setFont(fontIndex);
+
+  setFont = (fontId: string) => {
+    this._addComment("Set Font");
+    this._setFont(this._getFontSymbol(fontId));
     this._addNL();
   };
 

--- a/src/lib/compiler/scriptBuilder/scriptBuilder.ts
+++ b/src/lib/compiler/scriptBuilder/scriptBuilder.ts
@@ -1519,6 +1519,12 @@ class ScriptBuilder extends ScriptBuilderBase {
     this._setConstMemUInt8("overlay_cut_scanline", LYC_SYNC_VALUE);
     this._addNL();
   };
+  
+  setFont = (fontIndex = 0) => {
+    this._addComment("Set font");
+    this._setFont(fontIndex);
+    this._addNL();
+  };
 
   overlayShow = (color = "white", x = 0, y = 0) => {
     this._addComment("Overlay Show");

--- a/src/lib/compiler/scriptBuilder/scriptBuilderBase.ts
+++ b/src/lib/compiler/scriptBuilder/scriptBuilderBase.ts
@@ -355,6 +355,15 @@ abstract class ScriptBuilderBase {
     return index;
   };
 
+  _getFontSymbol = (fontId: string) => {
+    const { fonts } = this.options;
+    const font = fonts.find((f) => f.id === fontId);
+    if (!font?.symbol) {
+      return "0";
+    }
+    return font.symbol.toUpperCase();
+  };
+
   resolveActorId(id: ScriptBuilderVariable): ResolvedActorId {
     if (typeof id === "number") {
       return { type: "number", value: id };
@@ -1779,9 +1788,9 @@ abstract class ScriptBuilderBase {
   _setTextLayer = (layer: ".TEXT_LAYER_BKG" | ".TEXT_LAYER_WIN") => {
     this._addCmd("VM_SWITCH_TEXT_LAYER", layer);
   };
-  
-  _setFont = (fontIndex: number) => {
-    this._addCmd("VM_SET_FONT", fontIndex);
+
+  _setFont = (fontRef: number | string) => {
+    this._addCmd("VM_SET_FONT", fontRef);
   };
 
   _choice = (

--- a/src/lib/compiler/scriptBuilder/scriptBuilderBase.ts
+++ b/src/lib/compiler/scriptBuilder/scriptBuilderBase.ts
@@ -1779,6 +1779,10 @@ abstract class ScriptBuilderBase {
   _setTextLayer = (layer: ".TEXT_LAYER_BKG" | ".TEXT_LAYER_WIN") => {
     this._addCmd("VM_SWITCH_TEXT_LAYER", layer);
   };
+  
+  _setFont = (fontIndex: number) => {
+    this._addCmd("VM_SET_FONT", fontIndex);
+  };
 
   _choice = (
     variable: ScriptBuilderStackVariable,

--- a/src/lib/events/eventSetFont.js
+++ b/src/lib/events/eventSetFont.js
@@ -7,15 +7,15 @@ const fields = [
   {
     key: "fontId",
     label: l10n("FIELD_FONT"),
-    description: l10n("FIELD_FONT"),
+    description: l10n("FIELD_FONT_DESC"),
     type: "font",
     defaultValue: "LAST_FONT",
   },
 ];
 
 const compile = (input, helpers) => {
-  const { setFont, _getFontIndex } = helpers;
-  setFont(_getFontIndex(input.fontId));
+  const { setFont } = helpers;
+  setFont(input.fontId);
 };
 
 module.exports = {

--- a/src/lib/events/eventSetFont.js
+++ b/src/lib/events/eventSetFont.js
@@ -1,0 +1,27 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_SET_FONT";
+const groups = ["EVENT_GROUP_DIALOGUE"];
+
+const fields = [
+  {
+    key: "fontId",
+    label: l10n("FIELD_FONT"),
+    description: l10n("FIELD_FONT"),
+    type: "font",
+    defaultValue: "LAST_FONT",
+  },
+];
+
+const compile = (input, helpers) => {
+  const { setFont, _getFontIndex } = helpers;
+  setFont(_getFontIndex(input.fontId));
+};
+
+module.exports = {
+  id,
+  description: l10n("EVENT_SET_FONT_DESC"),
+  groups,
+  fields,
+  compile,
+};


### PR DESCRIPTION
This adds font selection input for custom events and adds a "set font" event that makes uses of the VM_SET_FONT gbvm operation. 
( This PR was made is mainly because I want to be able to use the font selection input for my plugin )