### PR TITLE
Fix issue where active sprite frame cannot be seen after arrow navigation

### DIFF
--- a/src/components/ui/lists/SortableList.tsx
+++ b/src/components/ui/lists/SortableList.tsx
@@ -1,4 +1,11 @@
-import React, { JSX, useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  JSX,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { SortableItem } from "ui/lists/SortableItem";
 import { StyledSortableList } from "./style";
 import throttle from "lodash/throttle";
@@ -114,6 +121,13 @@ export const SortableList = <T,>({
       window.removeEventListener("keydown", handleKeys);
     };
   });
+
+  useLayoutEffect(() => {
+    const el = listRef.current?.children[selectedIndex] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [selectedIndex]);
 
   return (
     <StyledSortableList

--- a/src/components/ui/lists/style.ts
+++ b/src/components/ui/lists/style.ts
@@ -116,6 +116,7 @@ export const StyledSortableList = styled.div<StyledSortableListProps>`
 
   & > * {
     flex-shrink: 0;
+    scroll-margin: ${(props) => props.$padding}px;
   }
 `;
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [X] Tests for the changes have been added (for bug fixes / features)
I don't think there are any tests readily available for React components although I did run my change in Storybook and it appeared to work correctly.
- [X] Docs have been added / updated (for bug fixes / features)
No document changes needed.

It is my first PR, so just let me know if I made errors on filling out the requirements.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for issue #1551

* **What is the current behavior?** (You can also link to an open issue here)
See issue #1551

* **What is the new behavior (if this is a feature change)?**
The SortableList component now properly scrolls to show its active item after using the keyboard to navigate to a item that is off of the edge of the layout. I also put a small amount of padding into the scroll-margin style so the edge of the item isn't flush with the edge of the layout after the scroll happens. It looks better that way.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
Since the SortableList component is used both in the Sprite Animation Frames and in the Pattern Order frame in the Music Editor, this fix works in both of those editor frames.
