### PR TITLE
Add scroll x and y to value field property selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for split patterns in the Music Editor, allowing different patterns to be set per channel
 - Add note sustain previews to Piano Roll view
 - Add ability to view current tracker keyboard layout (accessible in Preferences window in main app, and in menu `Input / Tracker Keyboard Layout` on music web app)
+- Add ability to read camera scroll x/y within script values [@pau-tomas](https://github.com/pau-tomas)
 - Ukrainian localisation. [@AmakerGame](https://github.com/AmakerGame)
 
 ### Changed

--- a/src/components/forms/PropertySelect.tsx
+++ b/src/components/forms/PropertySelect.tsx
@@ -240,10 +240,22 @@ export const PropertySelect = ({
       label: l10n("FIELD_CAMERA"),
       options: [
         {
+          label: l10n("FIELD_SCROLL_X"),
+          value: "camera:xscroll",
+          icon: <CameraIcon />,
+          menuIcon: <CameraIcon />,
+        },
+        {
+          label: l10n("FIELD_SCROLL_Y"),
+          value: "camera:yscroll",
+          icon: <CameraIcon />,
+          menuIcon: "",
+        },
+        {
           label: l10n("FIELD_X_POSITION"),
           value: "camera:xpos",
           icon: <CameraIcon />,
-          menuIcon: <CameraIcon />,
+          menuIcon: "",
         },
         {
           label: l10n("FIELD_Y_POSITION"),

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -311,6 +311,8 @@
   "FIELD_ACTOR_TYPE": "Sprite Type",
   "FIELD_OFFSET_X": "Offset X",
   "FIELD_OFFSET_Y": "Offset Y",
+  "FIELD_SCROLL_X": "Scroll X",
+  "FIELD_SCROLL_Y": "Scroll Y",
   "FIELD_SOURCE": "Source",
   "FIELD_DISTANCE": "Distance",
   "FIELD_DISTANCE_DESC": "The distance value.",

--- a/src/shared/lib/scriptValue/helpers.ts
+++ b/src/shared/lib/scriptValue/helpers.ts
@@ -593,6 +593,16 @@ export const precompileOptimisedScriptValue = (
           type: "memI8",
           value: "camera_offset_y",
         });
+      } else if (input.property === "xscroll") {
+        rpnOperations.push({
+          type: "memI16",
+          value: "scroll_x",
+        });
+      } else if (input.property === "yscroll") {
+        rpnOperations.push({
+          type: "memI16",
+          value: "scroll_y",
+        });
       } else {
         throw new Error(`Unsupported property type "${input.property}"`);
       }

--- a/src/shared/lib/scriptValue/types.ts
+++ b/src/shared/lib/scriptValue/types.ts
@@ -203,6 +203,8 @@ const validProperties = [
   "ydeadzone",
   "xoffset",
   "yoffset",
+  "xscroll",
+  "yscroll",
 ];
 
 export const isScriptValue = (value: unknown): value is ScriptValue => {

--- a/src/shared/lib/scripts/autoLabel.ts
+++ b/src/shared/lib/scripts/autoLabel.ts
@@ -93,6 +93,12 @@ export const getAutoLabel = (
       if (value === "yoffset") {
         return l10n("FIELD_OFFSET_Y").replace(/ /g, "");
       }
+      if (value === "xscroll") {
+        return l10n("FIELD_SCROLL_X").replace(/ /g, "");
+      }
+      if (value === "yscroll") {
+        return l10n("FIELD_SCROLL_Y").replace(/ /g, "");
+      }
       return value;
     };
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

I forgot to add the scroll values to the camera properties and they're, arguably, much more useful than the camera position in pixels or tiles as those will normally be the player position with a small offset.

* **What is the new behavior (if this is a feature change)?**

Added Scroll X and Scroll Y to the Properties menu:

<img width="536" height="435" alt="image" src="https://github.com/user-attachments/assets/0d4882a9-8cf6-4aee-a594-95c340fde07d" />

This is useful to, for example, make an actor that follows the scroll dynamically and has collisions. Like enemies in shmups that enter the screen and remain stationary while shooting at you (requested [here](https://discord.com/channels/554713715442712616/585023243732123676/1497615031196717059)). This can't be achieved by setting the actor to pinned because in that case we ignore the collisions:

<img width="578" height="174" alt="image" src="https://github.com/user-attachments/assets/2c489a98-a0ca-4c02-8084-1ad47cfa9b43" />


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

N/A