### PR TITLE
[dev] Fix react hooks eslint dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["plugin:@typescript-eslint/recommended", "react-app", "prettier", "plugin:react-hooks/recommended"],
+  "extends": ["plugin:@typescript-eslint/recommended", "react-app", "prettier"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["babel"],
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,6 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-storybook": "^10.4.6",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^7.2.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12985,7 +12985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:4.6.0, eslint-plugin-react-hooks@npm:^4.3.0":
+"eslint-plugin-react-hooks@npm:^4.3.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
   peerDependencies:
@@ -14231,7 +14231,6 @@ __metadata:
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:4.6.0"
     eslint-plugin-storybook: "npm:^10.4.6"
     file-loader: "npm:^6.2.0"
     focus-visible: "npm:^5.2.1"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

With the new dependency updates, the react hooks eslint stopped working. So, for example, linter wasn't wanrning if the useEffect dependencies were wrong.

* **What is the new behavior (if this is a feature change)?**

Updated the dependency to make it work.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
