### PR TITLE
Update tilesets gbsres height and width when the source image is resized.

### DIFF
--- a/src/lib/project/loadProjectData.ts
+++ b/src/lib/project/loadProjectData.ts
@@ -18,6 +18,8 @@ import {
   CompressedBackgroundResourceAsset,
   CompressedProjectResources,
   CompressedSceneResourceWithChildren,
+  CompressedTilesetResource,
+  CompressedTilesetResourceAsset,
   EngineFieldValuesResource,
   FontResource,
   FontResourceAsset,
@@ -30,16 +32,20 @@ import {
   VariablesResource,
   isProjectMetadataResource,
 } from "shared/lib/resources/types";
-import { defaultPalettes } from "consts";
+import { TILE_DEFAULT_UNSET, defaultPalettes } from "consts";
 import { migrateLegacyProject } from "./migration/legacy/migrateLegacyProject";
 import { loadProjectResources } from "./loadProjectResources";
 import { readJson } from "lib/helpers/fs/readJson";
 import type { ProjectData } from "store/features/project/projectActions";
 import { migrateProjectResources } from "./migration/migrateProjectResources";
 import { resizeTiles } from "shared/lib/helpers/tiles";
+import { resizeGrid } from "shared/lib/tiles/grid";
+import { isAutotileDefinitionWithinBounds } from "shared/lib/tiles/sceneTilemapData";
 import {
   compress8bitNumberArray,
+  compressNumberArray,
   decompress8bitNumberString,
+  decompressNumberString,
 } from "shared/lib/resources/compression";
 import { EngineSchema, loadEngineSchema } from "./loadEngineSchema";
 
@@ -315,11 +321,66 @@ const loadProject = async (projectPath: string): Promise<LoadProjectResult> => {
     "avatar",
   );
 
-  const tilesetResources = mergeAssetIdAndSymbolsWithResources(
-    tilesets,
-    resources.tilesets,
-    "tileset",
-  );
+  const tilesetResources = mergeAssetsWithResources<
+    CompressedTilesetResource,
+    CompressedTilesetResourceAsset
+  >(tilesets, resources.tilesets, (asset, resource) => {
+    if (resource) {
+      let tileColors = resource.tileColors ?? asset.tileColors;
+      let tileCollisions = resource.tileCollisions ?? asset.tileCollisions;
+      let autotiles = resource.autotiles ?? asset.autotiles;
+
+      if (resource.width !== asset.width || resource.height !== asset.height) {
+        tileColors = compressNumberArray(
+          resizeGrid(
+            decompressNumberString(tileColors ?? ""),
+            resource.width,
+            resource.height,
+            asset.width,
+            asset.height,
+            TILE_DEFAULT_UNSET,
+          ),
+        );
+        tileCollisions = compressNumberArray(
+          resizeGrid(
+            decompressNumberString(tileCollisions ?? ""),
+            resource.width,
+            resource.height,
+            asset.width,
+            asset.height,
+            TILE_DEFAULT_UNSET,
+          ),
+        );
+        autotiles =
+          resource.width > 0
+            ? (autotiles ?? [])
+                .map((definition) => {
+                  const x = definition.startTile % resource.width;
+                  const y = Math.floor(definition.startTile / resource.width);
+                  const startTile = y * asset.width + x;
+                  return isAutotileDefinitionWithinBounds(
+                    { ...definition, startTile },
+                    asset.width,
+                    asset.height,
+                  )
+                    ? { ...definition, startTile }
+                    : undefined;
+                })
+                .filter((value): value is NonNullable<typeof value> => !!value)
+            : [];
+      }
+
+      return {
+        ...asset,
+        id: resource.id,
+        symbol: resource?.symbol !== undefined ? resource.symbol : asset.symbol,
+        tileColors,
+        tileCollisions,
+        autotiles,
+      };
+    }
+    return asset;
+  });
 
   const soundResources = mergeAssetIdAndSymbolsWithResources(
     sounds,

--- a/src/lib/project/loadTilesetData.ts
+++ b/src/lib/project/loadTilesetData.ts
@@ -28,23 +28,25 @@ const loadTilesetData =
       const fileStat = await statAsync(filename, { bigint: true });
       const inode = fileStat.ino.toString();
       const name = file.replace(/.png/i, "");
-      const width = size?.width ?? 160;
-      const height = size?.height ?? 144;
+      const imageWidth = size?.width ?? 160;
+      const imageHeight = size?.height ?? 144;
+      const tileWidth = Math.min(Math.floor(imageWidth / TILE_SIZE), 255);
+      const tileHeight = Math.min(Math.floor(imageHeight / TILE_SIZE), 255);
       return {
         _resourceType: "tileset",
         id: uuid(),
         plugin,
         name,
         symbol: toValidSymbol(`tileset_${name}`),
-        width: Math.min(Math.floor(width / TILE_SIZE), 255),
-        height: Math.min(Math.floor(height / TILE_SIZE), 255),
         tileColors: "",
         tileCollisions: "",
         _v: Date.now(),
         ...resource,
         filename: file,
-        imageWidth: width,
-        imageHeight: height,
+        width: tileWidth,
+        height: tileHeight,
+        imageWidth,
+        imageHeight,
         inode,
       };
     } catch (e) {

--- a/src/store/features/entities/reducers/tilesetsReducers.ts
+++ b/src/store/features/entities/reducers/tilesetsReducers.ts
@@ -90,7 +90,8 @@ export const updateTilemapReferencesForTilesets = (
   state: EntitiesState,
   tilesetIds: readonly string[],
 ) => {
-  const resizes = new Map<string, TilesetResize>();
+  // Current size of each tileset, once brought back in sync with its image
+  const tilesetSizes = new Map<string, TilesetResize>();
 
   for (const tilesetId of tilesetIds) {
     const tileset = localTilesetSelectById(state, tilesetId);
@@ -111,6 +112,8 @@ export const updateTilemapReferencesForTilesets = (
 
     const nextWidth = Math.min(detectedWidth, 255);
     const nextHeight = Math.min(detectedHeight, 255);
+    tilesetSizes.set(tileset.id, { width: nextWidth, height: nextHeight });
+
     if (nextWidth === tileset.width && nextHeight === tileset.height) {
       continue;
     }
@@ -160,10 +163,9 @@ export const updateTilemapReferencesForTilesets = (
         autotiles,
       },
     });
-    resizes.set(tileset.id, { width: nextWidth, height: nextHeight });
   }
 
-  if (resizes.size === 0) {
+  if (tilesetSizes.size === 0) {
     return;
   }
 
@@ -178,7 +180,23 @@ export const updateTilemapReferencesForTilesets = (
     const scene = localSceneSelectById(state, String(sceneId));
     const sceneTilemap = scene?.tilemap;
 
-    if (!scene || !sceneTilemap?.tilesets.some(({ id }) => resizes.has(id))) {
+    if (!scene || !sceneTilemap) {
+      return memo;
+    }
+
+    // Tilesets this scene has stored at a size they are no longer using
+    const resizes = new Map<string, TilesetResize>();
+    for (const snapshot of sceneTilemap.tilesets) {
+      const size = tilesetSizes.get(snapshot.id);
+      if (
+        size &&
+        (size.width !== snapshot.width || size.height !== snapshot.height)
+      ) {
+        resizes.set(snapshot.id, size);
+      }
+    }
+
+    if (resizes.size === 0) {
       return memo;
     }
 

--- a/test/store/features/entities/reducers/projectLifecycleReducers.test.ts
+++ b/test/store/features/entities/reducers/projectLifecycleReducers.test.ts
@@ -259,3 +259,65 @@ test("Should update all tilemap references for resized tilesets on load", () => 
   });
   expect(newState.scenes.entities.scene1?.tilemap?.autotiles).toEqual([]);
 });
+
+test("Should update scene tilemap references when tileset was resized while project was closed", () => {
+  const state: EntitiesState = { ...initialState };
+  const loadData: CompressedProjectResources = {
+    ...dummyCompressedProjectResources,
+    // Tileset dimensions have already been brought in sync with the image
+    // on disk while loading the project, but the scene is still storing the
+    // size the tileset had when it was last saved
+    tilesets: [
+      {
+        ...dummyCompressedTilesetResource,
+        id: "tiles1",
+        width: 3,
+        height: 2,
+        imageWidth: 24,
+        imageHeight: 16,
+      },
+    ],
+    scenes: [
+      {
+        ...dummyCompressedSceneResource,
+        id: "scene1",
+        tilemap: {
+          tilesets: [{ id: "tiles1", width: 2, height: 2 }],
+          layers: [
+            {
+              id: "layer",
+              name: "Layer",
+              visible: true,
+              tiles: compressNumberArray([
+                encodeSceneTileRef(0, 1),
+                encodeSceneTileRef(0, 3),
+              ]),
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const action = projectActions.loadProject.fulfilled(
+    {
+      resources: loadData,
+      path: "project.gbsproj",
+      scriptEventDefs: {},
+      engineSchema: { fields: [], sceneTypes: [], consts: {} },
+      modifiedSpriteIds: [],
+      isMigrated: false,
+    },
+    "randomid",
+    "project.gbsproj",
+  );
+  const newState = reducer(state, action);
+
+  expect(newState.scenes.entities.scene1?.tilemap?.tilesets).toEqual([
+    { id: "tiles1", width: 3, height: 2 },
+  ]);
+  expect(newState.scenes.entities.scene1?.tilemap?.layers[0]?.tiles).toEqual([
+    encodeSceneTileRef(0, 1),
+    encodeSceneTileRef(0, 4),
+  ]);
+});


### PR DESCRIPTION
Fix tilesets gbsres not updating the height and width when the source image is resized, like how background images do.