### PR TITLE
Add deduping identical compiled entity scripts feature

### DIFF
--- a/src/components/settings/section/SettingsSectionBuild.tsx
+++ b/src/components/settings/section/SettingsSectionBuild.tsx
@@ -45,6 +45,9 @@ export const SettingsSectionBuild = ({
   const showRomUsageAfterBuild = useAppSelector(
     (state) => state.project.present.settings.showRomUsageAfterBuild,
   );
+  const dedupeScriptsEnabled = useAppSelector(
+    (state) => state.project.present.settings.dedupeScriptsEnabled,
+  );
   const compilerPreset = useAppSelector(
     (state) => state.project.present.settings.compilerPreset,
   );
@@ -113,6 +116,16 @@ export const SettingsSectionBuild = ({
     [dispatch],
   );
 
+  const onChangeDedupeScriptsEnabled = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      dispatch(
+        settingsActions.editSettings({
+          dedupeScriptsEnabled: castEventToBool(e),
+        }),
+      ),
+    [dispatch],
+  );
+
   const onChangeCompilerPreset = useCallback(
     (value: number) =>
       dispatch(
@@ -129,6 +142,7 @@ export const SettingsSectionBuild = ({
         settingsActions.editSettings({
           openBuildLogOnWarnings: true,
           generateDebugFilesEnabled: false,
+          dedupeScriptsEnabled: true,
           compilerPreset: 3000,
         }),
       ),
@@ -143,6 +157,7 @@ export const SettingsSectionBuild = ({
         l10n("FIELD_ROM_FILENAME"),
         l10n("FIELD_OPEN_BUILD_LOG_ON_WARNINGS"),
         l10n("FIELD_GENERATE_DEBUG_FILES"),
+        l10n("FIELD_DEDUPE_SCRIPTS"),
         l10n("FIELD_COMPILER_PRESET"),
       ]}
     >
@@ -228,6 +243,21 @@ export const SettingsSectionBuild = ({
             name="showRomUsageAfterBuild"
             checked={showRomUsageAfterBuild}
             onChange={onChangeShowRomUsageAfterBuild}
+          />
+        </SettingRowInput>
+      </SearchableSettingRow>
+
+      <SearchableSettingRow
+        searchTerm={searchTerm}
+        searchMatches={[l10n("FIELD_DEDUPE_SCRIPTS")]}
+      >
+        <SettingRowLabel>{l10n("FIELD_DEDUPE_SCRIPTS")}</SettingRowLabel>
+        <SettingRowInput>
+          <Checkbox
+            id="dedupeScriptsEnabled"
+            name="dedupeScriptsEnabled"
+            checked={dedupeScriptsEnabled}
+            onChange={onChangeDedupeScriptsEnabled}
           />
         </SettingRowInput>
       </SearchableSettingRow>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -343,6 +343,7 @@ export const defaultProjectSettings: Settings = {
   spriteMode: "8x16",
   openBuildFolderOnExport: true,
   showRomUsageAfterBuild: false,
+  dedupeScriptsEnabled: true,
   romFilename: "",
   defaultSceneTypeId: "TOPDOWN",
   disabledSceneTypeIds: [],

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1266,6 +1266,7 @@
   "FIELD_SET_SPRITE_MODE_OVERRIDE": "Set Sprite Mode Override",
   "FIELD_OPEN_BUILD_FOLDER_ON_EXPORT": "Open Build Folder On Export",
   "FIELD_SHOW_ROM_USAGE_AFTER_BUILD": "Show ROM Usage After Build",
+  "FIELD_DEDUPE_SCRIPTS": "Merge Duplicate Scripts",
   "FIELD_ROM_FILENAME": "ROM Filename",
   "FIELD_2_WAY": "2-Way",
   "FIELD_4_WAY": "4-Way",

--- a/src/lib/compiler/compileData.ts
+++ b/src/lib/compiler/compileData.ts
@@ -79,6 +79,7 @@ import {
   emptySpriteSheet,
 } from "./generateGBVMData";
 import compileSGBImage, { sgbImageHeader } from "./sgb";
+import { gbvmScriptChecksum } from "./gbvm/buildHelpers";
 import { compileScriptEngineInit } from "./compileBootstrap";
 import {
   compileMusicTracks,
@@ -1525,6 +1526,8 @@ const compile = async (
     }
   > = {};
   const additionalScriptsCache: Record<string, string> = {};
+  const entityScriptsCache: Record<string, string> = {};
+  let mergedEntityScriptsCount = 0;
   const recursiveSymbolMap: Record<string, string> = {};
   const compiledAssetsCache: Record<string, string> = {};
 
@@ -1621,6 +1624,18 @@ const compile = async (
           isFunction: false,
           debugEnabled,
         });
+
+        // If this script is identical to an already generated entity script
+        // just reuse the existing symbol rather than writing a duplicate file.
+        if (projectData.settings.dedupeScriptsEnabled) {
+          const scriptHash = gbvmScriptChecksum(compiledScript);
+          const existingScriptName = entityScriptsCache[scriptHash];
+          if (existingScriptName) {
+            mergedEntityScriptsCount++;
+            return existingScriptName;
+          }
+          entityScriptsCache[scriptHash] = scriptName;
+        }
 
         output[`${scriptName}.s`] = compiledScript;
         output[`${scriptName}.h`] = compileScriptHeader(scriptName);
@@ -1840,6 +1855,14 @@ const compile = async (
     );
     output[`${additional.symbol}.h`] = compileScriptHeader(additional.symbol);
   });
+
+  if (mergedEntityScriptsCount > 0) {
+    progress(
+      `Merged ${mergedEntityScriptsCount} duplicate entity script${
+        mergedEntityScriptsCount === 1 ? "" : "s"
+      }`,
+    );
+  }
 
   (
     Object.values(additionalOutput) as {

--- a/src/shared/lib/resources/types.ts
+++ b/src/shared/lib/resources/types.ts
@@ -982,6 +982,7 @@ export const SettingsResource = Type.Object({
   spriteMode: SpriteModeSetting,
   openBuildFolderOnExport: Type.Boolean(),
   showRomUsageAfterBuild: Type.Boolean(),
+  dedupeScriptsEnabled: Type.Boolean(),
   romFilename: Type.String(),
   defaultSceneTypeId: Type.String(),
   disabledSceneTypeIds: Type.Array(Type.String()),

--- a/test/compiler/compileDedupeEntityScripts.test.ts
+++ b/test/compiler/compileDedupeEntityScripts.test.ts
@@ -1,0 +1,339 @@
+import compile from "../../src/lib/compiler/compileData";
+import { EVENT_TEXT } from "../../src/consts";
+import { getTestScriptHandlers } from "../getTestScriptHandlers";
+import { ProjectResources, ScriptEvent } from "shared/lib/resources/types";
+import os from "os";
+
+const buildProject = ({
+  sceneAScript = [],
+  sceneBScript = [],
+  sceneAActors = [],
+  sceneBActors = [],
+  sceneATriggers = [],
+  sceneBTriggers = [],
+  dedupeScriptsEnabled = true,
+}: {
+  sceneAScript?: Partial<ScriptEvent>[];
+  sceneBScript?: Partial<ScriptEvent>[];
+  sceneAActors?: Record<string, unknown>[];
+  sceneBActors?: Record<string, unknown>[];
+  sceneATriggers?: Record<string, unknown>[];
+  sceneBTriggers?: Record<string, unknown>[];
+  dedupeScriptsEnabled?: boolean;
+}) =>
+  ({
+    startSceneId: "1",
+    startX: 5,
+    startY: 6,
+    startDirection: "down",
+    settings: {
+      playerSpriteSheetId: "SPRITE_1",
+      defaultPlayerSprites: {
+        TOPDOWN: "SPRITE_1",
+      },
+      dedupeScriptsEnabled,
+    },
+    scenes: [
+      {
+        id: "1",
+        name: "first_scene",
+        symbol: "scene_a",
+        backgroundId: "2",
+        width: 20,
+        height: 18,
+        type: "TOPDOWN",
+        collisions: [],
+        actors: sceneAActors,
+        triggers: sceneATriggers,
+        script: sceneAScript,
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+      {
+        id: "5",
+        name: "second_scene",
+        symbol: "scene_b",
+        backgroundId: "3",
+        width: 20,
+        height: 18,
+        type: "TOPDOWN",
+        collisions: [],
+        actors: sceneBActors,
+        triggers: sceneBTriggers,
+        script: sceneBScript,
+        playerHit1Script: [],
+        playerHit2Script: [],
+        playerHit3Script: [],
+      },
+    ],
+    backgrounds: [
+      {
+        id: "2",
+        symbol: "bg_1",
+        width: 20,
+        height: 32,
+        imageWidth: 160,
+        imageHeight: 256,
+        filename: "forest_clearing.png",
+      },
+      {
+        id: "3",
+        symbol: "bg_2",
+        width: 20,
+        height: 18,
+        imageWidth: 160,
+        imageHeight: 256,
+        filename: "mabe_house.png",
+      },
+    ],
+    sprites: [
+      {
+        id: "SPRITE_1",
+        symbol: "sprite_1",
+        filename: "sprite_1.png",
+        states: [
+          {
+            id: "SPRITE_STATE_1",
+            name: "",
+            animations: [
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+              { frames: [] },
+            ],
+          },
+        ],
+      },
+    ],
+    music: [],
+    fonts: [
+      {
+        id: "font1",
+        symbol: "font_1",
+        filename: "gbs-mono.png",
+      },
+    ],
+    palettes: [],
+    avatars: [],
+    emotes: [],
+    variables: {
+      variables: [],
+      constants: [],
+    },
+    engineFieldValues: {
+      engineFieldValues: [],
+    },
+  }) as unknown as ProjectResources;
+
+const compileProject = async (
+  project: ProjectResources,
+  debugEnabled = false,
+) => {
+  const scriptEventHandlers = await getTestScriptHandlers();
+  return compile(project, {
+    projectRoot: `${__dirname}/_files`,
+    scriptEventHandlers,
+    engineSchema: {
+      fields: [],
+      sceneTypes: [
+        {
+          key: "TOPDOWN",
+          label: "GAMETYPE_TOP_DOWN",
+        },
+      ],
+      consts: {},
+    },
+    tmpPath: os.tmpdir(),
+    debugEnabled,
+    progress: (_msg: string) => {},
+    warnings: (_msg: string) => {},
+  });
+};
+
+let nextEventId = 1;
+const textEvent = (text: string) => ({
+  id: `event_${nextEventId++}`,
+  command: EVENT_TEXT,
+  args: {
+    text,
+  },
+});
+
+test("should reuse identical trigger scripts across scenes", async () => {
+  const project = buildProject({
+    sceneATriggers: [
+      {
+        id: "92",
+        symbol: "trigger_a",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+    sceneBTriggers: [
+      {
+        id: "91",
+        symbol: "trigger_b",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+  });
+  const compiled = await compileProject(project);
+  // First trigger's script compiled as normal
+  expect(compiled.files["trigger_a_interact.s"]).toBeDefined();
+  // Identical second trigger script merged into first rather than duplicated
+  expect(compiled.files["trigger_b_interact.s"]).toBeUndefined();
+  // Second scene's trigger data points at the shared script
+  expect(compiled.files["scene_b_triggers.c"]).toContain("trigger_a_interact");
+  expect(compiled.files["scene_b_triggers.c"]).not.toContain(
+    "trigger_b_interact",
+  );
+});
+
+test("should reuse identical actor scripts across scenes", async () => {
+  const project = buildProject({
+    sceneAActors: [
+      {
+        id: "9",
+        symbol: "actor_a",
+        spriteSheetId: "SPRITE_1",
+        script: [textEvent("ACTOR TEST")],
+      },
+    ],
+    sceneBActors: [
+      {
+        id: "10",
+        symbol: "actor_b",
+        spriteSheetId: "SPRITE_1",
+        script: [textEvent("ACTOR TEST")],
+      },
+    ],
+  });
+  const compiled = await compileProject(project);
+  expect(compiled.files["actor_a_interact.s"]).toBeDefined();
+  expect(compiled.files["actor_b_interact.s"]).toBeUndefined();
+  expect(compiled.files["scene_b_actors.c"]).toContain("actor_a_interact");
+  expect(compiled.files["scene_b_actors.c"]).not.toContain("actor_b_interact");
+});
+
+test("should not merge scripts that compile differently due to Self references", async () => {
+  const selfHideScript = [
+    {
+      id: "event_self_hide",
+      command: "EVENT_ACTOR_HIDE",
+      args: {
+        actorId: "$self$",
+      },
+    },
+  ];
+  const project = buildProject({
+    sceneAActors: [
+      {
+        id: "9",
+        symbol: "actor_a",
+        spriteSheetId: "SPRITE_1",
+        script: selfHideScript,
+      },
+      {
+        id: "10",
+        symbol: "actor_b",
+        spriteSheetId: "SPRITE_1",
+        script: selfHideScript,
+      },
+    ],
+  });
+  const compiled = await compileProject(project);
+  // Identical JSON but Self resolves to different actor indexes
+  // so compiled output differs and scripts must NOT be merged
+  expect(compiled.files["actor_a_interact.s"]).toBeDefined();
+  expect(compiled.files["actor_b_interact.s"]).toBeDefined();
+  expect(compiled.files["actor_a_interact.s"]).not.toEqual(
+    compiled.files["actor_b_interact.s"],
+  );
+});
+
+test("should not merge identical scripts when dedupe setting is disabled", async () => {
+  const project = buildProject({
+    dedupeScriptsEnabled: false,
+    sceneATriggers: [
+      {
+        id: "92",
+        symbol: "trigger_a",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+    sceneBTriggers: [
+      {
+        id: "91",
+        symbol: "trigger_b",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+  });
+  const compiled = await compileProject(project);
+  expect(compiled.files["trigger_a_interact.s"]).toBeDefined();
+  expect(compiled.files["trigger_b_interact.s"]).toBeDefined();
+});
+
+test("should merge identical scripts in debug builds when dedupe setting is enabled", async () => {
+  const project = buildProject({
+    sceneATriggers: [
+      {
+        id: "92",
+        symbol: "trigger_a",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+    sceneBTriggers: [
+      {
+        id: "91",
+        symbol: "trigger_b",
+        x: 1,
+        y: 2,
+        width: 5,
+        height: 1,
+        trigger: "walk",
+        script: [textEvent("TRIGGER TEST")],
+        leaveScript: [],
+      },
+    ],
+  });
+  const compiled = await compileProject(project, true);
+  // Dedupe is controlled purely by the project setting - debug builds
+  // merge too (the checksum ignores GBVM debug symbol lines)
+  expect(compiled.files["trigger_a_interact.s"]).toBeDefined();
+  expect(compiled.files["trigger_b_interact.s"]).toBeUndefined();
+});

--- a/test/dummydata.ts
+++ b/test/dummydata.ts
@@ -388,6 +388,7 @@ export const dummyProjectData: ProjectData = {
     autoTileFlipEnabled: true,
     webTemplate: "",
     selectedSceneTilesetId: "",
+    dedupeScriptsEnabled: true,
   },
 };
 
@@ -699,6 +700,7 @@ export const dummySettingsResource: SettingsResource = {
   autoTileFlipEnabled: true,
   webTemplate: "",
   selectedSceneTilesetId: "",
+  dedupeScriptsEnabled: true,
 };
 
 export const dummyVariablesResource: VariablesResource = {
@@ -845,6 +847,7 @@ export const dummyProjectResources: ProjectResources = {
     autoTileFlipEnabled: true,
     webTemplate: "",
     selectedSceneTilesetId: "",
+    dedupeScriptsEnabled: true,
   },
 };
 

--- a/test/resources/types.test.ts
+++ b/test/resources/types.test.ts
@@ -655,6 +655,7 @@ describe("TypeBox Schemas", () => {
       autoTileFlipEnabled: true,
       webTemplate: "",
       selectedSceneTilesetId: "",
+      dedupeScriptsEnabled: true,
     };
     const invalidSettings = {
       _resourceType: "settings",


### PR DESCRIPTION
This feature adds the option in build settings (enabled by default) to dedupe identical entity scripts to reduce redundant ROM data and save on ROM space. Ideal for people who use actor/trigger prefabs with large scripts and use those prefabs across multiple scenes.