### PR TITLE
Fix: Scene palette overrides with incorrect defaults

### DIFF
--- a/src/components/editors/SceneEditor.tsx
+++ b/src/components/editors/SceneEditor.tsx
@@ -658,15 +658,19 @@ export const SceneEditor = ({ id }: SceneEditorProps) => {
     (background?.autoTileFlipOverride !== undefined ||
       autoTileFlipOverrideOpen);
   const onEditPaletteId = (index: number) => (paletteId: string) => {
-    const paletteIds = scene.paletteIds ? [...scene.paletteIds] : [];
+    const paletteIds = Array.from(
+      { length: 8 },
+      (_, i) => scene.paletteIds?.[i] ?? "",
+    );
     paletteIds[index] = paletteId;
     onChangeSceneProp("paletteIds", paletteIds);
   };
 
   const onEditSpritePaletteId = (index: number) => (paletteId: string) => {
-    const spritePaletteIds = scene.spritePaletteIds
-      ? [...scene.spritePaletteIds]
-      : [];
+    const spritePaletteIds = Array.from(
+      { length: 8 },
+      (_, i) => scene.spritePaletteIds?.[i] ?? "",
+    );
     spritePaletteIds[index] = paletteId;
     onChangeSceneProp("spritePaletteIds", spritePaletteIds);
   };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

When overriding a scene palette, if, for example, palette 4 is the overrode with "new-palette-id" the `paletteIds` field in the scene `.gbsres` will be just ["new-palette-id"]. This means that the next time the project is loaded the replaced palette will be palette 0 and not palette 4.

<img width="781" height="317" alt="image" src="https://github.com/user-attachments/assets/8fbc784f-3da6-4c58-9c4a-170d9d3f29ed" />



* **What is the new behavior (if this is a feature change)?**

`paletteIds` (and `spritePaletteIds`) are always stored as an 8 elements array, using empty strings for the palettes that aren't overrode.

For the same example as above `paletteIds` will be:
```
[
    "",
    "",
    "",
    "",
    "99af0c5b-2f2d-4c6d-8883-795ad9cb46fa",
    "",
    "",
    ""
  ]
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think so. 

* **Other information**:

Seems like the error is happening when the scene state is serialized to write to the gbsres file (maybe due to the `pruneMissingEntities`?). There might be a more elegant solution, but I'm not familiar with that part of the codebase.