### PR TITLE
fix: migrate raw variable data before schema cast to preserve flag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where clicking into Constant name field and leaving without changing anything would cause compiled symbol to change
 - Fix issue where changing a Constant's name and clicking away could sometimes cause name change to be lost
 - Fix issue where renaming a variable to have the same name but with different capitalisation could cause compiled symbol to change
+- Fix issue where custom variable flag names being lost when opening projects created before 5.0.0
 
 ## [4.3.2] - 2026-06-22
 

--- a/src/lib/project/loadProjectResources.ts
+++ b/src/lib/project/loadProjectResources.ts
@@ -33,6 +33,7 @@ import { readJson } from "lib/helpers/fs/readJson";
 import { Value } from "@sinclair/typebox/value";
 import type { Static, TSchema } from "@sinclair/typebox";
 import { naturalSortPaths, pathToPosix } from "shared/lib/helpers/path";
+import { migrateRawResource } from "lib/project/migration/rawResourceMigrations";
 
 const CONCURRENT_RESOURCE_LOAD_COUNT = 8;
 
@@ -199,8 +200,16 @@ export const loadProjectResources = async (
       // Invalid resource - skipping
       continue;
     }
+    const migratedResource = {
+      path: resource.path,
+      data: migrateRawResource(
+        resource.data,
+        metadataResource._version,
+        metadataResource._release,
+      ),
+    };
     for (const castFunction of castFns) {
-      if (castFunction(resource as ResourceWithPath<MinimalResource>)) {
+      if (castFunction(migratedResource as ResourceWithPath<MinimalResource>)) {
         break;
       }
     }

--- a/src/lib/project/migration/legacy/migrateLegacyProject.ts
+++ b/src/lib/project/migration/legacy/migrateLegacyProject.ts
@@ -32,6 +32,7 @@ import {
 import type { ScriptEventDefs } from "shared/lib/scripts/eventHelpers";
 import type { ProjectData } from "store/features/project/projectActions";
 import { Value } from "@sinclair/typebox/value";
+import { migrateRawResource } from "lib/project/migration/rawResourceMigrations";
 import { defaultProjectSettings } from "consts";
 import { toValidSymbol } from "shared/lib/helpers/symbols";
 
@@ -146,10 +147,16 @@ export const migrateLegacyProject = (
       chain(fixMissingSymbols("song"), encodeResource(MusicResource)),
     ),
     palettes: map(migratedProject.palettes, encodeResource(PaletteResource)),
-    variables: encodeResource(VariablesResource)({
-      _resourceType: "variables",
-      variables: migratedProject.variables,
-    }),
+    variables: encodeResource(VariablesResource)(
+      migrateRawResource(
+        {
+          _resourceType: "variables",
+          variables: migratedProject.variables,
+        },
+        migratedProject._version,
+        migratedProject._release,
+      ) as Partial<VariablesResource>,
+    ),
     engineFieldValues: encodeResource(EngineFieldValuesResource)({
       _resourceType: "engineFieldValues",
       engineFieldValues: migratedProject.engineFieldValues,

--- a/src/lib/project/migration/rawResourceMigrations.ts
+++ b/src/lib/project/migration/rawResourceMigrations.ts
@@ -1,0 +1,66 @@
+/**
+ * Migrations that run on raw resource data before it is cast with
+ * `Value.Cast`, for shape changes where casting old data against the
+ * current schema would be lossy.
+ */
+
+export type RawResourceMigration = {
+  resourceType: string;
+  appliesToVersion: (version: string, release: string) => boolean;
+  migrate: (data: unknown) => unknown;
+};
+
+const projectMajorVersion = (version: string): number => {
+  const major = parseInt(version.split(".")[0] ?? "", 10);
+  return Number.isNaN(major) ? 0 : major;
+};
+
+/**
+ * Pre-5.0.0 projects store variables without a `type` field. Casting them
+ * against the `Variable` schema (an intersect discriminated on `type`)
+ * drops optional fields such as `flags` (custom flag names). See #2181.
+ */
+export const migrateRawVariableTypes: RawResourceMigration = {
+  resourceType: "variables",
+  appliesToVersion: (version) => projectMajorVersion(version) < 5,
+  migrate: (data) => {
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !Array.isArray((data as Record<string, unknown>).variables)
+    ) {
+      return data;
+    }
+    const record = data as Record<string, unknown>;
+    const variables = record.variables as unknown[];
+    return {
+      ...record,
+      variables: variables.map((variable) =>
+        variable && typeof variable === "object" && !("type" in variable)
+          ? { ...(variable as Record<string, unknown>), type: "number" }
+          : variable,
+      ),
+    };
+  },
+};
+
+const rawResourceMigrations: RawResourceMigration[] = [migrateRawVariableTypes];
+
+export const migrateRawResource = (
+  data: unknown,
+  version: string,
+  release: string,
+): unknown => {
+  if (!data || typeof data !== "object") {
+    return data;
+  }
+  const resourceType = (data as Record<string, unknown>)._resourceType;
+  return rawResourceMigrations.reduce<unknown>(
+    (currentData, migration) =>
+      migration.resourceType === resourceType &&
+      migration.appliesToVersion(version, release)
+        ? migration.migrate(currentData)
+        : currentData,
+    data,
+  );
+};

--- a/test/migrate/rawResourceMigrations.test.ts
+++ b/test/migrate/rawResourceMigrations.test.ts
@@ -1,0 +1,78 @@
+import { Value } from "@sinclair/typebox/value";
+import { VariablesResource } from "shared/lib/resources/types";
+import {
+  migrateRawResource,
+  migrateRawVariableTypes,
+} from "lib/project/migration/rawResourceMigrations";
+
+const oldVariablesResource = {
+  _resourceType: "variables",
+  variables: [
+    {
+      id: "5",
+      name: "GameProgress",
+      symbol: "var_gameprogress",
+      flags: {
+        flag1: "ScoresToBeatSet",
+        flag2: "SeenTutorial",
+        flag7: "Theme 8 Unlocked",
+      },
+    },
+  ],
+  constants: [],
+};
+
+test("Value.Cast drops flags when a variable has no type (regression)", () => {
+  const castData = Value.Cast(VariablesResource, oldVariablesResource);
+  expect(castData.variables[0].flags).toBeUndefined();
+  expect(castData.variables[0].type).toBe("number");
+});
+
+test("raw migration preserves flags through Value.Cast for pre-5.0.0 projects", () => {
+  const castData = Value.Cast(
+    VariablesResource,
+    migrateRawResource(oldVariablesResource, "4.2.0", "10"),
+  );
+  expect(castData.variables[0].type).toBe("number");
+  expect(castData.variables[0].flags).toEqual({
+    flag1: "ScoresToBeatSet",
+    flag2: "SeenTutorial",
+    flag7: "Theme 8 Unlocked",
+  });
+});
+
+test("raw migration does not apply to 5.0.0+ projects", () => {
+  const migrated = migrateRawResource(oldVariablesResource, "5.0.0", "1");
+  expect(migrated).toBe(oldVariablesResource);
+});
+
+test("raw migration only applies to variables resources", () => {
+  const sceneResource = { _resourceType: "scene", variables: [{ id: "L0" }] };
+  const migrated = migrateRawResource(sceneResource, "4.2.0", "10");
+  expect(migrated).toBe(sceneResource);
+});
+
+test("raw migration leaves array variables untouched", () => {
+  const arrayVariablesResource = {
+    _resourceType: "variables",
+    variables: [
+      {
+        id: "6",
+        name: "Inventory",
+        symbol: "var_inventory",
+        type: "array",
+        size: 8,
+        flags: { flag1: "Equipped" },
+      },
+    ],
+    constants: [],
+  };
+  const result = migrateRawVariableTypes.migrate(arrayVariablesResource) as {
+    variables: unknown[];
+  };
+  expect(result.variables[0]).toEqual(arrayVariablesResource.variables[0]);
+
+  const castData = Value.Cast(VariablesResource, result);
+  expect(castData.variables[0].type).toBe("array");
+  expect(castData.variables[0].flags).toEqual({ flag1: "Equipped" });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/chrismaltby/gb-studio/issues/2181


* **What is the new behavior (if this is a feature change)?**
  Adds a small "raw resource migration" step that runs on raw resource data
  before `Value.Cast`, gated on the project version read from the metadata:
  for pre-5.0.0 projects, variables missing a `type` get `type: "number"`
  (is safe because those projects cannot contain array variables). With `type` present,
  the cast preserves `flags`.

  Applied to both load paths (resource-format projects and legacy single-file
  projects).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 Nope


* **Other information**:
