### PR TITLE
Security: Potential prototype pollution in sortByKey helper

### DIFF
--- a/src/shared/lib/helpers/sortByKey.ts
+++ b/src/shared/lib/helpers/sortByKey.ts
@@ -6,6 +6,6 @@ export const sortByKey = <T extends Record<string, unknown>>(input: T): T => {
         obj[key] = input[key];
         return obj;
       },
-      {} as Record<string, unknown>,
+      Object.create(null) as Record<string, unknown>,
     ) as T;
 };


### PR DESCRIPTION
## Problem

The sortByKey function uses Object.keys() and reduces into an object, but doesn't protect against prototype pollution via __proto__, constructor, or prototype keys. If user-controlled data is passed to this function, it could pollute the prototype chain.

**Severity**: `medium`
**File**: `src/shared/lib/helpers/sortByKey.ts`

## Solution

Use Object.create(null) as the initial reduce value, or explicitly check and reject dangerous keys like '__proto__', 'constructor', and 'prototype'.

## Changes

- `src/shared/lib/helpers/sortByKey.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
