### PR TITLE
Add tooltip to ConstantSelect dropdown options

### DIFF
--- a/src/components/forms/ConstantSelect.tsx
+++ b/src/components/forms/ConstantSelect.tsx
@@ -271,6 +271,9 @@ export const ConstantSelect: FC<ConstantSelectProps> = ({
               onChange(newValue.value);
             }
           }}
+          formatOptionLabel={(option: Option) => (
+            <span title={option.label}>{option.label}</span>
+          )}
           {...selectProps}
         />
       )}

--- a/src/components/ui/scripting/style.ts
+++ b/src/components/ui/scripting/style.ts
@@ -575,8 +575,8 @@ export const StyledScriptEventBranchHeader = styled.div<StyledScriptEventBranchH
       margin-right: 10px;
     }
     ${StyledFormFieldInput} {
-      width: 100%;
-      max-width: 200px;
+      flex: 1;
+      min-width: 0;
 
       .CustomSelect__control {
         height: 22px;
@@ -596,8 +596,8 @@ export const StyledScriptEventBranchHeader = styled.div<StyledScriptEventBranchH
 `;
 
 export const StyledScriptEventBranchHeaderFields = styled.div`
-  width: 100%;
-  max-width: 200px;
+  flex: 1;
+  min-width: 0;
 `;
 
 // #endregion ScriptEventBranchHeader


### PR DESCRIPTION
Constants can have long names that get truncated with no way of seeing the full name even after selecting it. The matter is made worse when using folders (with "/" separators).

Adds a `formatOptionLabel` render to `ConstantSelect` that wraps each option in a `<span>` with a `title` attribute, showing the full constant name on mouse over.

<img width="602" height="489" alt="image" src="https://github.com/user-attachments/assets/46114ebd-af23-42e2-b9cc-003d35c778d2" />
